### PR TITLE
Fixed mod title in Open Source mods documentation.

### DIFF
--- a/Documentation/opensource-mods.md
+++ b/Documentation/opensource-mods.md
@@ -262,7 +262,7 @@ Branch **dmc** in hlsdk-xash3d - https://github.com/FWGS/hlsdk-xash3d/tree/dmc
 ## Half-Life: Echoes
 Branch **echoes** in hlsdk-xash3d - https://github.com/FWGS/hlsdk-xash3d/tree/echoes
 
-## Half-Life: Induction
+## Half-Life: Invasion
 Port to HLSDK 2.4 by malortie - https://github.com/malortie/halflife/tree/mod-hl-invasion
 
 Port to Linux by fmoraw - https://github.com/fmoraw/hlinvasion


### PR DESCRIPTION
In [opensource-mods.md](https://github.com/FWGS/xash3d-fwgs/blob/master/Documentation/opensource-mods.md), the entry [Half-Life: Induction](https://github.com/FWGS/xash3d-fwgs/blob/master/Documentation/opensource-mods.md#half-life-induction-1) contains links to projects that seem to be related to 'Half-Life: Invasion'. The mod title was probably meant to be 'Half-Life: Invasion'.