### PR TITLE
engine: common: disable sleeptime by default for non-mobile platforms

### DIFF
--- a/common/defaults.h
+++ b/common/defaults.h
@@ -172,9 +172,11 @@ Default build-depended cvar and constant values
 #if XASH_MOBILE_PLATFORM
 	#define DEFAULT_TOUCH_ENABLE "1"
 	#define DEFAULT_M_IGNORE "1"
+	#define DEFAULT_SLEEPTIME "1"
 #else // !XASH_MOBILE_PLATFORM
 	#define DEFAULT_TOUCH_ENABLE "0"
 	#define DEFAULT_M_IGNORE "0"
+	#define DEFAULT_SLEEPTIME "0"
 #endif // !XASH_MOBILE_PLATFORM
 
 #if XASH_ANDROID || XASH_IOS || XASH_EMSCRIPTEN

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -1014,7 +1014,7 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 	host_serverstate = Cvar_Get( "host_serverstate", "0", FCVAR_READ_ONLY, "displays current server state" );
 	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE, "host fps upper limit" );
 	host_framerate = Cvar_Get( "host_framerate", "0", 0, "locks frame timing to this value in seconds" );
-	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
+	host_sleeptime = Cvar_Get( "sleeptime", DEFAULT_SLEEPTIME, FCVAR_ARCHIVE, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
 	host_gameloaded = Cvar_Get( "host_gameloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded game.dll" );
 	host_clientloaded = Cvar_Get( "host_clientloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded client.dll" );
 	host_limitlocal = Cvar_Get( "host_limitlocal", "0", 0, "apply cl_cmdrate and rate to loopback connection" );


### PR DESCRIPTION
Because it's causes issues with FPS on desktop systems and users had to manually set sleeptime 0 to get rid of this issue.