### PR TITLE
platform: win32: sdl: Fix zombie processes after early Sys_Error on windows+sdl

### DIFF
--- a/engine/platform/sdl/sys_sdl.c
+++ b/engine/platform/sdl/sys_sdl.c
@@ -64,8 +64,14 @@ void Platform_Init( void )
 #if XASH_POSIX
 	Posix_Daemonize();
 #endif
+#ifdef XASH_WIN32
+	Wcon_CreateConsole(); // system console used by dedicated server or show fatal errors
+#endif
 }
 
 void Platform_Shutdown( void )
 {
+#ifdef XASH_WIN32
+	Wcon_DestroyConsole();
+#endif
 }


### PR DESCRIPTION
If Sys_Error gets called on windows with dev parameter, for example here https://github.com/FWGS/xash3d-fwgs/blob/5e0a0765ce1f82869f9d7ff3ef731f834c4faab5/engine/common/host.c#L498
Engine will wait indefenetely until console window receiwes escape hotkey.
https://github.com/FWGS/xash3d-fwgs/blob/5e0a0765ce1f82869f9d7ff3ef731f834c4faab5/engine/common/system.c#L439
But this will never happen because Wcon wasn't initialized.
As a side effect, other xash instances won't receive any escape key events.
https://github.com/FWGS/xash3d-fwgs/blob/5e0a0765ce1f82869f9d7ff3ef731f834c4faab5/engine/platform/win32/con_win.c#L465