### PR TITLE
gl4es: Add GL4ES_COMPILE_FOR_USE_IN_SHARED_LIB

### DIFF
--- a/ref_gl/wscript
+++ b/ref_gl/wscript
@@ -111,7 +111,7 @@ def build(bld):
 			target   = 'gl4es',
 			features = 'c',
 			includes = ['gl4es/src', 'gl4es/src/gl', 'gl4es/src/glx', 'gl4es/include'],
-			defines = ['NOX11', 'NO_GBM', 'NO_INIT_CONSTRUCTOR', 'DEFAULT_ES=2', 'NOEGL', 'EXTERNAL_GETPROCADDRESS=GL4ES_GetProcAddress', 'NO_LOADER', 'STATICLIB'],
+			defines = ['NOX11', 'GL4ES_COMPILE_FOR_USE_IN_SHARED_LIB', 'NO_GBM', 'NO_INIT_CONSTRUCTOR', 'DEFAULT_ES=2', 'NOEGL', 'EXTERNAL_GETPROCADDRESS=GL4ES_GetProcAddress', 'NO_LOADER', 'STATICLIB'],
 			cflags = ['-w', '-fvisibility=hidden', '-std=gnu99'],
 			use      = libs,
 			subsystem = bld.env.MSVC_SUBSYSTEM)


### PR DESCRIPTION
This fixes gl4es crashing on unload if it wasn't initialized

It does not get initialized on load because we set `NO_INIT_CONSTRUCTOR`:

https://github.com/FWGS/xash3d-fwgs/blob/5a36a26dd116bdbddbf8b011f59597eb77e6d4cd/ref_gl/wscript#L114

See https://github.com/ptitSeb/gl4es/blob/215b5356ea300ec35c9db2f649964a1bc4d30182/src/gl/init.c#L669-L672