### PR TITLE
SV_LoadProgs: Fixed potential memory leak if function failed

### DIFF
--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -5025,14 +5025,14 @@ qboolean SV_LoadProgs( const char *name )
 	// fill it in
 	svgame.pmove = &gpMove;
 	svgame.globals = &gpGlobals;
-	
-	if ( !svgame.mempool )
-	{
-		svgame.mempool = Mem_AllocPool( "Server Edicts Zone" );
-	}
-	
+	svgame.mempool = Mem_AllocPool( "Server Edicts Zone" );
+
 	svgame.hInstance = COM_LoadLibrary( name, true, false );
-	if( !svgame.hInstance ) return false;
+	if( !svgame.hInstance )
+	{
+		Mem_FreePool(&svgame.mempool);
+		return false;
+	}
 
 	// make sure what new dll functions is cleared
 	memset( &svgame.dllFuncs2, 0, sizeof( svgame.dllFuncs2 ));
@@ -5052,6 +5052,7 @@ qboolean SV_LoadProgs( const char *name )
 		COM_FreeLibrary( svgame.hInstance );
          		Con_Printf( S_ERROR "SV_LoadProgs: failed to get address of GetEntityAPI proc\n" );
 		svgame.hInstance = NULL;
+		Mem_FreePool(&svgame.mempool);
 		return false;
 	}
 
@@ -5062,6 +5063,7 @@ qboolean SV_LoadProgs( const char *name )
 		COM_FreeLibrary( svgame.hInstance );
 		Con_Printf( S_ERROR "SV_LoadProgs: failed to get address of GiveFnptrsToDll proc\n" );
 		svgame.hInstance = NULL;
+		Mem_FreePool(&svgame.mempool);
 		return false;
 	}
 
@@ -5094,6 +5096,7 @@ qboolean SV_LoadProgs( const char *name )
 				COM_FreeLibrary( svgame.hInstance );
 				Con_Printf( S_ERROR "SV_LoadProgs: couldn't get entity API\n" );
 				svgame.hInstance = NULL;
+				Mem_FreePool(&svgame.mempool);
 				return false;
 			}
 		}
@@ -5104,6 +5107,7 @@ qboolean SV_LoadProgs( const char *name )
 		COM_FreeLibrary( svgame.hInstance );
 		Con_Printf( S_ERROR "SV_LoadProgs: couldn't get entity API\n" );
 		svgame.hInstance = NULL;
+		Mem_FreePool(&svgame.mempool);
 		return false;
 	}
 

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -40,7 +40,7 @@ edict_t *SV_EdictNum( int n )
 {
 	if(( n >= 0 ) && ( n < GI->max_edicts ))
 		return svgame.edicts + n;
-	return NULL;	
+	return NULL;
 }
 
 #ifndef NDEBUG
@@ -56,7 +56,7 @@ qboolean SV_CheckEdict( const edict_t *e, const char *file, const int line )
 		return !e->free;
 	Con_Printf( "bad entity %i (called at %s:%i)\n", n, file, line );
 
-	return false;	
+	return false;
 }
 #endif
 
@@ -67,7 +67,7 @@ EntvarsDescription
 entavrs table for FindEntityByString
 =============
 */
-static TYPEDESCRIPTION gEntvarsDescription[] = 
+static TYPEDESCRIPTION gEntvarsDescription[] =
 {
 	DEFINE_ENTITY_FIELD( classname, FIELD_STRING ),
 	DEFINE_ENTITY_FIELD( globalname, FIELD_STRING ),
@@ -151,7 +151,7 @@ float SV_AngleMod( float ideal, float current, float speed )
 	current = anglemod( current );
 
 	if( current == ideal ) // already there?
-		return current; 
+		return current;
 
 	move = ideal - current;
 
@@ -244,7 +244,7 @@ convert trace_t to TraceResult
 */
 void SV_ConvertTrace( TraceResult *dst, trace_t *src )
 {
-	if( !src || !dst ) return; 
+	if( !src || !dst ) return;
 
 	dst->fAllSolid = src->allsolid;
 	dst->fStartSolid = src->startsolid;
@@ -352,7 +352,7 @@ static int SV_Multicast( int dest, const vec3_t origin, const edict_t *ent, qboo
 		reliable = true;
 		// intentional fallthrough
 	case MSG_BROADCAST:
-		// nothing to sort	
+		// nothing to sort
 		break;
 	case MSG_PAS_R:
 		reliable = true;
@@ -500,7 +500,7 @@ NOTE: static entities only accepted when game is loading
 */
 qboolean SV_CreateStaticEntity( sizebuf_t *msg, int index )
 {
-	entity_state_t	nullstate, *baseline;	
+	entity_state_t	nullstate, *baseline;
 	entity_state_t	*state;
 	int		offset;
 
@@ -577,7 +577,7 @@ void SV_RestartAmbientSounds( void )
 	if( !SV_Active( )) return;
 
 	nSounds = S_GetCurrentStaticSounds( soundInfo, 256 );
-	
+
 	for( i = 0; i < nSounds; i++ )
 	{
 		soundlist_t *si = &soundInfo[i];
@@ -704,7 +704,7 @@ void SV_QueueChangeLevel( const char *level, const char *landname )
 		Con_Printf( S_ERROR "changelevel: %s is invalid or not supported\n", mapname );
 		return;
 	}
-	
+
 	if( !FBitSet( flags, MAP_IS_EXIST ))
 	{
 		Con_Printf( S_ERROR "changelevel: map %s doesn't exist\n", mapname );
@@ -728,7 +728,7 @@ void SV_QueueChangeLevel( const char *level, const char *landname )
 	if( smooth && !Q_stricmp( sv.name, level ))
 	{
 		Con_Printf( S_ERROR "can't changelevel with same map. Ignored.\n" );
-		return;	
+		return;
 	}
 
 	if( !smooth && !FBitSet( flags, MAP_HAS_SPAWNPOINT ))
@@ -736,7 +736,7 @@ void SV_QueueChangeLevel( const char *level, const char *landname )
 		if( sv_validate_changelevel->value )
 		{
 			Con_Printf( S_ERROR "changelevel: %s doesn't have a valid spawnpoint. Ignored.\n", mapname );
-			return;	
+			return;
 		}
 	}
 
@@ -793,7 +793,7 @@ void SV_WriteEntityPatch( const char *filename )
 	if( lumplen >= 10 )
 	{
 		char	*entities = NULL;
-		
+
 		FS_Seek( f, lumpofs, SEEK_SET );
 		entities = (char *)Z_Calloc( lumplen + 1 );
 		FS_Read( f, entities, lumplen );
@@ -824,7 +824,7 @@ static char *SV_ReadEntityScript( const char *filename, int *flags )
 
 	*flags = 0;
 
-	Q_strncpy( bspfilename, va( "maps/%s.bsp", filename ), sizeof( bspfilename ));			
+	Q_strncpy( bspfilename, va( "maps/%s.bsp", filename ), sizeof( bspfilename ));
 	f = FS_Open( bspfilename, "rb", false );
 	if( !f ) return NULL;
 
@@ -855,7 +855,7 @@ static char *SV_ReadEntityScript( const char *filename, int *flags )
 	if( ft2 != -1 && ft1 < ft2 )
 	{
 		// grab .ent files only from gamedir
-		ents = FS_LoadFile( entfilename, NULL, true ); 
+		ents = FS_LoadFile( entfilename, NULL, true );
 	}
 
 	// at least entities should contain "{ "classname" "worldspawn" }\0"
@@ -895,7 +895,7 @@ int SV_MapIsValid( const char *filename, const char *spawn_entity, const char *l
 		// g-cont. in-dev mode we can entering on map even without "info_player_start"
 		if( !need_landmark && host_developer.value )
 		{
-			// not transition 
+			// not transition
 			Mem_Free( ents );
 
 			// skip spawnpoint checks in devmode
@@ -1094,7 +1094,7 @@ edict_t* SV_AllocPrivateData( edict_t *ent, string_t className )
 
 	ent->v.classname = className;
 	ent->v.pContainingEntity = ent; // re-link
-	
+
 	// allocate edict private memory (passed by dlls)
 	SpawnEdict = SV_GetEntityClass( pszClassName );
 
@@ -1134,7 +1134,7 @@ create specified entity, alloc private data
 edict_t* SV_CreateNamedEntity( edict_t *ent, string_t className )
 {
 	edict_t *ed = SV_AllocPrivateData( ent, className );
-	
+
 	// for some reasons this flag should be immediately cleared
 	if( ed ) ClearBits( ed->v.flags, FL_CUSTOMENTITY );
 
@@ -1517,7 +1517,7 @@ void pfnChangePitch( edict_t* ent )
 	if( !SV_IsValidEdict( ent ))
 		return;
 
-	ent->v.angles[PITCH] = SV_AngleMod( ent->v.idealpitch, ent->v.angles[PITCH], ent->v.pitch_speed );	
+	ent->v.angles[PITCH] = SV_AngleMod( ent->v.idealpitch, ent->v.angles[PITCH], ent->v.pitch_speed );
 }
 
 /*
@@ -1549,7 +1549,7 @@ edict_t *SV_FindEntityByString( edict_t *pStartEdict, const char *pszField, cons
 		Con_Printf( S_ERROR "FindEntityByString: field %s not a string\n", pszField );
 		return svgame.edicts;
 	}
-	
+
 	for( e++; e < svgame.numEntities; e++ )
 	{
 		ed = EDICT_NUM( e );
@@ -1758,7 +1758,7 @@ edict_t* pfnFindClientInPVS( edict_t *pEdict )
 		sv.lastchecktime = sv.time;
 	}
 
-	// return check if it might be visible	
+	// return check if it might be visible
 	pClient = EDICT_NUM( sv.lastcheck );
 
 	if( !SV_ClientFromEdict( pClient, true ))
@@ -1804,7 +1804,7 @@ edict_t *pfnEntitiesInPVS( edict_t *pview )
 		return NULL;
 
 	VectorAdd( pview->v.origin, pview->v.view_ofs, viewpoint );
-	pchain = EDICT_NUM( 0 ); 
+	pchain = EDICT_NUM( 0 );
 
 	for( i = 1; i < svgame.numEntities; i++ )
 	{
@@ -1911,7 +1911,7 @@ static int pfnEntIsOnFloor( edict_t *e )
 
 	return SV_CheckBottom( e, MOVE_NORMAL );
 }
-	
+
 /*
 ===============
 pfnDropToFloor
@@ -2386,7 +2386,7 @@ void pfnGetAimVector( edict_t* ent, float speed, float *rgflReturn )
 		tr = SV_Move( start, vec3_origin, vec3_origin, end, MOVE_NORMAL, ent, false );
 
 		if( tr.ent == check )
-		{	
+		{
 			// can shoot at this one
 			VectorCopy( dir, bestdir );
 			bestdist = dist;
@@ -2535,7 +2535,7 @@ int pfnDecalIndex( const char *m )
 			return i;
 	}
 
-	return -1;	
+	return -1;
 }
 
 /*
@@ -2651,7 +2651,7 @@ void pfnMessageEnd( void )
 	{
 		int	expsize = svgame.msg[svgame.msg_index].size;
 		int	realsize = svgame.msg_realsize;
-	
+
 		// compare sizes
 		if( expsize != realsize )
 		{
@@ -2709,7 +2709,7 @@ pfnWriteByte
 */
 void pfnWriteByte( int iValue )
 {
-	if( iValue == -1 ) iValue = 0xFF; // convert char to byte 
+	if( iValue == -1 ) iValue = 0xFF; // convert char to byte
 	MSG_WriteByte( &sv.multicast, (byte)iValue );
 	svgame.msg_realsize++;
 }
@@ -2805,7 +2805,7 @@ void pfnWriteString( const char *src )
 	if( len == 1 )
 	{
 		MSG_WriteChar( &sv.multicast, 0 );
-		svgame.msg_realsize += 1; 
+		svgame.msg_realsize += 1;
 		return; // fast exit
 	}
 
@@ -2930,7 +2930,7 @@ static void pfnEngineFprintf( FILE *pfile, char *szFmt, ... ) _format( 2 );
 static void pfnEngineFprintf( FILE *pfile, char *szFmt, ... )
 {
 }
-	
+
 /*
 =============
 pfnBuildSoundMsg
@@ -3407,7 +3407,7 @@ pfnRegUserMsg
 int pfnRegUserMsg( const char *pszName, int iSize )
 {
 	int	i;
-	
+
 	if( !COM_CheckString( pszName ))
 		return svc_bad;
 
@@ -3434,7 +3434,7 @@ int pfnRegUserMsg( const char *pszName, int iSize )
 			return svc_lastmsg + i; // offset
 	}
 
-	if( i == MAX_USER_MESSAGES ) 
+	if( i == MAX_USER_MESSAGES )
 	{
 		Con_Printf( S_ERROR "REG_USER_MSG: user messages limit exceeded\n" );
 		return svc_bad;
@@ -3839,7 +3839,7 @@ void pfnSetClientKeyValue( int clientIndex, char *infobuffer, char *key, char *v
 	if( !Q_strcmp( Info_ValueForKey( infobuffer, key ), value ))
 		return;
 
-	cl = &svs.clients[clientIndex]; 
+	cl = &svs.clients[clientIndex];
 
 	Info_SetValueForStarKey( infobuffer, key, value, MAX_INFO_STRING );
 	SetBits( cl->flags, FCL_RESEND_USERINFO );
@@ -3951,7 +3951,7 @@ void SV_PlaybackEventFull( int flags, const edict_t *pInvoker, word eventindex, 
 	if( !COM_CheckString( sv.event_precache[eventindex] ))
 	{
 		Con_Printf( S_ERROR "EV_Playback: event %i was not precached\n", eventindex );
-		return;		
+		return;
 	}
 
 	memset( &args, 0, sizeof( args ));
@@ -4099,7 +4099,7 @@ void SV_PlaybackEventFull( int flags, const edict_t *pInvoker, word eventindex, 
 			for( j = 0; j < MAX_EVENT_QUEUE; j++ )
 			{
 				ei = &es->ei[j];
-		
+
 				if( ei->index == 0 )
 				{
 					// found an empty slot
@@ -4108,7 +4108,7 @@ void SV_PlaybackEventFull( int flags, const edict_t *pInvoker, word eventindex, 
 				}
 			}
 		}
-				
+
 		// no slot found for this player, oh well
 		if( bestslot == -1 ) continue;
 
@@ -4382,7 +4382,7 @@ void pfnGetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss )
 	if( packet_loss ) *packet_loss = cl->packet_loss;
 	if( ping ) *ping = cl->latency * 1000;
 }
-	
+
 /*
 =============
 pfnForceUnmodified
@@ -4546,16 +4546,16 @@ extended iface stubs
 static void pfnEngineStub( void )
 {
 }
-					
+
 // engine callbacks
-static enginefuncs_t gEngfuncs = 
+static enginefuncs_t gEngfuncs =
 {
 	pfnPrecacheModel,
-	SV_SoundIndex,	
+	SV_SoundIndex,
 	pfnSetModel,
 	pfnModelIndex,
 	pfnModelFrames,
-	pfnSetSize,	
+	pfnSetSize,
 	pfnChangeLevel,
 	pfnGetSpawnParms,
 	pfnSaveSpawnParms,
@@ -4631,7 +4631,7 @@ static enginefuncs_t gEngfuncs =
 	(void*)pfnFunctionFromName,
 	(void*)pfnNameForFunction,
 	pfnClientPrintf,
-	pfnServerPrint,	
+	pfnServerPrint,
 	Cmd_Args,
 	Cmd_Argv,
 	(void*)Cmd_Argc,
@@ -4685,7 +4685,7 @@ static enginefuncs_t gEngfuncs =
 	Delta_FindField,
 	Delta_SetFieldByIndex,
 	Delta_UnsetFieldByIndex,
-	pfnSetGroupMask,	
+	pfnSetGroupMask,
 	pfnCreateInstancedBaseline,
 	pfnCVarDirectSet,
 	pfnForceUnmodified,
@@ -4729,7 +4729,7 @@ qboolean SV_ParseEdict( char **pfile, edict_t *ent )
 
 	// go through all the dictionary pairs
 	while( 1 )
-	{	
+	{
 		string	keyname;
 
 		// parse key
@@ -4739,8 +4739,8 @@ qboolean SV_ParseEdict( char **pfile, edict_t *ent )
 
 		Q_strncpy( keyname, token, sizeof( keyname ));
 
-		// parse value	
-		if(( *pfile = COM_ParseFile( *pfile, token )) == NULL ) 
+		// parse value
+		if(( *pfile = COM_ParseFile( *pfile, token )) == NULL )
 			Host_Error( "ED_ParseEdict: EOF without closing brace\n" );
 
 		if( token[0] == '}' )
@@ -4765,13 +4765,13 @@ qboolean SV_ParseEdict( char **pfile, edict_t *ent )
 		pkvd[numpairs].szClassName = ""; // unknown at this moment
 		pkvd[numpairs].szKeyName = copystring( keyname );
 		pkvd[numpairs].szValue = copystring( token );
-		pkvd[numpairs].fHandled = false;		
+		pkvd[numpairs].fHandled = false;
 
 		if( !Q_strcmp( keyname, "classname" ) && classname == NULL )
 			classname = copystring( pkvd[numpairs].szValue );
 		if( ++numpairs >= 256 ) break;
 	}
-	
+
 	ent = SV_AllocPrivateData( ent, ALLOC_STRING( classname ));
 
 	if( !SV_IsValidEdict( ent ) || FBitSet( ent->v.flags, FL_KILLME ))
@@ -4942,7 +4942,7 @@ void SV_SpawnEntities( const char *mapname )
 	Cvar_Reset( "sv_wateramp" );
 	Cvar_Reset( "sv_wateralpha" );
 
-	// reset sky parms	
+	// reset sky parms
 	Cvar_Reset( "sv_skycolor_r" );
 	Cvar_Reset( "sv_skycolor_g" );
 	Cvar_Reset( "sv_skycolor_b" );
@@ -5025,7 +5025,12 @@ qboolean SV_LoadProgs( const char *name )
 	// fill it in
 	svgame.pmove = &gpMove;
 	svgame.globals = &gpGlobals;
-	svgame.mempool = Mem_AllocPool( "Server Edicts Zone" );
+
+	if ( !svgame.mempool )
+	{
+		svgame.mempool = Mem_AllocPool( "Server Edicts Zone" );
+	}
+
 	svgame.hInstance = COM_LoadLibrary( name, true, false );
 	if( !svgame.hInstance ) return false;
 
@@ -5066,7 +5071,7 @@ qboolean SV_LoadProgs( const char *name )
 	if( GiveNewDllFuncs )
 	{
 		version = NEW_DLL_FUNCTIONS_VERSION;
-	
+
 		if( !GiveNewDllFuncs( &svgame.dllFuncs2, &version ))
 		{
 			if( version != NEW_DLL_FUNCTIONS_VERSION )

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -40,7 +40,7 @@ edict_t *SV_EdictNum( int n )
 {
 	if(( n >= 0 ) && ( n < GI->max_edicts ))
 		return svgame.edicts + n;
-	return NULL;
+	return NULL;	
 }
 
 #ifndef NDEBUG
@@ -56,7 +56,7 @@ qboolean SV_CheckEdict( const edict_t *e, const char *file, const int line )
 		return !e->free;
 	Con_Printf( "bad entity %i (called at %s:%i)\n", n, file, line );
 
-	return false;
+	return false;	
 }
 #endif
 
@@ -67,7 +67,7 @@ EntvarsDescription
 entavrs table for FindEntityByString
 =============
 */
-static TYPEDESCRIPTION gEntvarsDescription[] =
+static TYPEDESCRIPTION gEntvarsDescription[] = 
 {
 	DEFINE_ENTITY_FIELD( classname, FIELD_STRING ),
 	DEFINE_ENTITY_FIELD( globalname, FIELD_STRING ),
@@ -151,7 +151,7 @@ float SV_AngleMod( float ideal, float current, float speed )
 	current = anglemod( current );
 
 	if( current == ideal ) // already there?
-		return current;
+		return current; 
 
 	move = ideal - current;
 
@@ -244,7 +244,7 @@ convert trace_t to TraceResult
 */
 void SV_ConvertTrace( TraceResult *dst, trace_t *src )
 {
-	if( !src || !dst ) return;
+	if( !src || !dst ) return; 
 
 	dst->fAllSolid = src->allsolid;
 	dst->fStartSolid = src->startsolid;
@@ -352,7 +352,7 @@ static int SV_Multicast( int dest, const vec3_t origin, const edict_t *ent, qboo
 		reliable = true;
 		// intentional fallthrough
 	case MSG_BROADCAST:
-		// nothing to sort
+		// nothing to sort	
 		break;
 	case MSG_PAS_R:
 		reliable = true;
@@ -500,7 +500,7 @@ NOTE: static entities only accepted when game is loading
 */
 qboolean SV_CreateStaticEntity( sizebuf_t *msg, int index )
 {
-	entity_state_t	nullstate, *baseline;
+	entity_state_t	nullstate, *baseline;	
 	entity_state_t	*state;
 	int		offset;
 
@@ -577,7 +577,7 @@ void SV_RestartAmbientSounds( void )
 	if( !SV_Active( )) return;
 
 	nSounds = S_GetCurrentStaticSounds( soundInfo, 256 );
-
+	
 	for( i = 0; i < nSounds; i++ )
 	{
 		soundlist_t *si = &soundInfo[i];
@@ -704,7 +704,7 @@ void SV_QueueChangeLevel( const char *level, const char *landname )
 		Con_Printf( S_ERROR "changelevel: %s is invalid or not supported\n", mapname );
 		return;
 	}
-
+	
 	if( !FBitSet( flags, MAP_IS_EXIST ))
 	{
 		Con_Printf( S_ERROR "changelevel: map %s doesn't exist\n", mapname );
@@ -728,7 +728,7 @@ void SV_QueueChangeLevel( const char *level, const char *landname )
 	if( smooth && !Q_stricmp( sv.name, level ))
 	{
 		Con_Printf( S_ERROR "can't changelevel with same map. Ignored.\n" );
-		return;
+		return;	
 	}
 
 	if( !smooth && !FBitSet( flags, MAP_HAS_SPAWNPOINT ))
@@ -736,7 +736,7 @@ void SV_QueueChangeLevel( const char *level, const char *landname )
 		if( sv_validate_changelevel->value )
 		{
 			Con_Printf( S_ERROR "changelevel: %s doesn't have a valid spawnpoint. Ignored.\n", mapname );
-			return;
+			return;	
 		}
 	}
 
@@ -793,7 +793,7 @@ void SV_WriteEntityPatch( const char *filename )
 	if( lumplen >= 10 )
 	{
 		char	*entities = NULL;
-
+		
 		FS_Seek( f, lumpofs, SEEK_SET );
 		entities = (char *)Z_Calloc( lumplen + 1 );
 		FS_Read( f, entities, lumplen );
@@ -824,7 +824,7 @@ static char *SV_ReadEntityScript( const char *filename, int *flags )
 
 	*flags = 0;
 
-	Q_strncpy( bspfilename, va( "maps/%s.bsp", filename ), sizeof( bspfilename ));
+	Q_strncpy( bspfilename, va( "maps/%s.bsp", filename ), sizeof( bspfilename ));			
 	f = FS_Open( bspfilename, "rb", false );
 	if( !f ) return NULL;
 
@@ -855,7 +855,7 @@ static char *SV_ReadEntityScript( const char *filename, int *flags )
 	if( ft2 != -1 && ft1 < ft2 )
 	{
 		// grab .ent files only from gamedir
-		ents = FS_LoadFile( entfilename, NULL, true );
+		ents = FS_LoadFile( entfilename, NULL, true ); 
 	}
 
 	// at least entities should contain "{ "classname" "worldspawn" }\0"
@@ -895,7 +895,7 @@ int SV_MapIsValid( const char *filename, const char *spawn_entity, const char *l
 		// g-cont. in-dev mode we can entering on map even without "info_player_start"
 		if( !need_landmark && host_developer.value )
 		{
-			// not transition
+			// not transition 
 			Mem_Free( ents );
 
 			// skip spawnpoint checks in devmode
@@ -1094,7 +1094,7 @@ edict_t* SV_AllocPrivateData( edict_t *ent, string_t className )
 
 	ent->v.classname = className;
 	ent->v.pContainingEntity = ent; // re-link
-
+	
 	// allocate edict private memory (passed by dlls)
 	SpawnEdict = SV_GetEntityClass( pszClassName );
 
@@ -1134,7 +1134,7 @@ create specified entity, alloc private data
 edict_t* SV_CreateNamedEntity( edict_t *ent, string_t className )
 {
 	edict_t *ed = SV_AllocPrivateData( ent, className );
-
+	
 	// for some reasons this flag should be immediately cleared
 	if( ed ) ClearBits( ed->v.flags, FL_CUSTOMENTITY );
 
@@ -1517,7 +1517,7 @@ void pfnChangePitch( edict_t* ent )
 	if( !SV_IsValidEdict( ent ))
 		return;
 
-	ent->v.angles[PITCH] = SV_AngleMod( ent->v.idealpitch, ent->v.angles[PITCH], ent->v.pitch_speed );
+	ent->v.angles[PITCH] = SV_AngleMod( ent->v.idealpitch, ent->v.angles[PITCH], ent->v.pitch_speed );	
 }
 
 /*
@@ -1549,7 +1549,7 @@ edict_t *SV_FindEntityByString( edict_t *pStartEdict, const char *pszField, cons
 		Con_Printf( S_ERROR "FindEntityByString: field %s not a string\n", pszField );
 		return svgame.edicts;
 	}
-
+	
 	for( e++; e < svgame.numEntities; e++ )
 	{
 		ed = EDICT_NUM( e );
@@ -1758,7 +1758,7 @@ edict_t* pfnFindClientInPVS( edict_t *pEdict )
 		sv.lastchecktime = sv.time;
 	}
 
-	// return check if it might be visible
+	// return check if it might be visible	
 	pClient = EDICT_NUM( sv.lastcheck );
 
 	if( !SV_ClientFromEdict( pClient, true ))
@@ -1804,7 +1804,7 @@ edict_t *pfnEntitiesInPVS( edict_t *pview )
 		return NULL;
 
 	VectorAdd( pview->v.origin, pview->v.view_ofs, viewpoint );
-	pchain = EDICT_NUM( 0 );
+	pchain = EDICT_NUM( 0 ); 
 
 	for( i = 1; i < svgame.numEntities; i++ )
 	{
@@ -1911,7 +1911,7 @@ static int pfnEntIsOnFloor( edict_t *e )
 
 	return SV_CheckBottom( e, MOVE_NORMAL );
 }
-
+	
 /*
 ===============
 pfnDropToFloor
@@ -2386,7 +2386,7 @@ void pfnGetAimVector( edict_t* ent, float speed, float *rgflReturn )
 		tr = SV_Move( start, vec3_origin, vec3_origin, end, MOVE_NORMAL, ent, false );
 
 		if( tr.ent == check )
-		{
+		{	
 			// can shoot at this one
 			VectorCopy( dir, bestdir );
 			bestdist = dist;
@@ -2535,7 +2535,7 @@ int pfnDecalIndex( const char *m )
 			return i;
 	}
 
-	return -1;
+	return -1;	
 }
 
 /*
@@ -2651,7 +2651,7 @@ void pfnMessageEnd( void )
 	{
 		int	expsize = svgame.msg[svgame.msg_index].size;
 		int	realsize = svgame.msg_realsize;
-
+	
 		// compare sizes
 		if( expsize != realsize )
 		{
@@ -2709,7 +2709,7 @@ pfnWriteByte
 */
 void pfnWriteByte( int iValue )
 {
-	if( iValue == -1 ) iValue = 0xFF; // convert char to byte
+	if( iValue == -1 ) iValue = 0xFF; // convert char to byte 
 	MSG_WriteByte( &sv.multicast, (byte)iValue );
 	svgame.msg_realsize++;
 }
@@ -2805,7 +2805,7 @@ void pfnWriteString( const char *src )
 	if( len == 1 )
 	{
 		MSG_WriteChar( &sv.multicast, 0 );
-		svgame.msg_realsize += 1;
+		svgame.msg_realsize += 1; 
 		return; // fast exit
 	}
 
@@ -2930,7 +2930,7 @@ static void pfnEngineFprintf( FILE *pfile, char *szFmt, ... ) _format( 2 );
 static void pfnEngineFprintf( FILE *pfile, char *szFmt, ... )
 {
 }
-
+	
 /*
 =============
 pfnBuildSoundMsg
@@ -3407,7 +3407,7 @@ pfnRegUserMsg
 int pfnRegUserMsg( const char *pszName, int iSize )
 {
 	int	i;
-
+	
 	if( !COM_CheckString( pszName ))
 		return svc_bad;
 
@@ -3434,7 +3434,7 @@ int pfnRegUserMsg( const char *pszName, int iSize )
 			return svc_lastmsg + i; // offset
 	}
 
-	if( i == MAX_USER_MESSAGES )
+	if( i == MAX_USER_MESSAGES ) 
 	{
 		Con_Printf( S_ERROR "REG_USER_MSG: user messages limit exceeded\n" );
 		return svc_bad;
@@ -3839,7 +3839,7 @@ void pfnSetClientKeyValue( int clientIndex, char *infobuffer, char *key, char *v
 	if( !Q_strcmp( Info_ValueForKey( infobuffer, key ), value ))
 		return;
 
-	cl = &svs.clients[clientIndex];
+	cl = &svs.clients[clientIndex]; 
 
 	Info_SetValueForStarKey( infobuffer, key, value, MAX_INFO_STRING );
 	SetBits( cl->flags, FCL_RESEND_USERINFO );
@@ -3951,7 +3951,7 @@ void SV_PlaybackEventFull( int flags, const edict_t *pInvoker, word eventindex, 
 	if( !COM_CheckString( sv.event_precache[eventindex] ))
 	{
 		Con_Printf( S_ERROR "EV_Playback: event %i was not precached\n", eventindex );
-		return;
+		return;		
 	}
 
 	memset( &args, 0, sizeof( args ));
@@ -4099,7 +4099,7 @@ void SV_PlaybackEventFull( int flags, const edict_t *pInvoker, word eventindex, 
 			for( j = 0; j < MAX_EVENT_QUEUE; j++ )
 			{
 				ei = &es->ei[j];
-
+		
 				if( ei->index == 0 )
 				{
 					// found an empty slot
@@ -4108,7 +4108,7 @@ void SV_PlaybackEventFull( int flags, const edict_t *pInvoker, word eventindex, 
 				}
 			}
 		}
-
+				
 		// no slot found for this player, oh well
 		if( bestslot == -1 ) continue;
 
@@ -4382,7 +4382,7 @@ void pfnGetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss )
 	if( packet_loss ) *packet_loss = cl->packet_loss;
 	if( ping ) *ping = cl->latency * 1000;
 }
-
+	
 /*
 =============
 pfnForceUnmodified
@@ -4546,16 +4546,16 @@ extended iface stubs
 static void pfnEngineStub( void )
 {
 }
-
+					
 // engine callbacks
-static enginefuncs_t gEngfuncs =
+static enginefuncs_t gEngfuncs = 
 {
 	pfnPrecacheModel,
-	SV_SoundIndex,
+	SV_SoundIndex,	
 	pfnSetModel,
 	pfnModelIndex,
 	pfnModelFrames,
-	pfnSetSize,
+	pfnSetSize,	
 	pfnChangeLevel,
 	pfnGetSpawnParms,
 	pfnSaveSpawnParms,
@@ -4631,7 +4631,7 @@ static enginefuncs_t gEngfuncs =
 	(void*)pfnFunctionFromName,
 	(void*)pfnNameForFunction,
 	pfnClientPrintf,
-	pfnServerPrint,
+	pfnServerPrint,	
 	Cmd_Args,
 	Cmd_Argv,
 	(void*)Cmd_Argc,
@@ -4685,7 +4685,7 @@ static enginefuncs_t gEngfuncs =
 	Delta_FindField,
 	Delta_SetFieldByIndex,
 	Delta_UnsetFieldByIndex,
-	pfnSetGroupMask,
+	pfnSetGroupMask,	
 	pfnCreateInstancedBaseline,
 	pfnCVarDirectSet,
 	pfnForceUnmodified,
@@ -4729,7 +4729,7 @@ qboolean SV_ParseEdict( char **pfile, edict_t *ent )
 
 	// go through all the dictionary pairs
 	while( 1 )
-	{
+	{	
 		string	keyname;
 
 		// parse key
@@ -4739,8 +4739,8 @@ qboolean SV_ParseEdict( char **pfile, edict_t *ent )
 
 		Q_strncpy( keyname, token, sizeof( keyname ));
 
-		// parse value
-		if(( *pfile = COM_ParseFile( *pfile, token )) == NULL )
+		// parse value	
+		if(( *pfile = COM_ParseFile( *pfile, token )) == NULL ) 
 			Host_Error( "ED_ParseEdict: EOF without closing brace\n" );
 
 		if( token[0] == '}' )
@@ -4765,13 +4765,13 @@ qboolean SV_ParseEdict( char **pfile, edict_t *ent )
 		pkvd[numpairs].szClassName = ""; // unknown at this moment
 		pkvd[numpairs].szKeyName = copystring( keyname );
 		pkvd[numpairs].szValue = copystring( token );
-		pkvd[numpairs].fHandled = false;
+		pkvd[numpairs].fHandled = false;		
 
 		if( !Q_strcmp( keyname, "classname" ) && classname == NULL )
 			classname = copystring( pkvd[numpairs].szValue );
 		if( ++numpairs >= 256 ) break;
 	}
-
+	
 	ent = SV_AllocPrivateData( ent, ALLOC_STRING( classname ));
 
 	if( !SV_IsValidEdict( ent ) || FBitSet( ent->v.flags, FL_KILLME ))
@@ -4942,7 +4942,7 @@ void SV_SpawnEntities( const char *mapname )
 	Cvar_Reset( "sv_wateramp" );
 	Cvar_Reset( "sv_wateralpha" );
 
-	// reset sky parms
+	// reset sky parms	
 	Cvar_Reset( "sv_skycolor_r" );
 	Cvar_Reset( "sv_skycolor_g" );
 	Cvar_Reset( "sv_skycolor_b" );
@@ -5025,12 +5025,12 @@ qboolean SV_LoadProgs( const char *name )
 	// fill it in
 	svgame.pmove = &gpMove;
 	svgame.globals = &gpGlobals;
-
+	
 	if ( !svgame.mempool )
 	{
 		svgame.mempool = Mem_AllocPool( "Server Edicts Zone" );
 	}
-
+	
 	svgame.hInstance = COM_LoadLibrary( name, true, false );
 	if( !svgame.hInstance ) return false;
 
@@ -5071,7 +5071,7 @@ qboolean SV_LoadProgs( const char *name )
 	if( GiveNewDllFuncs )
 	{
 		version = NEW_DLL_FUNCTIONS_VERSION;
-
+	
 		if( !GiveNewDllFuncs( &svgame.dllFuncs2, &version ))
 		{
 			if( version != NEW_DLL_FUNCTIONS_VERSION )


### PR DESCRIPTION
I noticed this when attempting to load a corrupted server DLL. If the functions cannot be found in the DLL, the existing mempool pointer was overwritten without being freed the next time `SV_LoadProgs` was called.