### PR TITLE
Prevented net send errors from triggering an entire host error

### DIFF
--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -1412,7 +1412,7 @@ void NET_SendPacketEx( netsrc_t sock, size_t length, const void *data, netadr_t 
 		}
 		else
 		{
-			Host_Error( "NET_SendPacket: %s to %s\n", NET_ErrorString(), NET_AdrToString( to ));
+			Con_Printf( S_ERROR "NET_SendPacket: %s to %s\n", NET_ErrorString(), NET_AdrToString( to ));
 		}
 	}
 


### PR DESCRIPTION
Swapped out a `Host_Error` for a `Con_Printf`, to prevent jumping to the console and potentially preventing progress through game menus if the network is down.