### PR TITLE
partially fix amd64 build on windows

### DIFF
--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -3945,7 +3945,7 @@ qboolean CL_LoadProgs( const char *name )
 
 	// a1ba: we need to check if client.dll has direct dependency on SDL2
 	// and if so, disable relative mouse mode
-#if XASH_WIN32 && !defined(XASH_64BIT)
+#if XASH_WIN32 && !XASH_64BIT
 	if( ( clgame.client_dll_uses_sdl = COM_CheckLibraryDirectDependency( name, OS_LIB_PREFIX "SDL2." OS_LIB_EXT, false ) ) )
 	{
 		Con_Printf( S_NOTE "%s uses SDL2 for mouse input\n", name );

--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -3945,7 +3945,7 @@ qboolean CL_LoadProgs( const char *name )
 
 	// a1ba: we need to check if client.dll has direct dependency on SDL2
 	// and if so, disable relative mouse mode
-#if XASH_WIN32
+#if XASH_WIN32 && !defined(XASH_64BIT)
 	if( ( clgame.client_dll_uses_sdl = COM_CheckLibraryDirectDependency( name, OS_LIB_PREFIX "SDL2." OS_LIB_EXT, false ) ) )
 	{
 		Con_Printf( S_NOTE "%s uses SDL2 for mouse input\n", name );

--- a/engine/client/cl_netgraph.c
+++ b/engine/client/cl_netgraph.c
@@ -658,7 +658,7 @@ void SCR_DrawNetGraph( void )
 	if( net_graph->value < 3 )
 	{
 		ref.dllFuncs.GL_SetRenderMode( kRenderTransAdd );
-
+		ref.dllFuncs.GL_Bind( XASH_TEXTURE0, R_GetBuiltinTexture( REF_WHITE_TEXTURE ) );
 		ref.dllFuncs.Begin( TRI_QUADS ); // draw all the fills as a long solid sequence of quads for speedup reasons
 
 		// NOTE: fill colors without texture at this point

--- a/engine/client/vid_common.c
+++ b/engine/client/vid_common.c
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #define WINDOW_NAME			XASH_ENGINE_NAME " Window" // Half-Life
 convar_t	*vid_displayfrequency;
 convar_t	*vid_fullscreen;
+convar_t	*vid_mode;
 convar_t	*vid_brightness;
 convar_t	*vid_gamma;
 convar_t	*vid_highdpi;
@@ -182,6 +183,7 @@ void VID_Init( void )
 	vid_brightness = Cvar_Get( "brightness", "0.0", FCVAR_ARCHIVE, "brightness factor" );
 	vid_displayfrequency = Cvar_Get ( "vid_displayfrequency", "0", FCVAR_RENDERINFO|FCVAR_VIDRESTART, "fullscreen refresh rate" );
 	vid_fullscreen = Cvar_Get( "fullscreen", "0", FCVAR_RENDERINFO|FCVAR_VIDRESTART, "enable fullscreen mode" );
+	vid_mode = Cvar_Get( "vid_mode", "0", FCVAR_RENDERINFO, "current video mode index (used just for storage)" );
 	vid_highdpi = Cvar_Get( "vid_highdpi", "1", FCVAR_RENDERINFO|FCVAR_VIDRESTART, "enable High-DPI mode" );
 	vid_rotate = Cvar_Get( "vid_rotate", "0", FCVAR_RENDERINFO|FCVAR_VIDRESTART, "screen rotation (0-3)" );
 	vid_scale = Cvar_Get( "vid_scale", "1.0", FCVAR_RENDERINFO|FCVAR_VIDRESTART, "pixel scale" );

--- a/engine/common/filesystem.c
+++ b/engine/common/filesystem.c
@@ -324,7 +324,7 @@ static void listdirectory( stringlist_t *list, const char *path, qboolean lowerc
 #if XASH_WIN32
 	char pattern[4096];
 	struct _finddata_t	n_file;
-	int		hFile;
+	intptr_t		hFile;
 #else
 	DIR *dir;
 	struct dirent *entry;

--- a/engine/platform/win32/con_win.c
+++ b/engine/platform/win32/con_win.c
@@ -354,7 +354,11 @@ void Wcon_CreateConsole( void )
 
 	if( host.type == HOST_DEDICATED )
 	{
+#ifdef XASH_64BIT
+		s_wcd.SysInputLineWndProc = (WNDPROC)SetWindowLongPtr( s_wcd.hwndInputLine, GWLP_WNDPROC, (LONG_PTR)Wcon_InputLineProc );
+#else
 		s_wcd.SysInputLineWndProc = (WNDPROC)SetWindowLong( s_wcd.hwndInputLine, GWL_WNDPROC, (long)Wcon_InputLineProc );
+#endif
 		SendMessage( s_wcd.hwndInputLine, WM_SETFONT, ( WPARAM )s_wcd.hfBufferFont, 0 );
 	}
 

--- a/engine/platform/win32/lib_win.c
+++ b/engine/platform/win32/lib_win.c
@@ -20,9 +20,14 @@ GNU General Public License for more details.
 #ifdef XASH_64BIT
 #include <dbghelp.h>
 
-void *COM_LoadLibrary( const char *dllname, int build_ordinals_table )
+void *COM_LoadLibrary( const char *dllname, int build_ordinals_table, qboolean directpath )
 {
-	return LoadLibraryA( dllname );
+	dll_user_t *hInst;
+
+	hInst = FS_FindLibrary( dllname, directpath );
+	if( !hInst ) return NULL; // nothing to load
+
+	return LoadLibraryA( hInst->fullPath );
 }
 
 void COM_FreeLibrary( void *hInstance )

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -3138,9 +3138,9 @@ void SV_AllocStringPool( void )
 #endif
 
 	str64.pstringarray = ptr;
-	str64.pstringarraystatic = ptr + str64.maxstringarray;
+	str64.pstringarraystatic = (byte*)ptr + str64.maxstringarray;
 	str64.pstringbase = str64.poldstringbase = ptr;
-	str64.plast = ptr + 1;
+	str64.plast = (byte*)ptr + 1;
 	svgame.globals->pStringBase = ptr;
 #else
 	svgame.stringspool = Mem_AllocPool( "Server Strings" );
@@ -3153,9 +3153,11 @@ void SV_FreeStringPool( void )
 #ifdef XASH_64BIT
 	Con_Reportf( "SV_FreeStringPool()\n" );
 
+#if USE_MMAP
 	if( str64.pstringarray != str64.staticstringarray )
 		munmap( str64.pstringarray, (str64.maxstringarray * 2) & ~(sysconf( _SC_PAGESIZE ) - 1) );
 	else
+#endif
 		Mem_Free( str64.staticstringarray );
 #else
 	Mem_FreePool( &svgame.stringspool );

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -3153,7 +3153,7 @@ void SV_FreeStringPool( void )
 #ifdef XASH_64BIT
 	Con_Reportf( "SV_FreeStringPool()\n" );
 
-#if USE_MMAP
+#ifdef USE_MMAP
 	if( str64.pstringarray != str64.staticstringarray )
 		munmap( str64.pstringarray, (str64.maxstringarray * 2) & ~(sysconf( _SC_PAGESIZE ) - 1) );
 	else

--- a/scripts/waifulib/compiler_optimizations.py
+++ b/scripts/waifulib/compiler_optimizations.py
@@ -73,7 +73,7 @@ CFLAGS = {
 		'default': ['-O3']
 	},
 	'debug': {
-		'msvc':    ['/O1'],
+		'msvc':    ['/Od'],
 		'gcc':     ['-Og'],
 		'owcc':    ['-O0', '-fno-omit-frame-pointer', '-funwind-tables', '-fno-omit-leaf-frame-pointer'],
 		'default': ['-O1']

--- a/wscript
+++ b/wscript
@@ -94,9 +94,9 @@ def options(opt):
 
 		opt.add_subproject(i.name)
 
-	opt.load('xshlib xcompile compiler_cxx compiler_c sdl2 clang_compilation_database strip_on_install waf_unit_test')
+	opt.load('xshlib xcompile compiler_cxx compiler_c sdl2 clang_compilation_database strip_on_install waf_unit_test msdev msvs')
 	if sys.platform == 'win32':
-		opt.load('msvc msdev msvs')
+		opt.load('msvc')
 	opt.load('reconfigure')
 
 def configure(conf):
@@ -110,24 +110,17 @@ def configure(conf):
 	conf.env.MSVC_SUBSYSTEM = 'WINDOWS,5.01'
 	conf.env.MSVC_TARGETS = ['x86' if not conf.options.ALLOW64 else 'x64']
 
-	if sys.platform == 'win32':
-		conf.load('msvc msvc_pdb msdev msvs')
+	# Load compilers early
+	conf.load('xshlib xcompile compiler_c compiler_cxx')
 
-	# FIXME windows64
-	# On Windows with option -8 (and this MSVC_TARGETS being set to x64)
-	# conf.env.DEST_CPU will be set to value 'amd64', which is totally unexpected
-	# by the rest of xash3d-fwgs/waf build system. I have no idea what is the
-	# correct fix for this. As a workaround we'd want to set to 'x86_64' (the
-	# expected value) here, but the next `conf.load` line calls into msvc again
-	# and rewrited the value a couple of times.
-	# Send help.
-
-	conf.load('xshlib subproject xcompile compiler_c compiler_cxx gitversion clang_compilation_database strip_on_install waf_unit_test enforce_pic')
-
-	# FIXME windows64
-	# NOW we can rewrite the DEST_CPU value...
-	if sys.platform == 'win32' and conf.env.DEST_CPU == 'amd64':
+	# HACKHACK: override msvc DEST_CPU value by something that we understand
+	if conf.env.DEST_CPU == 'amd64':
 		conf.env.DEST_CPU = 'x86_64'
+
+	if conf.env.COMPILER_CC == 'msvc':
+		conf.load('msvc_pdb')
+
+	conf.load('msvs msdev subproject gitversion clang_compilation_database strip_on_install waf_unit_test enforce_pic')
 
 	enforce_pic = True # modern defaults
 

--- a/wscript
+++ b/wscript
@@ -104,16 +104,30 @@ def configure(conf):
 	if conf.options.IGNORE_PROJECTS:
 		conf.env.IGNORE_PROJECTS = conf.options.IGNORE_PROJECTS.split(',')
 
-
 	# Force XP compability, all build targets should add
 	# subsystem=bld.env.MSVC_SUBSYSTEM
 	# TODO: wrapper around bld.stlib, bld.shlib and so on?
 	conf.env.MSVC_SUBSYSTEM = 'WINDOWS,5.01'
-	conf.env.MSVC_TARGETS = ['x86'] # explicitly request x86 target for MSVC
+	conf.env.MSVC_TARGETS = ['x86' if not conf.options.ALLOW64 else 'x64']
+
 	if sys.platform == 'win32':
 		conf.load('msvc msvc_pdb msdev msvs')
+
+	# FIXME windows64
+	# On Windows with option -8 (and this MSVC_TARGETS being set to x64)
+	# conf.env.DEST_CPU will be set to value 'amd64', which is totally unexpected
+	# by the rest of xash3d-fwgs/waf build system. I have no idea what is the
+	# correct fix for this. As a workaround we'd want to set to 'x86_64' (the
+	# expected value) here, but the next `conf.load` line calls into msvc again
+	# and rewrited the value a couple of times.
+	# Send help.
+
 	conf.load('xshlib subproject xcompile compiler_c compiler_cxx gitversion clang_compilation_database strip_on_install waf_unit_test enforce_pic')
 
+	# FIXME windows64
+	# NOW we can rewrite the DEST_CPU value...
+	if sys.platform == 'win32' and conf.env.DEST_CPU == 'amd64':
+		conf.env.DEST_CPU = 'x86_64'
 
 	enforce_pic = True # modern defaults
 


### PR DESCRIPTION
Quality of this PR is questionable. I have no idea whether what I did here makes sense or not.
But it compiles and runs (provided with hlsdk-xash3d amd64 build, which is another story).

This hacks `wscript` `DEST_CPU` value really badly (tldr: `msvc` will detect 64-bit cpu as `amd64`, but many parts of xash build scripts, including some in waifu, expect it to be `x86_64` and break badly if it's not set properly). I've yet to figure out how to fix it properly.
Hence DRAFT status of this PR.

This change is a precursor for RTX Vulkan effort -- VK_KHR_ray_tracing_pipeline and friends are only available on 64-bit nvidia drivers (no idea about AMD, pls send GPUs onegai).

I'd appreciate reviews and any other help in stabilizing Windows amd64 target.