### PR TITLE
engine: client: Fixed sounds emitted by viewmodel animations only playing at where they were emitted from in the world

### DIFF
--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -2228,7 +2228,7 @@ static pmtrace_t *pfnTraceLine( float *start, float *end, int flags, int usehull
 static void GAME_EXPORT pfnPlaySoundByNameAtLocation( char *szSound, float volume, float *origin )
 {
 	int hSound = S_RegisterSound( szSound );
-	S_StartSound( origin, 0, CHAN_AUTO, hSound, volume, ATTN_NORM, PITCH_NORM, 0 );
+	S_StartSound( origin, cl.viewentity, CHAN_AUTO, hSound, volume, ATTN_NORM, PITCH_NORM, 0 );
 }
 
 /*


### PR DESCRIPTION
This fixes a minor bug where sounds played via pfnPlaySoundByNameAtLocation (mainly from viewmodel animations e.g. MP5) would be left where it was emitted in the world, rather than following the local player as it does in Goldsrc.

I'm unsure of any long-term issues, but it fixes this one issue in particular.