### PR TITLE
Gamepad fixes

### DIFF
--- a/engine/client/in_joy.c
+++ b/engine/client/in_joy.c
@@ -385,8 +385,8 @@ void Joy_Init( void )
 	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE, "joystick side sensitivity. Values from -1.0 to 1.0" );
 	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE, "joystick forward sensitivity. Values from -1.0 to 1.0" );
 
-	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "-16384", FCVAR_ARCHIVE, "left trigger threshold. Value from -32768 to 32767");
-	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "-16384", FCVAR_ARCHIVE, "right trigger threshold. Value from -32768 to 32767" );
+	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE, "left trigger threshold. Value from 0 to 32767");
+	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE, "right trigger threshold. Value from 0 to 32767" );
 
 	// emit a key event at 75% axis move
 	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE, "side axis key event emit threshold. Value from 0 to 32767" );

--- a/engine/client/in_joy.c
+++ b/engine/client/in_joy.c
@@ -24,17 +24,6 @@ GNU General Public License for more details.
 #define SHRT_MAX 0x7FFF
 #endif
 
-typedef enum engineAxis_e
-{
-	JOY_AXIS_SIDE = 0,
-	JOY_AXIS_FWD,
-	JOY_AXIS_PITCH,
-	JOY_AXIS_YAW,
-	JOY_AXIS_RT,
-	JOY_AXIS_LT,
-	JOY_AXIS_NULL
-} engineAxis_t;
-
 #define MAX_AXES JOY_AXIS_NULL
 
 // index - axis num come from event
@@ -246,8 +235,6 @@ Axis events
 */
 void Joy_AxisMotionEvent( byte axis, short value )
 {
-	byte engineAxis;
-
 	if( !joy_found->value )
 		return;
 
@@ -257,8 +244,11 @@ void Joy_AxisMotionEvent( byte axis, short value )
 		return;
 	}
 
-	engineAxis = joyaxesmap[axis]; // convert to engine inner axis control
+	return Joy_KnownAxisMotionEvent( joyaxesmap[axis], value );
+}
 
+void Joy_KnownAxisMotionEvent( engineAxis_t engineAxis, short value )
+{
 	if( engineAxis == JOY_AXIS_NULL )
 		return;
 

--- a/engine/client/input.h
+++ b/engine/client/input.h
@@ -93,9 +93,21 @@ enum
 	JOY_HAT_LEFTDOWN  = JOY_HAT_LEFT  | JOY_HAT_DOWN
 };
 
+typedef enum engineAxis_e
+{
+	JOY_AXIS_SIDE = 0,
+	JOY_AXIS_FWD,
+	JOY_AXIS_PITCH,
+	JOY_AXIS_YAW,
+	JOY_AXIS_RT,
+	JOY_AXIS_LT,
+	JOY_AXIS_NULL
+} engineAxis_t;
+
 qboolean Joy_IsActive( void );
 void Joy_HatMotionEvent( byte hat, byte value );
 void Joy_AxisMotionEvent( byte axis, short value );
+void Joy_KnownAxisMotionEvent( engineAxis_t engineAxis, short value );
 void Joy_BallMotionEvent( byte ball, short xrel, short yrel );
 void Joy_ButtonEvent( byte button, byte down );
 void Joy_AddEvent( void );

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -98,26 +98,32 @@ keyname_t keynames[] =
 {"KP_PLUS",	K_KP_PLUS,	""		},
 {"PAUSE",		K_PAUSE,		"pause"		},
 
-{"A_BUTTON", K_A_BUTTON, ""}, // they match xbox controller
-{"B_BUTTON", K_B_BUTTON, ""},
-{"X_BUTTON", K_X_BUTTON, ""},
-{"Y_BUTTON", K_Y_BUTTON, ""},
-{"L1_BUTTON",  K_L1_BUTTON, ""},
-{"R1_BUTTON",  K_R1_BUTTON, ""},
-{"BACK",   K_BACK_BUTTON, ""},
+// Gamepad
+// A/B X/Y names match the Xbox controller layout
+{"A_BUTTON", K_A_BUTTON, "+jump"},
+{"B_BUTTON", K_B_BUTTON, "+use"},
+{"X_BUTTON", K_X_BUTTON, "+reload"}, // Flashlight
+{"Y_BUTTON", K_Y_BUTTON, "impulse 100"},
+{"BACK",   K_BACK_BUTTON, "cancelselect"}, // Menu
 {"MODE",   K_MODE_BUTTON, ""},
-{"START",  K_START_BUTTON, ""},
-{"STICK1", K_LSTICK, ""},
-{"STICK2", K_RSTICK, ""},
-{"L2_BUTTON", K_L2_BUTTON, ""}, // in case...
-{"R2_BUTTON", K_R2_BUTTON, ""},
+{"START",  K_START_BUTTON, "pause"},
+{"STICK1", K_LSTICK, "+speed"},
+{"STICK2", K_RSTICK, "+duck"},
+{"L1_BUTTON",  K_L1_BUTTON, "+duck"},
+{"R1_BUTTON",  K_R1_BUTTON, "+attack"},
+{"DPAD_UP",	K_DPAD_UP,	"impulse 201"}, // Spray
+{"DPAD_DOWN",	K_DPAD_DOWN,	"lastinv"},
+{"DPAD_LEFT",	K_DPAD_LEFT,	"invprev"},
+{"DPAD_RIGHT",	K_DPAD_RIGHT,	"invnext"},
+{"L2_BUTTON", K_L2_BUTTON, "+speed"},
+{"R2_BUTTON", K_R2_BUTTON, "+attack2"},
+{"LTRIGGER" , K_JOY1 , "+speed"}, // L2 in SDL2
+{"RTRIGGER" , K_JOY2 , "+attack2"}, // R2 in SDL2
+{"JOY3" , K_JOY3 , ""},
+{"JOY4" , K_JOY4 , ""},
 {"C_BUTTON", K_C_BUTTON, ""},
 {"Z_BUTTON", K_Z_BUTTON, ""},
-{"AUX16", K_AUX16, ""}, // generic
-{"AUX17", K_AUX17, ""},
-{"AUX18", K_AUX18, ""},
-{"AUX19", K_AUX19, ""},
-{"AUX20", K_AUX20, ""},
+{"AUX20", K_AUX20, ""}, // generic
 {"AUX21", K_AUX21, ""},
 {"AUX22", K_AUX22, ""},
 {"AUX23", K_AUX23, ""},
@@ -130,10 +136,6 @@ keyname_t keynames[] =
 {"AUX30", K_AUX30, ""},
 {"AUX31", K_AUX31, ""},
 {"AUX32", K_AUX32, ""},
-{"LTRIGGER" , K_JOY1 , ""},
-{"RTRIGGER" , K_JOY2 , ""},
-{"JOY3" , K_JOY3 , ""},
-{"JOY4" , K_JOY4 , ""},
 
 // raw semicolon seperates commands
 {"SEMICOLON",	';',		""		},

--- a/engine/keydefs.h
+++ b/engine/keydefs.h
@@ -77,8 +77,8 @@
 //
 // joystick buttons
 //
-#define K_JOY1		203
-#define K_JOY2		204
+#define K_JOY1		203 // LTRIGGER (L2)
+#define K_JOY2		204 // RTRIGGER (R2)
 #define K_JOY3		205
 #define K_JOY4		206
 
@@ -132,9 +132,17 @@
 #define K_Z_BUTTON  K_AUX15
 
 #define K_AUX16		222
+#define K_DPAD_UP  K_AUX16
+
 #define K_AUX17		223
+#define K_DPAD_DOWN  K_AUX17
+
 #define K_AUX18		224
+#define K_DPAD_LEFT  K_AUX18
+
 #define K_AUX19		225
+#define K_DPAD_RIGHT  K_AUX19
+
 #define K_AUX20		226
 #define K_AUX21		227
 #define K_AUX22		228

--- a/engine/platform/sdl/events.c
+++ b/engine/platform/sdl/events.c
@@ -550,17 +550,16 @@ static void SDLash_EventFilter( SDL_Event *event )
 	{
 		static int sdlControllerButtonToEngine[] =
 		{
-			K_AUX16, // invalid
 			K_A_BUTTON, K_B_BUTTON, K_X_BUTTON,	K_Y_BUTTON,
 			K_BACK_BUTTON, K_MODE_BUTTON, K_START_BUTTON,
 			K_LSTICK, K_RSTICK,
 			K_L1_BUTTON, K_R1_BUTTON,
-			K_UPARROW, K_DOWNARROW, K_LEFTARROW, K_RIGHTARROW
+			K_DPAD_UP, K_DPAD_DOWN, K_DPAD_LEFT, K_DPAD_RIGHT
 		};
 
 		// TODO: Use joyinput funcs, for future multiple gamepads support
-		if( Joy_IsActive() )
-			Key_Event( sdlControllerButtonToEngine[event->cbutton.button + 1], event->cbutton.state );
+		if( Joy_IsActive() && event->cbutton.button != SDL_CONTROLLER_BUTTON_INVALID )
+			Key_Event( sdlControllerButtonToEngine[event->cbutton.button], event->cbutton.state );
 		break;
 	}
 

--- a/engine/platform/sdl/events.c
+++ b/engine/platform/sdl/events.c
@@ -532,18 +532,21 @@ static void SDLash_EventFilter( SDL_Event *event )
 
 	/* GameController API */
 	case SDL_CONTROLLERAXISMOTION:
-		if( event->caxis.axis == (Uint8)SDL_CONTROLLER_AXIS_INVALID )
-			break;
-
+	{
 		// Swap axis to follow default axis binding:
 		// LeftX, LeftY, RightX, RightY, TriggerRight, TriggerLeft
-		if( event->caxis.axis == SDL_CONTROLLER_AXIS_TRIGGERLEFT )
-			event->caxis.axis = SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
-		else if( event->caxis.axis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT )
-			event->caxis.axis = SDL_CONTROLLER_AXIS_TRIGGERLEFT;
-
-		Joy_AxisMotionEvent( event->caxis.axis, event->caxis.value );
+		static int sdlControllerAxisToEngine[] = {
+			JOY_AXIS_SIDE, // SDL_CONTROLLER_AXIS_LEFTX,
+			JOY_AXIS_FWD, // SDL_CONTROLLER_AXIS_LEFTY,
+			JOY_AXIS_PITCH, // SDL_CONTROLLER_AXIS_RIGHTX,
+			JOY_AXIS_YAW, // SDL_CONTROLLER_AXIS_RIGHTY,
+			JOY_AXIS_LT, // SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+			JOY_AXIS_RT, // SDL_CONTROLLER_AXIS_TRIGGERRIGHT,
+		};
+		if( Joy_IsActive() && event->caxis.axis != (Uint8)SDL_CONTROLLER_AXIS_INVALID )
+			Joy_KnownAxisMotionEvent( sdlControllerAxisToEngine[event->caxis.axis], event->caxis.value );
 		break;
+	}
 
 	case SDL_CONTROLLERBUTTONDOWN:
 	case SDL_CONTROLLERBUTTONUP:
@@ -558,7 +561,7 @@ static void SDLash_EventFilter( SDL_Event *event )
 		};
 
 		// TODO: Use joyinput funcs, for future multiple gamepads support
-		if( Joy_IsActive() && event->cbutton.button != SDL_CONTROLLER_BUTTON_INVALID )
+		if( Joy_IsActive() && event->cbutton.button != (Uint8)SDL_CONTROLLER_BUTTON_INVALID )
 			Key_Event( sdlControllerButtonToEngine[event->cbutton.button], event->cbutton.state );
 		break;
 	}


### PR DESCRIPTION
1. Adds separate D-Pad bindings so that they don't conflict with arrow keys on the keyboard (companion `mainui` PR https://github.com/FWGS/mainui_cpp/pull/40).

2. Fix trigger buttons (the thresholds were wrong).

3. Adds basic default mappings for gamepad buttons.