### PR TITLE
.gitignore: Fix waf ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,8 +314,8 @@ build-*
 
 # Waf
 build_current
-\.?waf-*/
-\.?waf3-*/
+.waf-*/
+.waf3-*/
 .lock-waf*
 *.lastbuildstate
 *.unsuccessfulbuild


### PR DESCRIPTION
Dot (`.`) is not a special character in `.gitignore` files
Reference: https://git-scm.com/docs/gitignore#_pattern_format