### PR TITLE
.clang-format: SpaceBeforeParens: Never

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ AllowShortLoopsOnASingleLine: false
 NamespaceIndentation: Inner
 
 SpaceAfterCStyleCast: false
-SpaceBeforeParens: true
+SpaceBeforeParens: Never
 SpaceInEmptyParentheses: true
 SpacesInAngles: true
 SpacesInParentheses: true


### PR DESCRIPTION
This is more consistent with how xash3d formats its `if` and `switch` statements