### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,35 @@
+BasedOnStyle: WebKit
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+
+BreakBeforeBraces: Allman
+
+AlignAfterOpenBracket: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignConsecutiveMacros: true
+AlignOperands: true
+
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+NamespaceIndentation: Inner
+
+SpaceAfterCStyleCast: false
+SpaceBeforeParens: true
+SpaceInEmptyParentheses: true
+SpacesInAngles: true
+SpacesInParentheses: true
+SpacesBeforeTrailingComments: 1
+
+IndentCaseLabels: false
+IndentWrappedFunctionNames: true
+
+PointerAlignment: Right
+
+ColumnLimit: 0
+BinPackArguments: false


### PR DESCRIPTION
Based on https://github.com/FWGS/xash3d/blob/725fd84b5ba8d405979d63df7a906feb1bc87d51/.clang-format with the following changes:

1. Uncomments `BasedOnStyle: WebKit` to be explicit.
2. Adds:

       AlignConsecutiveDeclarations: true
       AlignConsecutiveMacros: true