### PR TITLE
gl4es: Fix `so` name and add to renderer collector

### DIFF
--- a/engine/common/com_strings.h
+++ b/engine/common/com_strings.h
@@ -65,7 +65,7 @@ GNU General Public License for more details.
 
 #define XASH_ENGINE_NAME "Xash3D FWGS"
 
-#define DEFAULT_RENDERERS { "gl", "gles1", "gles2", "soft" }
-#define DEFAULT_RENDERERS_LEN 4
+#define DEFAULT_RENDERERS { "gl", "gles1", "gles2", "gl4es", "soft" }
+#define DEFAULT_RENDERERS_LEN 5
 
 #endif//COM_STRINGS_H

--- a/ref_gl/wscript
+++ b/ref_gl/wscript
@@ -118,7 +118,7 @@ def build(bld):
 
 		bld.shlib(
 			source   = source,
-			target   = 'ref_gles2_gl4es',
+			target   = 'ref_gl4es',
 			features = 'c',
 			includes = includes,
 			use      = libs + ['DL', 'gl4es', 'LOG'],


### PR DESCRIPTION
1. `libref_gles2_gl4es.so` -> `libref_gl4es.so` because this is what's passed to `R_LoadRenderer`.

2. Add `gl4es` to `DEFAULT_RENDERERS` so that `R_CollectRendererNames` finds it.