### PR TITLE
engine: sound: warn about late precached sounds in developer mode

### DIFF
--- a/engine/client/s_load.c
+++ b/engine/client/s_load.c
@@ -141,6 +141,9 @@ wavdata_t *S_LoadSound( sfx_t *sfx )
 	if( Q_stricmp( sfx->name, "*default" ))
 	{
 		// load it from disk
+		if( host_developer.value > 0 && CL_Active() ) {
+			Con_Printf( S_WARN "S_LoadSound: late precache of %s\n", sfx->name );
+		}
 		if( sfx->name[0] == '*' )
 			sc = FS_LoadSound( sfx->name + 1, NULL, 0 );
 		else sc = FS_LoadSound( sfx->name, NULL, 0 );


### PR DESCRIPTION
Довольно удобная мера чтобы определять звуки, которые забыли запрекешить, и видеть, из-за какого конкретно файла произошло подвисание во время игры.