### PR TITLE
game_launch: Add a --disable-menu-changegame build option

### DIFF
--- a/game_launch/game.cpp
+++ b/game_launch/game.cpp
@@ -129,9 +129,16 @@ static void Sys_ChangeGame( const char *progname )
 _inline int Sys_Start( void )
 {
 	int ret;
+	pfnChangeGame changeGame = NULL;
 
 	Sys_LoadEngine();
-	ret = Xash_Main( szArgc, szArgv, GAME_PATH, 0, Xash_Shutdown ? Sys_ChangeGame : NULL );
+
+#ifndef XASH_DISABLE_MENU_CHANGEGAME
+	if( Xash_Shutdown )
+		changeGame = Sys_ChangeGame;
+#endif
+
+	ret = Xash_Main( szArgc, szArgv, GAME_PATH, 0, changeGame );
 	Sys_UnloadEngine();
 
 	return ret;

--- a/game_launch/wscript
+++ b/game_launch/wscript
@@ -9,11 +9,16 @@ import sys
 top = '.'
 
 def options(opt):
-	return
+	grp = opt.add_option_group('Game launcher options')
+
+	grp.add_option('--disable-menu-changegame', action = 'store_true', dest = 'DISABLE_MENU_CHANGEGAME', default = False,
+		help = 'disable changing the game from the menu [default: %default]')
 
 def configure(conf):
 	if conf.env.DEST_OS == 'win32':
 		conf.load('winres')
+
+	conf.define_cond('XASH_DISABLE_MENU_CHANGEGAME', conf.options.DISABLE_MENU_CHANGEGAME)
 
 def build(bld):
 	source = ['game.cpp']


### PR DESCRIPTION
This option is useful when xash3d is launched externally by a script that performs additional setup.