### PR TITLE
client: backport con_fontnum from old engine

### DIFF
--- a/engine/client/console.c
+++ b/engine/client/console.c
@@ -675,7 +675,9 @@ static void Con_LoadConchars( void )
 		Con_LoadConsoleFont( i, con.chars + i );
 
 	// select properly fontsize
-	if( refState.width <= 640 )
+	if( con_fontnum->value >= 0 && con_fontnum->value <= CON_NUMFONTS - 1 )
+		fontSize = con_fontnum->value;
+	else if( refState.width <= 640 )
 		fontSize = 0;
 	else if( refState.width >= 1280 )
 		fontSize = 2;


### PR DESCRIPTION
Возможность смены размера шрифта консоли кваром con_fontnum как это было в старом движке