### PR TITLE
engine: client: update the ref state before R_NewMap is called

### DIFF
--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -1578,6 +1578,12 @@ void CL_RegisterResources( sizebuf_t *msg )
 
 			CL_ClearWorld ();
 
+			// update the ref state.
+			refState.time      = cl.time;
+			refState.oldtime   = cl.oldtime;
+			refState.realtime  = host.realtime;
+			refState.frametime = host.frametime;
+
 			// tell rendering system we have a new set of models.
 			ref.dllFuncs.R_NewMap ();
 
@@ -3167,6 +3173,12 @@ void CL_LegacyPrecache_f( void )
 	cl.audio_prepped = true;
 	if( clgame.entities )
 		clgame.entities->model = cl.worldmodel;
+
+	// update the ref state.
+	refState.time      = cl.time;
+	refState.oldtime   = cl.oldtime;
+	refState.realtime  = host.realtime;
+	refState.frametime = host.frametime;
 
 	// tell rendering system we have a new set of models.
 	ref.dllFuncs.R_NewMap ();


### PR DESCRIPTION
This fixes fades that occur at the beginning of a map being a tad screwy as a result of the ref state not being updated with fresh values, which only happens when a frame is being rendered (loading happens to prevent that).

For this issue:
https://github.com/FWGS/xash3d-fwgs/issues/103