### PR TITLE
engine: GetGameDir should return gamedir only. Add proper stub functions for some engine APIs

### DIFF
--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -2607,7 +2607,7 @@ const char *pfnGetGameDirectory( void )
 {
 	static char	szGetGameDir[MAX_SYSPATH];
 
-	Q_sprintf( szGetGameDir, "%s/%s", host.rootdir, GI->gamefolder );
+	Q_strcpy( szGetGameDir, GI->gamefolder );
 	return szGetGameDir;
 }
 

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -1123,7 +1123,7 @@ pfnGetGameDir
 void pfnGetGameDir( char *szGetGameDir )
 {
 	if( !szGetGameDir ) return;
-	Q_sprintf( szGetGameDir, "%s/%s", host.rootdir, GI->gamefolder );
+	Q_strcpy( szGetGameDir, GI->gamefolder );
 }
 
 qboolean COM_IsSafeFileToDownload( const char *filename )

--- a/engine/eiface.h
+++ b/engine/eiface.h
@@ -262,17 +262,17 @@ typedef struct enginefuncs_s
 
 	const char *(*pfnGetPlayerAuthId)		( edict_t *e );
 
-	void	(*pfnUnused1)( void );
-	void	(*pfnUnused2)( void );
-	void	(*pfnUnused3)( void );
-	void	(*pfnUnused4)( void );
-	void	(*pfnUnused5)( void );
-	void	(*pfnUnused6)( void );
-	void	(*pfnUnused7)( void );
-	void	(*pfnUnused8)( void );
-	void	(*pfnUnused9)( void );
-	void	(*pfnUnused10)( void );
-	void	(*pfnUnused11)( void );
+	void*	(*pfnSequenceGet)				( const char* fileName, const char* entryName );
+	void*	(*pfnSequencePickSentence)		( const char* groupName, int pickMethod, int *picked );
+	int			(*pfnGetFileSize)						( char *filename );
+	unsigned int (*pfnGetApproxWavePlayLen)				(const char *filepath);
+	int			(*pfnIsCareerMatch)						( void );
+	int			(*pfnGetLocalizedStringLength)			(const char *label);
+	void		(*pfnRegisterTutorMessageShown)			(int mid);
+	int			(*pfnGetTimesTutorMessageShown)			(int mid);
+	void		(*pfnProcessTutorMessageDecayBuffer)	(int *buffer, int bufferLength);
+	void		(*pfnConstructTutorMessageDecayBuffer)	(int *buffer, int bufferLength);
+	void		(*pfnResetTutorMessageDecayData)		( void );
 
 	// three useable funcs
 	void	(*pfnQueryClientCvarValue)( const edict_t *player, const char *cvarName );

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -4550,10 +4550,19 @@ pfnEngineStub
 extended iface stubs
 =============
 */
-static void pfnEngineStub( void )
+static int pfnGetFileSize( char *filename )
 {
+	return 0;
 }
-					
+static unsigned int pfnGetApproxWavePlayLen(const char *filepath)
+{
+	return 0;
+}
+static int pfnGetLocalizedStringLength(const char *label)
+{
+	return 0;
+}
+
 // engine callbacks
 static enginefuncs_t gEngfuncs = 
 {
@@ -4701,17 +4710,17 @@ static enginefuncs_t gEngfuncs =
 	pfnVoice_GetClientListening,
 	pfnVoice_SetClientListening,
 	pfnGetPlayerAuthId,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
-	pfnEngineStub,
+	pfnSequenceGet,
+	pfnSequencePickSentence,
+	pfnGetFileSize,
+	pfnGetApproxWavePlayLen,
+	pfnIsCareerMatch,
+	pfnGetLocalizedStringLength,
+	pfnRegisterTutorMessageShown,
+	pfnGetTimesTutorMessageShown,
+	pfnProcessTutorMessageDecayBuffer,
+	pfnConstructTutorMessageDecayBuffer,
+	pfnResetTutorMessageDecayData,
 	pfnQueryClientCvarValue,
 	pfnQueryClientCvarValue2,
 	COM_CheckParm,


### PR DESCRIPTION
IIRC GetGameDir() used to return full path of game (in very old non-steam HL 1.1.1.0), however this has changed since steam version of Half-Life. Current versions of GoldSrc only returns the gamedir.
This was also the behavior of old versions of Xash3D FWGS.

Also using void functions for stub breaks some MODs which call those functions and rely on the return value (such as Counter-Strike 1.6 regamedll). This fixes the problem.