### PR TITLE
Fix COM_LibraryError newline handling

### DIFF
--- a/engine/client/cl_gameui.c
+++ b/engine/client/cl_gameui.c
@@ -1046,7 +1046,7 @@ int GAME_EXPORT pfnCheckGameDll( void )
 		COM_FreeLibrary( hInst ); // don't increase linker's reference counter
 		return true;
 	}
-	Con_Reportf( S_WARN "Could not load server library:\n%s", COM_GetLibraryError() );
+	Con_Reportf( S_WARN "Could not load server library: %s\n", COM_GetLibraryError() );
 	return false;
 }
 

--- a/engine/client/vgui/vgui_draw.c
+++ b/engine/client/vgui/vgui_draw.c
@@ -285,7 +285,7 @@ void VGui_Startup( const char *clientlib, int width, int height )
 		if( !s_pVGuiSupport )
 		{
 			if( FS_FileExists( vguiloader, false ) )
-				Con_Reportf( S_ERROR  "Failed to load vgui_support library: %s", COM_GetLibraryError() );
+				Con_Reportf( S_ERROR  "Failed to load vgui_support library: %s\n", COM_GetLibraryError() );
 			else
 				Con_Reportf( "vgui_support: not found\n" );
 		}

--- a/engine/common/lib_common.c
+++ b/engine/common/lib_common.c
@@ -32,8 +32,9 @@ void COM_ResetLibraryError( void )
 
 void COM_PushLibraryError( const char *error )
 {
+	if( s_szLastError[0] )
+		Q_strncat( s_szLastError, "\n", sizeof( s_szLastError ) );
 	Q_strncat( s_szLastError, error, sizeof( s_szLastError ) );
-	Q_strncat( s_szLastError, "\n", sizeof( s_szLastError ) );
 }
 
 void *COM_FunctionFromName_SR( void *hInstance, const char *pName )


### PR DESCRIPTION
1. Do not append a trailing newline to the result of COM_GetLibraryError.
2. Fix call sites.