### PR TITLE
engine: common: filesystem.c: do not load zip-archives with zip extension as bullet proof.

### DIFF
--- a/engine/common/filesystem.c
+++ b/engine/common/filesystem.c
@@ -1124,7 +1124,7 @@ qboolean FS_AddZip_Fullpath( const char *zipfile, qboolean *already_loaded, int 
   
 	if( already_loaded ) *already_loaded = false;
   
-	if( !Q_stricmp( ext, "zip" ) || !Q_stricmp( ext, "pk3" ) )
+	if( !Q_stricmp( ext, "pk3" ) )
 		zip = FS_LoadZip( zipfile, &errorcode );
   
 	if( zip )


### PR DESCRIPTION
I think .zip extension can cause trouble with performance penalty if:
1. user put zip-archive with game data to mod folder to unpack it(and not remove it).
2. existing mods already has zip-archives with some data.

And I think It's main reason why Quake 3 uses .pk3 extension for zip-archives.