### PR TITLE
server: mark TSource responses as connectionless 

### DIFF
--- a/engine/server/sv_client.c
+++ b/engine/server/sv_client.c
@@ -2182,6 +2182,7 @@ void SV_TSourceEngineQuery( netadr_t from )
 
 	MSG_Init( &buf, "TSourceEngineQuery", answer, sizeof( answer ));
 
+	MSG_WriteLong( &buf, -1 ); // Mark as connectionless
 	MSG_WriteByte( &buf, 'm' );
 	MSG_WriteString( &buf, NET_AdrToString( net_local ));
 	MSG_WriteString( &buf, hostname.string );
@@ -2192,8 +2193,11 @@ void SV_TSourceEngineQuery( netadr_t from )
 	MSG_WriteByte( &buf, svs.maxclients );
 	MSG_WriteByte( &buf, PROTOCOL_VERSION );
 	MSG_WriteByte( &buf, Host_IsDedicated() ? 'D' : 'L' );
+#if defined(_WIN32)
 	MSG_WriteByte( &buf, 'W' );
-
+#else
+	MSG_WriteByte( &buf, 'L' );
+#endif
 	if( Q_stricmp( GI->gamefolder, "valve" ))
 	{
 		MSG_WriteByte( &buf, 1 ); // mod


### PR DESCRIPTION
Also changing the OS type based on which platform engine was built on.
