### PR TITLE
Tighten engine and client security: Implement cl_filterstuffcmd

### DIFF
--- a/common/cvardef.h
+++ b/common/cvardef.h
@@ -26,12 +26,16 @@
 #define FCVAR_UNLOGGED		(1<<8)	// If this is a FCVAR_SERVER, don't log changes to the log file / console if we are creating a log
 #define FCVAR_NOEXTRAWHITEPACE	(1<<9)	// strip trailing/leading white space from this cvar
 #define FCVAR_PRIVILEGED	(1<<10) // only available in privileged mode
+#define FCVAR_FILTERABLE	(1<<11) // filtered in unprivileged mode if cl_filterstuffcmd is 1
 
-#define FCVAR_LATCH			(1<<11)	// notify client what this cvar will be applied only after server restart (but don't does more nothing)
+// Xash3D extensions
 #define FCVAR_GLCONFIG		(1<<12)	// write it into <renderer>.cfg(see RefAPI)
 #define FCVAR_CHANGED		(1<<13)	// set each time the cvar is changed
 #define FCVAR_GAMEUIDLL		(1<<14)	// defined by the menu DLL
 #define FCVAR_CHEAT			(1<<15)	// can not be changed if cheats are disabled
+
+// a1ba: let's reuse higher bits for flags extensions from now on
+#define FCVAR_LATCH			(1<<30)	// notify client what this cvar will be applied only after server restart (but don't does more nothing)
 
 typedef struct cvar_s
 {

--- a/common/cvardef.h
+++ b/common/cvardef.h
@@ -25,8 +25,8 @@
 #define FCVAR_PRINTABLEONLY		(1<<7)	// This cvar's string cannot contain unprintable characters ( e.g., used for player name etc ).
 #define FCVAR_UNLOGGED		(1<<8)	// If this is a FCVAR_SERVER, don't log changes to the log file / console if we are creating a log
 #define FCVAR_NOEXTRAWHITEPACE	(1<<9)	// strip trailing/leading white space from this cvar
+#define FCVAR_LOCALONLY		(1<<10)
 
-#define FCVAR_MOVEVARS		(1<<10)	// this cvar is a part of movevars_t struct that shared between client and server
 #define FCVAR_LATCH			(1<<11)	// notify client what this cvar will be applied only after server restart (but don't does more nothing)
 #define FCVAR_GLCONFIG		(1<<12)	// write it into <renderer>.cfg(see RefAPI)
 #define FCVAR_CHANGED		(1<<13)	// set each time the cvar is changed

--- a/common/cvardef.h
+++ b/common/cvardef.h
@@ -25,7 +25,7 @@
 #define FCVAR_PRINTABLEONLY		(1<<7)	// This cvar's string cannot contain unprintable characters ( e.g., used for player name etc ).
 #define FCVAR_UNLOGGED		(1<<8)	// If this is a FCVAR_SERVER, don't log changes to the log file / console if we are creating a log
 #define FCVAR_NOEXTRAWHITEPACE	(1<<9)	// strip trailing/leading white space from this cvar
-#define FCVAR_LOCALONLY		(1<<10)
+#define FCVAR_PRIVILEGED	(1<<10) // only available in privileged mode
 
 #define FCVAR_LATCH			(1<<11)	// notify client what this cvar will be applied only after server restart (but don't does more nothing)
 #define FCVAR_GLCONFIG		(1<<12)	// write it into <renderer>.cfg(see RefAPI)

--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -1754,8 +1754,17 @@ static int GAME_EXPORT pfnFilteredClientCmd( const char *szCmdString )
 	if( !COM_CheckString( szCmdString ))
 		return 0;
 
+	// a1ba:
+	// there should be stufftext validator, that checks
+	// hardcoded commands and disallows them before passing to
+	// filtered buffer, returning 0
+	// I've replaced it by hooking potentially exploitable
+	// commands and variables(motd_write, motdfile, etc) in client interfaces
+
 	Cbuf_AddFilteredText( szCmdString );
 	Cbuf_AddFilteredText( "\n" );
+
+	return 1;
 }
 
 /*

--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -1746,6 +1746,20 @@ static int GAME_EXPORT pfnClientCmd( const char *szCmdString )
 
 /*
 =============
+pfnFilteredClientCmd
+=============
+*/
+static int GAME_EXPORT pfnFilteredClientCmd( const char *szCmdString )
+{
+	if( !COM_CheckString( szCmdString ))
+		return 0;
+
+	Cbuf_AddFilteredText( szCmdString );
+	Cbuf_AddFilteredText( "\n" );
+}
+
+/*
+=============
 pfnGetPlayerInfo
 
 =============
@@ -3878,10 +3892,7 @@ static cl_enginefunc_t gEngfuncs =
 	pfnGetAppID,
 	Cmd_AliasGetList,
 	pfnVguiWrap2_GetMouseDelta,
-
-	// HACKHACK: added it here so it wouldn't cause overflow or segfault
-	// TODO: itself client command filtering is not implemented yet
-	pfnClientCmd
+	pfnFilteredClientCmd
 };
 
 void CL_UnloadProgs( void )

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -30,7 +30,7 @@ GNU General Public License for more details.
 #define CL_TEST_RETRIES_NORESPONCE	2
 #define CL_TEST_RETRIES		5
 
-CVAR_DEFINE_AUTO( mp_decals, "300", FCVAR_ARCHIVE, "decals limit in multiplayer" );
+CVAR_DEFINE_AUTO( mp_decals, "300", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "decals limit in multiplayer" );
 CVAR_DEFINE_AUTO( dev_overview, "0", 0, "draw level in overview-mode" );
 CVAR_DEFINE_AUTO( cl_resend, "6.0", 0, "time to resend connect" );
 CVAR_DEFINE_AUTO( cl_allow_download, "1", FCVAR_ARCHIVE, "allow to downloading resources from the server" );
@@ -2820,13 +2820,13 @@ void CL_InitLocal( void )
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0, "disable delta-compression for server messages" );
 	cl_idealpitchscale = Cvar_Get( "cl_idealpitchscale", "0.8", 0, "how much to look up/down slopes and stairs when not using freelook" );
 	cl_solid_players = Cvar_Get( "cl_solid_players", "1", 0, "Make all players not solid (can't traceline them)" );
-	cl_interp = Cvar_Get( "ex_interp", "0.1", FCVAR_ARCHIVE, "Interpolate object positions starting this many seconds in past" );
+	cl_interp = Cvar_Get( "ex_interp", "0.1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "Interpolate object positions starting this many seconds in past" );
 	cl_timeout = Cvar_Get( "cl_timeout", "60", 0, "connect timeout (in-seconds)" );
 	cl_charset = Cvar_Get( "cl_charset", "utf-8", FCVAR_ARCHIVE, "1-byte charset to use (iconv style)" );
 	hud_utf8 = Cvar_Get( "hud_utf8", "0", FCVAR_ARCHIVE, "Use utf-8 encoding for hud text" );
 
-	rcon_client_password = Cvar_Get( "rcon_password", "", 0, "remote control client password" );
-	rcon_address = Cvar_Get( "rcon_address", "", 0, "remote control address" );
+	rcon_client_password = Cvar_Get( "rcon_password", "", FCVAR_LOCALONLY, "remote control client password" );
+	rcon_address = Cvar_Get( "rcon_address", "", FCVAR_LOCALONLY, "remote control address" );
 
 	cl_trace_messages = Cvar_Get( "cl_trace_messages", "0", FCVAR_ARCHIVE|FCVAR_CHEAT, "enable message names tracing (good for developers)");
 

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -30,7 +30,7 @@ GNU General Public License for more details.
 #define CL_TEST_RETRIES_NORESPONCE	2
 #define CL_TEST_RETRIES		5
 
-CVAR_DEFINE_AUTO( mp_decals, "300", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "decals limit in multiplayer" );
+CVAR_DEFINE_AUTO( mp_decals, "300", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "decals limit in multiplayer" );
 CVAR_DEFINE_AUTO( dev_overview, "0", 0, "draw level in overview-mode" );
 CVAR_DEFINE_AUTO( cl_resend, "6.0", 0, "time to resend connect" );
 CVAR_DEFINE_AUTO( cl_allow_download, "1", FCVAR_ARCHIVE, "allow to downloading resources from the server" );
@@ -2820,13 +2820,13 @@ void CL_InitLocal( void )
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0, "disable delta-compression for server messages" );
 	cl_idealpitchscale = Cvar_Get( "cl_idealpitchscale", "0.8", 0, "how much to look up/down slopes and stairs when not using freelook" );
 	cl_solid_players = Cvar_Get( "cl_solid_players", "1", 0, "Make all players not solid (can't traceline them)" );
-	cl_interp = Cvar_Get( "ex_interp", "0.1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "Interpolate object positions starting this many seconds in past" );
+	cl_interp = Cvar_Get( "ex_interp", "0.1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "Interpolate object positions starting this many seconds in past" );
 	cl_timeout = Cvar_Get( "cl_timeout", "60", 0, "connect timeout (in-seconds)" );
 	cl_charset = Cvar_Get( "cl_charset", "utf-8", FCVAR_ARCHIVE, "1-byte charset to use (iconv style)" );
 	hud_utf8 = Cvar_Get( "hud_utf8", "0", FCVAR_ARCHIVE, "Use utf-8 encoding for hud text" );
 
-	rcon_client_password = Cvar_Get( "rcon_password", "", FCVAR_LOCALONLY, "remote control client password" );
-	rcon_address = Cvar_Get( "rcon_address", "", FCVAR_LOCALONLY, "remote control address" );
+	rcon_client_password = Cvar_Get( "rcon_password", "", FCVAR_PRIVILEGED, "remote control client password" );
+	rcon_address = Cvar_Get( "rcon_address", "", FCVAR_PRIVILEGED, "remote control address" );
 
 	cl_trace_messages = Cvar_Get( "cl_trace_messages", "0", FCVAR_ARCHIVE|FCVAR_CHEAT, "enable message names tracing (good for developers)");
 

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -30,7 +30,7 @@ GNU General Public License for more details.
 #define CL_TEST_RETRIES_NORESPONCE	2
 #define CL_TEST_RETRIES		5
 
-CVAR_DEFINE_AUTO( mp_decals, "300", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "decals limit in multiplayer" );
+CVAR_DEFINE_AUTO( mp_decals, "300", FCVAR_ARCHIVE, "decals limit in multiplayer" );
 CVAR_DEFINE_AUTO( dev_overview, "0", 0, "draw level in overview-mode" );
 CVAR_DEFINE_AUTO( cl_resend, "6.0", 0, "time to resend connect" );
 CVAR_DEFINE_AUTO( cl_allow_download, "1", FCVAR_ARCHIVE, "allow to downloading resources from the server" );
@@ -2820,7 +2820,7 @@ void CL_InitLocal( void )
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0, "disable delta-compression for server messages" );
 	cl_idealpitchscale = Cvar_Get( "cl_idealpitchscale", "0.8", 0, "how much to look up/down slopes and stairs when not using freelook" );
 	cl_solid_players = Cvar_Get( "cl_solid_players", "1", 0, "Make all players not solid (can't traceline them)" );
-	cl_interp = Cvar_Get( "ex_interp", "0.1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "Interpolate object positions starting this many seconds in past" );
+	cl_interp = Cvar_Get( "ex_interp", "0.1", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "Interpolate object positions starting this many seconds in past" );
 	cl_timeout = Cvar_Get( "cl_timeout", "60", 0, "connect timeout (in-seconds)" );
 	cl_charset = Cvar_Get( "cl_charset", "utf-8", FCVAR_ARCHIVE, "1-byte charset to use (iconv style)" );
 	hud_utf8 = Cvar_Get( "hud_utf8", "0", FCVAR_ARCHIVE, "Use utf-8 encoding for hud text" );
@@ -2837,7 +2837,7 @@ void CL_InitLocal( void )
 	cl_updaterate = Cvar_Get( "cl_updaterate", "20", FCVAR_USERINFO|FCVAR_ARCHIVE, "refresh rate of server messages" );
 	cl_dlmax = Cvar_Get( "cl_dlmax", "0", FCVAR_USERINFO|FCVAR_ARCHIVE, "max allowed outcoming fragment size" );
 	cl_upmax = Cvar_Get( "cl_upmax", "1200", FCVAR_ARCHIVE, "max allowed incoming fragment size" );
-	rate = Cvar_Get( "rate", "3500", FCVAR_USERINFO|FCVAR_ARCHIVE, "player network rate" );
+	rate = Cvar_Get( "rate", "3500", FCVAR_USERINFO|FCVAR_ARCHIVE|FCVAR_FILTERABLE, "player network rate" );
 	topcolor = Cvar_Get( "topcolor", "0", FCVAR_USERINFO|FCVAR_ARCHIVE, "player top color" );
 	bottomcolor = Cvar_Get( "bottomcolor", "0", FCVAR_USERINFO|FCVAR_ARCHIVE, "player bottom color" );
 	cl_lw = Cvar_Get( "cl_lw", "1", FCVAR_ARCHIVE|FCVAR_USERINFO, "enable client weapon predicting" );

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -1306,7 +1306,11 @@ void CL_Rcon_f( void )
 
 	for( i = 1; i < Cmd_Argc(); i++ )
 	{
-		Q_strcat( message, Cmd_Argv( i ));
+		string commmand;
+
+		Cmd_Escape( command, Cmd_Argv( i ), sizeof( command ));
+
+		Q_strcat( message, command );
 		Q_strcat( message, " " );
 	}
 

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -2876,7 +2876,7 @@ void CL_InitLocal( void )
 	Cmd_AddCommand ("give", NULL, "give specified item or weapon" );
 	Cmd_AddCommand ("drop", NULL, "drop current/specified item or weapon" );
 	Cmd_AddCommand ("gametitle", NULL, "show game logo" );
-	Cmd_AddCommand( "kill", NULL, "die instantly" );
+	Cmd_AddRestrictedCommand ("kill", NULL, "die instantly" );
 	Cmd_AddCommand ("god", NULL, "enable godmode" );
 	Cmd_AddCommand ("fov", NULL, "set client field of view" );
 	Cmd_AddCommand ("log", NULL, "logging server events" );
@@ -2889,8 +2889,8 @@ void CL_InitLocal( void )
 	Cmd_AddCommand ("mp3", CL_PlayCDTrack_f, "Play mp3-track (based on virtual cd-player)" );
 	Cmd_AddCommand ("waveplaylen", CL_WavePlayLen_f, "Get approximate length of wave file");
 
-	Cmd_AddCommand ("setinfo", CL_SetInfo_f, "examine or change the userinfo string (alias of userinfo)" );
-	Cmd_AddCommand ("userinfo", CL_SetInfo_f, "examine or change the userinfo string (alias of setinfo)" );
+	Cmd_AddRestrictedCommand ("setinfo", CL_SetInfo_f, "examine or change the userinfo string (alias of userinfo)" );
+	Cmd_AddRestrictedCommand ("userinfo", CL_SetInfo_f, "examine or change the userinfo string (alias of setinfo)" );
 	Cmd_AddCommand ("physinfo", CL_Physinfo_f, "print current client physinfo" );
 	Cmd_AddCommand ("disconnect", CL_Disconnect_f, "disconnect from server" );
 	Cmd_AddCommand ("record", CL_Record_f, "record a demo" );
@@ -2909,8 +2909,8 @@ void CL_InitLocal( void )
 	Cmd_AddCommand ("fullserverinfo", CL_FullServerinfo_f, "sent by server when serverinfo changes" );
 	Cmd_AddCommand ("upload", CL_BeginUpload_f, "uploading file to the server" );
 
-	Cmd_AddCommand ("quit", CL_Quit_f, "quit from game" );
-	Cmd_AddCommand ("exit", CL_Quit_f, "quit from game" );
+	Cmd_AddRestrictedCommand ("quit", CL_Quit_f, "quit from game" );
+	Cmd_AddRestrictedCommand ("exit", CL_Quit_f, "quit from game" );
 
 	Cmd_AddCommand ("screenshot", CL_ScreenShot_f, "takes a screenshot of the next rendered frame" );
 	Cmd_AddCommand ("snapshot", CL_SnapShot_f, "takes a snapshot of the next rendered frame" );
@@ -2919,7 +2919,7 @@ void CL_InitLocal( void )
 	Cmd_AddCommand ("levelshot", CL_LevelShot_f, "same as \"screenshot\", used for create plaque images" );
 	Cmd_AddCommand ("saveshot", CL_SaveShot_f, "used for create save previews with LoadGame menu" );
 
-	Cmd_AddCommand ("connect", CL_Connect_f, "connect to a server by hostname" );
+	Cmd_AddRestrictedCommand ("connect", CL_Connect_f, "connect to a server by hostname" );
 	Cmd_AddCommand ("reconnect", CL_Reconnect_f, "reconnect to current level" );
 
 	Cmd_AddCommand ("rcon", CL_Rcon_f, "sends a command to the server console (rcon_password and rcon_address required)" );

--- a/engine/client/cl_mobile.c
+++ b/engine/client/cl_mobile.c
@@ -93,6 +93,15 @@ static void *pfnGetNativeObject( const char *obj )
 	return Platform_GetNativeObject( obj );
 }
 
+static void pfnTouch_HideButtons( const char *name, byte state )
+{
+	Touch_HideButtons( name, state, true );
+}
+
+static void pfnTouch_RemoveButton( const char *name )
+{
+	Touch_RemoveButton( name, true );
+}
 
 static mobile_engfuncs_t gpMobileEngfuncs =
 {
@@ -101,9 +110,9 @@ static mobile_engfuncs_t gpMobileEngfuncs =
 	pfnEnableTextInput,
 	Touch_AddClientButton,
 	Touch_AddDefaultButton,
-	Touch_HideButtons,
-	Touch_RemoveButton,
-	(void*)Touch_SetClientOnly,
+	pfnTouch_HideButtons,
+	pfnTouch_RemoveButton,
+	Touch_SetClientOnly,
 	Touch_ResetDefaultButtons,
 	pfnDrawScaledCharacter,
 	Sys_Warn,

--- a/engine/client/cl_mobile.c
+++ b/engine/client/cl_mobile.c
@@ -125,8 +125,8 @@ qboolean Mobile_Init( void )
 		success = true;
 
 	Cmd_AddCommand( "vibrate", (xcommand_t)Vibrate_f, "Vibrate for specified time");
-	vibration_length = Cvar_Get( "vibration_length", "1.0", FCVAR_ARCHIVE, "Vibration length");
-	vibration_enable = Cvar_Get( "vibration_enable", "1", FCVAR_ARCHIVE, "Enable vibration");
+	vibration_length = Cvar_Get( "vibration_length", "1.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "Vibration length");
+	vibration_enable = Cvar_Get( "vibration_enable", "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "Enable vibration");
 
 	return success;
 }

--- a/engine/client/cl_mobile.c
+++ b/engine/client/cl_mobile.c
@@ -125,8 +125,8 @@ qboolean Mobile_Init( void )
 		success = true;
 
 	Cmd_AddCommand( "vibrate", (xcommand_t)Vibrate_f, "Vibrate for specified time");
-	vibration_length = Cvar_Get( "vibration_length", "1.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "Vibration length");
-	vibration_enable = Cvar_Get( "vibration_enable", "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "Enable vibration");
+	vibration_length = Cvar_Get( "vibration_length", "1.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "Vibration length");
+	vibration_enable = Cvar_Get( "vibration_enable", "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "Enable vibration");
 
 	return success;
 }

--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -1883,46 +1883,42 @@ Find the client cvar value
 and sent it back to the server
 ==============
 */
-void CL_ParseCvarValue( sizebuf_t *msg )
+void CL_ParseCvarValue( sizebuf_t *msg, const qboolean ext )
 {
-	const char *cvarName = MSG_ReadString( msg );
-	convar_t *cvar = Cvar_FindVar( cvarName );
+	const char *cvarName, *response;
+	convar_t *cvar;
+	int requestID;
 
-	// build the answer
-	MSG_BeginClientCmd( &cls.netchan.message, clc_requestcvarvalue );
-	MSG_WriteString( &cls.netchan.message, cvar ? cvar->string : "Not Found" );
-}
+	if( ext )
+		requestID = MSG_ReadLong( msg );
 
-/*
-==============
-CL_ParseCvarValue2
-
-Find the client cvar value
-and sent it back to the server
-==============
-*/
-void CL_ParseCvarValue2( sizebuf_t *msg )
-{
-	int requestID = MSG_ReadLong( msg );
-	const char *cvarName = MSG_ReadString( msg );
-	convar_t *cvar = Cvar_FindVar( cvarName );
-
-	// build the answer
-	MSG_BeginClientCmd( &cls.netchan.message, clc_requestcvarvalue2 );
-	MSG_WriteLong( &cls.netchan.message, requestID );
-	MSG_WriteString( &cls.netchan.message, cvarName );
+	cvarName = MSG_ReadString( msg );
+	cvar = Cvar_FindVar( cvarName );
 
 	if( cvar )
 	{
-		// cheater can change value ignoring Cvar_Set so we responce incorrect value
-		if( cvar->value != Q_atof( cvar->string ))
-			MSG_WriteString( &cls.netchan.message, va( "%s (%g)", cvar->string, cvar->value ));
-		else MSG_WriteString( &cls.netchan.message, cvar->string );
+		if( cvar->flags & FCVAR_PRIVILEGED )
+			response = "CVAR is privileged";
+		else if( cvar->flags & FCVAR_SERVER )
+			response = "CVAR is server-only";
+		else if( cvar->flags & FCVAR_PROTECTED )
+			response = "CVAR is protected";
+		else
+			response = cvar->string;
+	}
+	else response = "Bad CVAR request";
+
+	if( ext )
+	{
+		MSG_BeginClientCmd( &cls.netchan.message, clc_requestcvarvalue2 );
+		MSG_WriteLong( &cls.netchan.message, requestID );
+		MSG_WriteString( &cls.netchan.message, cvarName );
 	}
 	else
 	{
-		MSG_WriteString( &cls.netchan.message, "Not Found" );
+		MSG_BeginClientCmd( &cls.netchan.message, clc_requestcvarvalue );
 	}
+	MSG_WriteString( &cls.netchan.message, response );
 }
 
 /*
@@ -2329,10 +2325,10 @@ void CL_ParseServerMessage( sizebuf_t *msg, qboolean normal_message )
 			CL_ParseResLocation( msg );
 			break;
 		case svc_querycvarvalue:
-			CL_ParseCvarValue( msg );
+			CL_ParseCvarValue( msg, false );
 			break;
 		case svc_querycvarvalue2:
-			CL_ParseCvarValue2( msg );
+			CL_ParseCvarValue( msg, true );
 			break;
 		default:
 			CL_ParseUserMessage( msg, cmd );

--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -2179,11 +2179,11 @@ void CL_ParseServerMessage( sizebuf_t *msg, qboolean normal_message )
 		case svc_stufftext:
 			s = MSG_ReadString( msg );
 #ifdef HACKS_RELATED_HLMODS
-			// dsiable Cry Of Fear antisave protection
+			// disable Cry Of Fear antisave protection
 			if( !Q_strnicmp( s, "disconnect", 10 ) && cls.signon != SIGNONS )
 				break; // too early
 #endif
-			Cbuf_AddText( s );
+			Cbuf_AddFilteredText( s );
 			break;
 		case svc_setangle:
 			CL_ParseSetAngle( msg );
@@ -2944,13 +2944,13 @@ void CL_ParseLegacyServerMessage( sizebuf_t *msg, qboolean normal_message )
 		case svc_stufftext:
 			s = MSG_ReadString( msg );
 #ifdef HACKS_RELATED_HLMODS
-			// dsiable Cry Of Fear antisave protection
+			// disable Cry Of Fear antisave protection
 			if( !Q_strnicmp( s, "disconnect", 10 ) && cls.signon != SIGNONS )
 				break; // too early
 #endif
 
 			Con_Reportf( "Stufftext: %s", s );
-			Cbuf_AddText( s );
+			Cbuf_AddFilteredText( s );
 			break;
 		case svc_setangle:
 			CL_ParseSetAngle( msg );

--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -3112,10 +3112,10 @@ void CL_ParseLegacyServerMessage( sizebuf_t *msg, qboolean normal_message )
 			CL_ParseResLocation( msg );
 			break;
 		case svc_querycvarvalue:
-			CL_ParseCvarValue( msg );
+			CL_ParseCvarValue( msg, false );
 			break;
 		case svc_querycvarvalue2:
-			CL_ParseCvarValue2( msg );
+			CL_ParseCvarValue( msg, true );
 			break;
 		default:
 			CL_ParseUserMessage( msg, cmd );

--- a/engine/client/cl_qparse.c
+++ b/engine/client/cl_qparse.c
@@ -825,6 +825,9 @@ CL_QuakeStuffText
 void CL_QuakeStuffText( const char *text )
 {
 	Q_strncat( cmd_buf, text, sizeof( cmd_buf ));
+
+	// a1ba: didn't filtered, anyway quake protocol
+	// only supported for demos, not network games
 	Cbuf_AddText( text );
 }
 

--- a/engine/client/console.c
+++ b/engine/client/console.c
@@ -33,6 +33,8 @@ convar_t        *con_color;
 static int g_codepage = 0;
 static qboolean g_utf8 = false;
 
+static qboolean g_messagemode_privileged = true;
+
 #define CON_TIMES		4	// notify lines
 #define CON_MAX_TIMES	64	// notify max lines
 #define COLOR_DEFAULT	'7'
@@ -242,6 +244,8 @@ Con_MessageMode_f
 */
 void Con_MessageMode_f( void )
 {
+	g_messagemode_privileged = Cmd_CurrentCommandIsPrivileged();
+
 	if( Cmd_Argc() == 2 )
 		Q_strncpy( con.chat_cmd, Cmd_Argv( 1 ), sizeof( con.chat_cmd ));
 	else Q_strncpy( con.chat_cmd, "say", sizeof( con.chat_cmd ));
@@ -256,6 +260,8 @@ Con_MessageMode2_f
 */
 void Con_MessageMode2_f( void )
 {
+	g_messagemode_privileged = Cmd_CurrentCommandIsPrivileged();
+
 	Q_strncpy( con.chat_cmd, "say_team", sizeof( con.chat_cmd ));
 	Key_SetKeyDest( key_message );
 }
@@ -1865,7 +1871,10 @@ void Key_Message( int key )
 		if( con.chat.buffer[0] && cls.state == ca_active )
 		{
 			Q_snprintf( buffer, sizeof( buffer ), "%s \"%s\"\n", con.chat_cmd, con.chat.buffer );
-			Cbuf_AddText( buffer );
+
+			if( g_messagemode_privileged )
+				Cbuf_AddText( buffer );
+			else Cbuf_AddFilteredText( buffer );
 		}
 
 		Key_SetKeyDest( key_game );

--- a/engine/client/in_joy.c
+++ b/engine/client/in_joy.c
@@ -380,32 +380,32 @@ Main init procedure
 */
 void Joy_Init( void )
 {
-	joy_pitch   = Cvar_Get( "joy_pitch",   "100.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick pitch sensitivity" );
-	joy_yaw     = Cvar_Get( "joy_yaw",     "100.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick yaw sensitivity" );
-	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick side sensitivity. Values from -1.0 to 1.0" );
-	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick forward sensitivity. Values from -1.0 to 1.0" );
+	joy_pitch   = Cvar_Get( "joy_pitch",   "100.0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "joystick pitch sensitivity" );
+	joy_yaw     = Cvar_Get( "joy_yaw",     "100.0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "joystick yaw sensitivity" );
+	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "joystick side sensitivity. Values from -1.0 to 1.0" );
+	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "joystick forward sensitivity. Values from -1.0 to 1.0" );
 
-	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "left trigger threshold. Value from 0 to 32767");
-	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "right trigger threshold. Value from 0 to 32767" );
+	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "left trigger threshold. Value from 0 to 32767");
+	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "right trigger threshold. Value from 0 to 32767" );
 
 	// emit a key event at 75% axis move
-	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "side axis key event emit threshold. Value from 0 to 32767" );
-	joy_forward_key_threshold = Cvar_Get( "joy_forward_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "forward axis key event emit threshold. Value from 0 to 32767");
+	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "side axis key event emit threshold. Value from 0 to 32767" );
+	joy_forward_key_threshold = Cvar_Get( "joy_forward_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "forward axis key event emit threshold. Value from 0 to 32767");
 
 	// by default, we rely on deadzone detection come from system, but some glitchy devices report false deadzones
-	joy_side_deadzone = Cvar_Get( "joy_side_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "side axis deadzone. Value from 0 to 32767" );
-	joy_forward_deadzone = Cvar_Get( "joy_forward_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "forward axis deadzone. Value from 0 to 32767");
-	joy_pitch_deadzone = Cvar_Get( "joy_pitch_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "pitch axis deadzone. Value from 0 to 32767");
-	joy_yaw_deadzone = Cvar_Get( "joy_yaw_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "yaw axis deadzone. Value from 0 to 32767" );
+	joy_side_deadzone = Cvar_Get( "joy_side_deadzone", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "side axis deadzone. Value from 0 to 32767" );
+	joy_forward_deadzone = Cvar_Get( "joy_forward_deadzone", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "forward axis deadzone. Value from 0 to 32767");
+	joy_pitch_deadzone = Cvar_Get( "joy_pitch_deadzone", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "pitch axis deadzone. Value from 0 to 32767");
+	joy_yaw_deadzone = Cvar_Get( "joy_yaw_deadzone", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "yaw axis deadzone. Value from 0 to 32767" );
 
-	joy_axis_binding = Cvar_Get( "joy_axis_binding", "sfpyrl", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "axis hardware id to engine inner axis binding, "
+	joy_axis_binding = Cvar_Get( "joy_axis_binding", "sfpyrl", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "axis hardware id to engine inner axis binding, "
 		"s - side, f - forward, y - yaw, p - pitch, r - left trigger, l - right trigger" );
 	joy_found   = Cvar_Get( "joy_found", "0", FCVAR_READ_ONLY, "is joystick is connected" );
 	// we doesn't loaded config.cfg yet, so this cvar is not archive.
 	// change by +set joy_index in cmdline
 	joy_index   = Cvar_Get( "joy_index", "0", FCVAR_READ_ONLY, "current active joystick" );
 
-	joy_enable = Cvar_Get( "joy_enable", "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable joystick" );
+	joy_enable = Cvar_Get( "joy_enable", "1", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "enable joystick" );
 
 	if( Sys_CheckParm( "-nojoy" ))
 	{

--- a/engine/client/in_joy.c
+++ b/engine/client/in_joy.c
@@ -380,32 +380,32 @@ Main init procedure
 */
 void Joy_Init( void )
 {
-	joy_pitch   = Cvar_Get( "joy_pitch",   "100.0", FCVAR_ARCHIVE, "joystick pitch sensitivity" );
-	joy_yaw     = Cvar_Get( "joy_yaw",     "100.0", FCVAR_ARCHIVE, "joystick yaw sensitivity" );
-	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE, "joystick side sensitivity. Values from -1.0 to 1.0" );
-	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE, "joystick forward sensitivity. Values from -1.0 to 1.0" );
+	joy_pitch   = Cvar_Get( "joy_pitch",   "100.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick pitch sensitivity" );
+	joy_yaw     = Cvar_Get( "joy_yaw",     "100.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick yaw sensitivity" );
+	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick side sensitivity. Values from -1.0 to 1.0" );
+	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick forward sensitivity. Values from -1.0 to 1.0" );
 
-	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE, "left trigger threshold. Value from 0 to 32767");
-	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE, "right trigger threshold. Value from 0 to 32767" );
+	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "left trigger threshold. Value from 0 to 32767");
+	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "right trigger threshold. Value from 0 to 32767" );
 
 	// emit a key event at 75% axis move
-	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE, "side axis key event emit threshold. Value from 0 to 32767" );
-	joy_forward_key_threshold = Cvar_Get( "joy_forward_key_threshold", "24576", FCVAR_ARCHIVE, "forward axis key event emit threshold. Value from 0 to 32767");
+	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "side axis key event emit threshold. Value from 0 to 32767" );
+	joy_forward_key_threshold = Cvar_Get( "joy_forward_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "forward axis key event emit threshold. Value from 0 to 32767");
 
 	// by default, we rely on deadzone detection come from system, but some glitchy devices report false deadzones
-	joy_side_deadzone = Cvar_Get( "joy_side_deadzone", "0", FCVAR_ARCHIVE, "side axis deadzone. Value from 0 to 32767" );
-	joy_forward_deadzone = Cvar_Get( "joy_forward_deadzone", "0", FCVAR_ARCHIVE, "forward axis deadzone. Value from 0 to 32767");
-	joy_pitch_deadzone = Cvar_Get( "joy_pitch_deadzone", "0", FCVAR_ARCHIVE, "pitch axis deadzone. Value from 0 to 32767");
-	joy_yaw_deadzone = Cvar_Get( "joy_yaw_deadzone", "0", FCVAR_ARCHIVE, "yaw axis deadzone. Value from 0 to 32767" );
+	joy_side_deadzone = Cvar_Get( "joy_side_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "side axis deadzone. Value from 0 to 32767" );
+	joy_forward_deadzone = Cvar_Get( "joy_forward_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "forward axis deadzone. Value from 0 to 32767");
+	joy_pitch_deadzone = Cvar_Get( "joy_pitch_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "pitch axis deadzone. Value from 0 to 32767");
+	joy_yaw_deadzone = Cvar_Get( "joy_yaw_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "yaw axis deadzone. Value from 0 to 32767" );
 
-	joy_axis_binding = Cvar_Get( "joy_axis_binding", "sfpyrl", FCVAR_ARCHIVE, "axis hardware id to engine inner axis binding, "
+	joy_axis_binding = Cvar_Get( "joy_axis_binding", "sfpyrl", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "axis hardware id to engine inner axis binding, "
 		"s - side, f - forward, y - yaw, p - pitch, r - left trigger, l - right trigger" );
 	joy_found   = Cvar_Get( "joy_found", "0", FCVAR_READ_ONLY, "is joystick is connected" );
 	// we doesn't loaded config.cfg yet, so this cvar is not archive.
 	// change by +set joy_index in cmdline
 	joy_index   = Cvar_Get( "joy_index", "0", FCVAR_READ_ONLY, "current active joystick" );
 
-	joy_enable = Cvar_Get( "joy_enable", "1", FCVAR_ARCHIVE, "enable joystick" );
+	joy_enable = Cvar_Get( "joy_enable", "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable joystick" );
 
 	if( Sys_CheckParm( "-nojoy" ))
 	{

--- a/engine/client/in_joy.c
+++ b/engine/client/in_joy.c
@@ -380,32 +380,32 @@ Main init procedure
 */
 void Joy_Init( void )
 {
-	joy_pitch   = Cvar_Get( "joy_pitch",   "100.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick pitch sensitivity" );
-	joy_yaw     = Cvar_Get( "joy_yaw",     "100.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick yaw sensitivity" );
-	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick side sensitivity. Values from -1.0 to 1.0" );
-	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "joystick forward sensitivity. Values from -1.0 to 1.0" );
+	joy_pitch   = Cvar_Get( "joy_pitch",   "100.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick pitch sensitivity" );
+	joy_yaw     = Cvar_Get( "joy_yaw",     "100.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick yaw sensitivity" );
+	joy_side    = Cvar_Get( "joy_side",    "1.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick side sensitivity. Values from -1.0 to 1.0" );
+	joy_forward = Cvar_Get( "joy_forward", "1.0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "joystick forward sensitivity. Values from -1.0 to 1.0" );
 
-	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "left trigger threshold. Value from 0 to 32767");
-	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "right trigger threshold. Value from 0 to 32767" );
+	joy_lt_threshold = Cvar_Get( "joy_lt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "left trigger threshold. Value from 0 to 32767");
+	joy_rt_threshold = Cvar_Get( "joy_rt_threshold", "16384", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "right trigger threshold. Value from 0 to 32767" );
 
 	// emit a key event at 75% axis move
-	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "side axis key event emit threshold. Value from 0 to 32767" );
-	joy_forward_key_threshold = Cvar_Get( "joy_forward_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "forward axis key event emit threshold. Value from 0 to 32767");
+	joy_side_key_threshold = Cvar_Get( "joy_side_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "side axis key event emit threshold. Value from 0 to 32767" );
+	joy_forward_key_threshold = Cvar_Get( "joy_forward_key_threshold", "24576", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "forward axis key event emit threshold. Value from 0 to 32767");
 
 	// by default, we rely on deadzone detection come from system, but some glitchy devices report false deadzones
-	joy_side_deadzone = Cvar_Get( "joy_side_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "side axis deadzone. Value from 0 to 32767" );
-	joy_forward_deadzone = Cvar_Get( "joy_forward_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "forward axis deadzone. Value from 0 to 32767");
-	joy_pitch_deadzone = Cvar_Get( "joy_pitch_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "pitch axis deadzone. Value from 0 to 32767");
-	joy_yaw_deadzone = Cvar_Get( "joy_yaw_deadzone", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "yaw axis deadzone. Value from 0 to 32767" );
+	joy_side_deadzone = Cvar_Get( "joy_side_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "side axis deadzone. Value from 0 to 32767" );
+	joy_forward_deadzone = Cvar_Get( "joy_forward_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "forward axis deadzone. Value from 0 to 32767");
+	joy_pitch_deadzone = Cvar_Get( "joy_pitch_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "pitch axis deadzone. Value from 0 to 32767");
+	joy_yaw_deadzone = Cvar_Get( "joy_yaw_deadzone", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "yaw axis deadzone. Value from 0 to 32767" );
 
-	joy_axis_binding = Cvar_Get( "joy_axis_binding", "sfpyrl", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "axis hardware id to engine inner axis binding, "
+	joy_axis_binding = Cvar_Get( "joy_axis_binding", "sfpyrl", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "axis hardware id to engine inner axis binding, "
 		"s - side, f - forward, y - yaw, p - pitch, r - left trigger, l - right trigger" );
 	joy_found   = Cvar_Get( "joy_found", "0", FCVAR_READ_ONLY, "is joystick is connected" );
 	// we doesn't loaded config.cfg yet, so this cvar is not archive.
 	// change by +set joy_index in cmdline
 	joy_index   = Cvar_Get( "joy_index", "0", FCVAR_READ_ONLY, "current active joystick" );
 
-	joy_enable = Cvar_Get( "joy_enable", "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable joystick" );
+	joy_enable = Cvar_Get( "joy_enable", "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable joystick" );
 
 	if( Sys_CheckParm( "-nojoy" ))
 	{

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -1037,35 +1037,35 @@ void Touch_Init( void )
 	Cmd_AddRestrictedCommand( "touch_toggleselection", Touch_ToggleSelection_f, "toggle vidibility on selected button in editor" );
 
 	// not saved, just runtime state for scripting
-	touch_in_menu = Cvar_Get( "touch_in_menu", "0", FCVAR_PRIVILEGED, "draw touch in menu (for internal use only)" );
+	touch_in_menu = Cvar_Get( "touch_in_menu", "0", FCVAR_FILTERABLE, "draw touch in menu (for internal use only)" );
 
 	// sensitivity configuration
-	touch_forwardzone = Cvar_Get( "touch_forwardzone", "0.06", FCVAR_PRIVILEGED, "forward touch zone" );
-	touch_sidezone = Cvar_Get( "touch_sidezone", "0.06", FCVAR_PRIVILEGED, "side touch zone" );
-	touch_pitch = Cvar_Get( "touch_pitch", "90", FCVAR_PRIVILEGED, "touch pitch sensitivity" );
-	touch_yaw = Cvar_Get( "touch_yaw", "120", FCVAR_PRIVILEGED, "touch yaw sensitivity" );
-	touch_nonlinear_look = Cvar_Get( "touch_nonlinear_look", "0", FCVAR_PRIVILEGED, "enable nonlinear touch look" );
-	touch_pow_factor = Cvar_Get( "touch_pow_factor", "1.3", FCVAR_PRIVILEGED, "set > 1 to enable" );
-	touch_pow_mult = Cvar_Get( "touch_pow_mult", "400.0", FCVAR_PRIVILEGED, "power multiplier, usually 200-1000" );
-	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", FCVAR_PRIVILEGED, "exponent multiplier, usually 20-200, 0 to disable" );
+	touch_forwardzone = Cvar_Get( "touch_forwardzone", "0.06", FCVAR_FILTERABLE, "forward touch zone" );
+	touch_sidezone = Cvar_Get( "touch_sidezone", "0.06", FCVAR_FILTERABLE, "side touch zone" );
+	touch_pitch = Cvar_Get( "touch_pitch", "90", FCVAR_FILTERABLE, "touch pitch sensitivity" );
+	touch_yaw = Cvar_Get( "touch_yaw", "120", FCVAR_FILTERABLE, "touch yaw sensitivity" );
+	touch_nonlinear_look = Cvar_Get( "touch_nonlinear_look", "0", FCVAR_FILTERABLE, "enable nonlinear touch look" );
+	touch_pow_factor = Cvar_Get( "touch_pow_factor", "1.3", FCVAR_FILTERABLE, "set > 1 to enable" );
+	touch_pow_mult = Cvar_Get( "touch_pow_mult", "400.0", FCVAR_FILTERABLE, "power multiplier, usually 200-1000" );
+	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", FCVAR_FILTERABLE, "exponent multiplier, usually 20-200, 0 to disable" );
 
 	// touch.cfg
-	touch_grid_count = Cvar_Get( "touch_grid_count", "50", FCVAR_PRIVILEGED, "touch grid count" );
-	touch_grid_enable = Cvar_Get( "touch_grid_enable", "1", FCVAR_PRIVILEGED, "enable touch grid" );
+	touch_grid_count = Cvar_Get( "touch_grid_count", "50", FCVAR_FILTERABLE, "touch grid count" );
+	touch_grid_enable = Cvar_Get( "touch_grid_enable", "1", FCVAR_FILTERABLE, "enable touch grid" );
 	touch_config_file = Cvar_Get( "touch_config_file", "touch.cfg", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "current touch profile file" );
-	touch_precise_amount = Cvar_Get( "touch_precise_amount", "0.5", FCVAR_PRIVILEGED, "sensitivity multiplier for precise-look" );
+	touch_precise_amount = Cvar_Get( "touch_precise_amount", "0.5", FCVAR_FILTERABLE, "sensitivity multiplier for precise-look" );
 	touch_highlight_r = Cvar_Get( "touch_highlight_r", "1.0", 0, "highlight r color" );
 	touch_highlight_g = Cvar_Get( "touch_highlight_g", "1.0", 0, "highlight g color" );
 	touch_highlight_b = Cvar_Get( "touch_highlight_b", "1.0", 0, "highlight b color" );
 	touch_highlight_a = Cvar_Get( "touch_highlight_a", "1.0", 0, "highlight alpha" );
-	touch_dpad_radius = Cvar_Get( "touch_dpad_radius", "1.0", FCVAR_PRIVILEGED, "dpad radius multiplier" );
-	touch_joy_radius = Cvar_Get( "touch_joy_radius", "1.0", FCVAR_PRIVILEGED, "joy radius multiplier" );
-	touch_move_indicator = Cvar_Get( "touch_move_indicator", "0.0", FCVAR_PRIVILEGED, "indicate move events (0 to disable)" );
-	touch_joy_texture = Cvar_Get( "touch_joy_texture", "touch_default/joy.tga", FCVAR_PRIVILEGED, "texture for move indicator");
+	touch_dpad_radius = Cvar_Get( "touch_dpad_radius", "1.0", FCVAR_FILTERABLE, "dpad radius multiplier" );
+	touch_joy_radius = Cvar_Get( "touch_joy_radius", "1.0", FCVAR_FILTERABLE, "joy radius multiplier" );
+	touch_move_indicator = Cvar_Get( "touch_move_indicator", "0.0", FCVAR_FILTERABLE, "indicate move events (0 to disable)" );
+	touch_joy_texture = Cvar_Get( "touch_joy_texture", "touch_default/joy.tga", FCVAR_FILTERABLE, "texture for move indicator");
 
 	// input devices cvar
-	touch_enable = Cvar_Get( "touch_enable", DEFAULT_TOUCH_ENABLE, FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable touch controls" );
-	touch_emulate = Cvar_Get( "touch_emulate", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "emulate touch with mouse" );
+	touch_enable = Cvar_Get( "touch_enable", DEFAULT_TOUCH_ENABLE, FCVAR_ARCHIVE | FCVAR_FILTERABLE, "enable touch controls" );
+	touch_emulate = Cvar_Get( "touch_emulate", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "emulate touch with mouse" );
 
 	/// TODO: touch sdl platform
 	// SDL_SetHint( SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1" );

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -1037,17 +1037,17 @@ void Touch_Init( void )
 	Cmd_AddRestrictedCommand( "touch_toggleselection", Touch_ToggleSelection_f, "toggle vidibility on selected button in editor" );
 
 	// not saved, just runtime state for scripting
-	touch_in_menu = Cvar_Get( "touch_in_menu", "0", 0, "draw touch in menu (for internal use only)" );
+	touch_in_menu = Cvar_Get( "touch_in_menu", "0", FCVAR_LOCALONLY, "draw touch in menu (for internal use only)" );
 
 	// sensitivity configuration
-	touch_forwardzone = Cvar_Get( "touch_forwardzone", "0.06", 0, "forward touch zone" );
-	touch_sidezone = Cvar_Get( "touch_sidezone", "0.06", 0, "side touch zone" );
-	touch_pitch = Cvar_Get( "touch_pitch", "90", 0, "touch pitch sensitivity" );
-	touch_yaw = Cvar_Get( "touch_yaw", "120", 0, "touch yaw sensitivity" );
-	touch_nonlinear_look = Cvar_Get( "touch_nonlinear_look", "0", 0, "enable nonlinear touch look" );
-	touch_pow_factor = Cvar_Get( "touch_pow_factor", "1.3", 0, "set > 1 to enable" );
-	touch_pow_mult = Cvar_Get( "touch_pow_mult", "400.0", 0, "power multiplier, usually 200-1000" );
-	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", 0, "exponent multiplier, usually 20-200, 0 to disable" );
+	touch_forwardzone = Cvar_Get( "touch_forwardzone", "0.06", FCVAR_LOCALONLY, "forward touch zone" );
+	touch_sidezone = Cvar_Get( "touch_sidezone", "0.06", FCVAR_LOCALONLY, "side touch zone" );
+	touch_pitch = Cvar_Get( "touch_pitch", "90", FCVAR_LOCALONLY, "touch pitch sensitivity" );
+	touch_yaw = Cvar_Get( "touch_yaw", "120", FCVAR_LOCALONLY, "touch yaw sensitivity" );
+	touch_nonlinear_look = Cvar_Get( "touch_nonlinear_look", "0", FCVAR_LOCALONLY, "enable nonlinear touch look" );
+	touch_pow_factor = Cvar_Get( "touch_pow_factor", "1.3", FCVAR_LOCALONLY, "set > 1 to enable" );
+	touch_pow_mult = Cvar_Get( "touch_pow_mult", "400.0", FCVAR_LOCALONLY, "power multiplier, usually 200-1000" );
+	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", FCVAR_LOCALONLY, "exponent multiplier, usually 20-200, 0 to disable" );
 
 	// touch.cfg
 	touch_grid_count = Cvar_Get( "touch_grid_count", "50", FCVAR_LOCALONLY, "touch grid count" );

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -1037,35 +1037,35 @@ void Touch_Init( void )
 	Cmd_AddRestrictedCommand( "touch_toggleselection", Touch_ToggleSelection_f, "toggle vidibility on selected button in editor" );
 
 	// not saved, just runtime state for scripting
-	touch_in_menu = Cvar_Get( "touch_in_menu", "0", FCVAR_LOCALONLY, "draw touch in menu (for internal use only)" );
+	touch_in_menu = Cvar_Get( "touch_in_menu", "0", FCVAR_PRIVILEGED, "draw touch in menu (for internal use only)" );
 
 	// sensitivity configuration
-	touch_forwardzone = Cvar_Get( "touch_forwardzone", "0.06", FCVAR_LOCALONLY, "forward touch zone" );
-	touch_sidezone = Cvar_Get( "touch_sidezone", "0.06", FCVAR_LOCALONLY, "side touch zone" );
-	touch_pitch = Cvar_Get( "touch_pitch", "90", FCVAR_LOCALONLY, "touch pitch sensitivity" );
-	touch_yaw = Cvar_Get( "touch_yaw", "120", FCVAR_LOCALONLY, "touch yaw sensitivity" );
-	touch_nonlinear_look = Cvar_Get( "touch_nonlinear_look", "0", FCVAR_LOCALONLY, "enable nonlinear touch look" );
-	touch_pow_factor = Cvar_Get( "touch_pow_factor", "1.3", FCVAR_LOCALONLY, "set > 1 to enable" );
-	touch_pow_mult = Cvar_Get( "touch_pow_mult", "400.0", FCVAR_LOCALONLY, "power multiplier, usually 200-1000" );
-	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", FCVAR_LOCALONLY, "exponent multiplier, usually 20-200, 0 to disable" );
+	touch_forwardzone = Cvar_Get( "touch_forwardzone", "0.06", FCVAR_PRIVILEGED, "forward touch zone" );
+	touch_sidezone = Cvar_Get( "touch_sidezone", "0.06", FCVAR_PRIVILEGED, "side touch zone" );
+	touch_pitch = Cvar_Get( "touch_pitch", "90", FCVAR_PRIVILEGED, "touch pitch sensitivity" );
+	touch_yaw = Cvar_Get( "touch_yaw", "120", FCVAR_PRIVILEGED, "touch yaw sensitivity" );
+	touch_nonlinear_look = Cvar_Get( "touch_nonlinear_look", "0", FCVAR_PRIVILEGED, "enable nonlinear touch look" );
+	touch_pow_factor = Cvar_Get( "touch_pow_factor", "1.3", FCVAR_PRIVILEGED, "set > 1 to enable" );
+	touch_pow_mult = Cvar_Get( "touch_pow_mult", "400.0", FCVAR_PRIVILEGED, "power multiplier, usually 200-1000" );
+	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", FCVAR_PRIVILEGED, "exponent multiplier, usually 20-200, 0 to disable" );
 
 	// touch.cfg
-	touch_grid_count = Cvar_Get( "touch_grid_count", "50", FCVAR_LOCALONLY, "touch grid count" );
-	touch_grid_enable = Cvar_Get( "touch_grid_enable", "1", FCVAR_LOCALONLY, "enable touch grid" );
-	touch_config_file = Cvar_Get( "touch_config_file", "touch.cfg", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "current touch profile file" );
-	touch_precise_amount = Cvar_Get( "touch_precise_amount", "0.5", FCVAR_LOCALONLY, "sensitivity multiplier for precise-look" );
+	touch_grid_count = Cvar_Get( "touch_grid_count", "50", FCVAR_PRIVILEGED, "touch grid count" );
+	touch_grid_enable = Cvar_Get( "touch_grid_enable", "1", FCVAR_PRIVILEGED, "enable touch grid" );
+	touch_config_file = Cvar_Get( "touch_config_file", "touch.cfg", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "current touch profile file" );
+	touch_precise_amount = Cvar_Get( "touch_precise_amount", "0.5", FCVAR_PRIVILEGED, "sensitivity multiplier for precise-look" );
 	touch_highlight_r = Cvar_Get( "touch_highlight_r", "1.0", 0, "highlight r color" );
 	touch_highlight_g = Cvar_Get( "touch_highlight_g", "1.0", 0, "highlight g color" );
 	touch_highlight_b = Cvar_Get( "touch_highlight_b", "1.0", 0, "highlight b color" );
 	touch_highlight_a = Cvar_Get( "touch_highlight_a", "1.0", 0, "highlight alpha" );
-	touch_dpad_radius = Cvar_Get( "touch_dpad_radius", "1.0", FCVAR_LOCALONLY, "dpad radius multiplier" );
-	touch_joy_radius = Cvar_Get( "touch_joy_radius", "1.0", FCVAR_LOCALONLY, "joy radius multiplier" );
-	touch_move_indicator = Cvar_Get( "touch_move_indicator", "0.0", FCVAR_LOCALONLY, "indicate move events (0 to disable)" );
-	touch_joy_texture = Cvar_Get( "touch_joy_texture", "touch_default/joy.tga", FCVAR_LOCALONLY, "texture for move indicator");
+	touch_dpad_radius = Cvar_Get( "touch_dpad_radius", "1.0", FCVAR_PRIVILEGED, "dpad radius multiplier" );
+	touch_joy_radius = Cvar_Get( "touch_joy_radius", "1.0", FCVAR_PRIVILEGED, "joy radius multiplier" );
+	touch_move_indicator = Cvar_Get( "touch_move_indicator", "0.0", FCVAR_PRIVILEGED, "indicate move events (0 to disable)" );
+	touch_joy_texture = Cvar_Get( "touch_joy_texture", "touch_default/joy.tga", FCVAR_PRIVILEGED, "texture for move indicator");
 
 	// input devices cvar
-	touch_enable = Cvar_Get( "touch_enable", DEFAULT_TOUCH_ENABLE, FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable touch controls" );
-	touch_emulate = Cvar_Get( "touch_emulate", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "emulate touch with mouse" );
+	touch_enable = Cvar_Get( "touch_enable", DEFAULT_TOUCH_ENABLE, FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable touch controls" );
+	touch_emulate = Cvar_Get( "touch_emulate", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "emulate touch with mouse" );
 
 	/// TODO: touch sdl platform
 	// SDL_SetHint( SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1" );

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -197,6 +197,8 @@ static inline int Touch_ExportButtonToConfig( file_t *f, touch_button_t *button,
 	if( FBitSet( flags, TOUCH_FL_DEF_HIDE ))
 		SetBits( flags, TOUCH_FL_HIDE );
 
+	Cmd_Escape( newCommand, B( command ), sizeof( newCommand ));
+
 	FS_Printf( f, "touch_addbutton \"%s\" \"%s\" \"%s\" %f %f %f %f %d %d %d %d %d",
 		B(name), B(texturefile), newCommand,
 		B(x1), B(y1), B(x2), B(y2),

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -1023,18 +1023,18 @@ void Touch_Init( void )
 	Cmd_AddCommand( "touch_show", Touch_Show_f, "show button" );
 	Cmd_AddCommand( "touch_hide", Touch_Hide_f, "hide button" );
 	Cmd_AddCommand( "touch_list", Touch_ListButtons_f, "list buttons" );
-	Cmd_AddCommand( "touch_removeall", Touch_RemoveAll_f, "remove all buttons" );
-	Cmd_AddCommand( "touch_loaddefaults", Touch_LoadDefaults_f, "generate config from defaults" );
+	Cmd_AddRestrictedCommand( "touch_removeall", Touch_RemoveAll_f, "remove all buttons" );
+	Cmd_AddRestrictedCommand( "touch_loaddefaults", Touch_LoadDefaults_f, "generate config from defaults" );
 	Cmd_AddCommand( "touch_roundall", Touch_RoundAll_f, "round all buttons coordinates to grid" );
-	Cmd_AddCommand( "touch_exportconfig", Touch_ExportConfig_f, "export config keeping aspect ratio" );
+	Cmd_AddRestrictedCommand( "touch_exportconfig", Touch_ExportConfig_f, "export config keeping aspect ratio" );
 	Cmd_AddCommand( "touch_set_stroke", Touch_Stroke_f, "set global stroke width and color" );
 	Cmd_AddCommand( "touch_setclientonly", Touch_SetClientOnly_f, "when 1, only client buttons are shown" );
-	Cmd_AddCommand( "touch_reloadconfig", Touch_ReloadConfig_f, "load config, not saving changes" );
-	Cmd_AddCommand( "touch_writeconfig", Touch_WriteConfig, "save current config" );
-	Cmd_AddCommand( "touch_deleteprofile", Touch_DeleteProfile_f, "delete profile by name" );
+	Cmd_AddRestrictedCommand( "touch_reloadconfig", Touch_ReloadConfig_f, "load config, not saving changes" );
+	Cmd_AddRestrictedCommand( "touch_writeconfig", Touch_WriteConfig, "save current config" );
+	Cmd_AddRestrictedCommand( "touch_deleteprofile", Touch_DeleteProfile_f, "delete profile by name" );
 	Cmd_AddCommand( "touch_generate_code", Touch_GenerateCode_f, "create code sample for mobility API" );
 	Cmd_AddCommand( "touch_fade", Touch_Fade_f, "start fade animation for selected buttons" );
-	Cmd_AddCommand( "touch_toggleselection", Touch_ToggleSelection_f, "toggle vidibility on selected button in editor" );
+	Cmd_AddRestrictedCommand( "touch_toggleselection", Touch_ToggleSelection_f, "toggle vidibility on selected button in editor" );
 
 	// not saved, just runtime state for scripting
 	touch_in_menu = Cvar_Get( "touch_in_menu", "0", 0, "draw touch in menu (for internal use only)" );
@@ -1050,22 +1050,22 @@ void Touch_Init( void )
 	touch_exp_mult = Cvar_Get( "touch_exp_mult", "0", 0, "exponent multiplier, usually 20-200, 0 to disable" );
 
 	// touch.cfg
-	touch_grid_count = Cvar_Get( "touch_grid_count", "50", 0, "touch grid count" );
-	touch_grid_enable = Cvar_Get( "touch_grid_enable", "1", 0, "enable touch grid" );
-	touch_config_file = Cvar_Get( "touch_config_file", "touch.cfg", FCVAR_ARCHIVE, "current touch profile file" );
-	touch_precise_amount = Cvar_Get( "touch_precise_amount", "0.5", 0, "sensitivity multiplier for precise-look" );
+	touch_grid_count = Cvar_Get( "touch_grid_count", "50", FCVAR_LOCALONLY, "touch grid count" );
+	touch_grid_enable = Cvar_Get( "touch_grid_enable", "1", FCVAR_LOCALONLY, "enable touch grid" );
+	touch_config_file = Cvar_Get( "touch_config_file", "touch.cfg", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "current touch profile file" );
+	touch_precise_amount = Cvar_Get( "touch_precise_amount", "0.5", FCVAR_LOCALONLY, "sensitivity multiplier for precise-look" );
 	touch_highlight_r = Cvar_Get( "touch_highlight_r", "1.0", 0, "highlight r color" );
 	touch_highlight_g = Cvar_Get( "touch_highlight_g", "1.0", 0, "highlight g color" );
 	touch_highlight_b = Cvar_Get( "touch_highlight_b", "1.0", 0, "highlight b color" );
 	touch_highlight_a = Cvar_Get( "touch_highlight_a", "1.0", 0, "highlight alpha" );
-	touch_dpad_radius = Cvar_Get( "touch_dpad_radius", "1.0", 0, "dpad radius multiplier" );
-	touch_joy_radius = Cvar_Get( "touch_joy_radius", "1.0", 0, "joy radius multiplier" );
-	touch_move_indicator = Cvar_Get( "touch_move_indicator", "0.0", 0, "indicate move events (0 to disable)" );
-	touch_joy_texture = Cvar_Get( "touch_joy_texture", "touch_default/joy.tga", 0, "texture for move indicator");
+	touch_dpad_radius = Cvar_Get( "touch_dpad_radius", "1.0", FCVAR_LOCALONLY, "dpad radius multiplier" );
+	touch_joy_radius = Cvar_Get( "touch_joy_radius", "1.0", FCVAR_LOCALONLY, "joy radius multiplier" );
+	touch_move_indicator = Cvar_Get( "touch_move_indicator", "0.0", FCVAR_LOCALONLY, "indicate move events (0 to disable)" );
+	touch_joy_texture = Cvar_Get( "touch_joy_texture", "touch_default/joy.tga", FCVAR_LOCALONLY, "texture for move indicator");
 
 	// input devices cvar
-	touch_enable = Cvar_Get( "touch_enable", DEFAULT_TOUCH_ENABLE, FCVAR_ARCHIVE, "enable touch controls" );
-	touch_emulate = Cvar_Get( "touch_emulate", "0", FCVAR_ARCHIVE, "emulate touch with mouse" );
+	touch_enable = Cvar_Get( "touch_enable", DEFAULT_TOUCH_ENABLE, FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable touch controls" );
+	touch_emulate = Cvar_Get( "touch_emulate", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "emulate touch with mouse" );
 
 	/// TODO: touch sdl platform
 	// SDL_SetHint( SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1" );

--- a/engine/client/input.c
+++ b/engine/client/input.c
@@ -111,14 +111,14 @@ IN_StartupMouse
 */
 void IN_StartupMouse( void )
 {
-	m_ignore = Cvar_Get( "m_ignore", DEFAULT_M_IGNORE, FCVAR_ARCHIVE | FCVAR_LOCALONLY, "ignore mouse events" );
+	m_ignore = Cvar_Get( "m_ignore", DEFAULT_M_IGNORE, FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "ignore mouse events" );
 
-	m_enginemouse = Cvar_Get( "m_enginemouse", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "read mouse events in engine instead of client" );
-	m_enginesens = Cvar_Get( "m_enginesens", "0.3", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "mouse sensitivity, when m_enginemouse enabled" );
-	m_pitch = Cvar_Get( "m_pitch", "0.022", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "mouse pitch value" );
-	m_yaw = Cvar_Get( "m_yaw", "0.022", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "mouse yaw value" );
-	look_filter = Cvar_Get( "look_filter", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "filter look events making it smoother" );
-	m_rawinput = Cvar_Get( "m_rawinput", "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable mouse raw input" );
+	m_enginemouse = Cvar_Get( "m_enginemouse", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "read mouse events in engine instead of client" );
+	m_enginesens = Cvar_Get( "m_enginesens", "0.3", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "mouse sensitivity, when m_enginemouse enabled" );
+	m_pitch = Cvar_Get( "m_pitch", "0.022", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "mouse pitch value" );
+	m_yaw = Cvar_Get( "m_yaw", "0.022", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "mouse yaw value" );
+	look_filter = Cvar_Get( "look_filter", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "filter look events making it smoother" );
+	m_rawinput = Cvar_Get( "m_rawinput", "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable mouse raw input" );
 
 	// You can use -nomouse argument to prevent using mouse from client
 	// -noenginemouse will disable all mouse input
@@ -462,9 +462,9 @@ IN_Init
 */
 void IN_Init( void )
 {
-	cl_forwardspeed	= Cvar_Get( "cl_forwardspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_LOCALONLY, "Default forward move speed" );
-	cl_backspeed	= Cvar_Get( "cl_backspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_LOCALONLY, "Default back move speed"  );
-	cl_sidespeed	= Cvar_Get( "cl_sidespeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_LOCALONLY, "Default side move speed"  );
+	cl_forwardspeed	= Cvar_Get( "cl_forwardspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_PRIVILEGED, "Default forward move speed" );
+	cl_backspeed	= Cvar_Get( "cl_backspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_PRIVILEGED, "Default back move speed"  );
+	cl_sidespeed	= Cvar_Get( "cl_sidespeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_PRIVILEGED, "Default side move speed"  );
 
 	if( !Host_IsDedicated() )
 	{

--- a/engine/client/input.c
+++ b/engine/client/input.c
@@ -111,14 +111,14 @@ IN_StartupMouse
 */
 void IN_StartupMouse( void )
 {
-	m_ignore = Cvar_Get( "m_ignore", DEFAULT_M_IGNORE, FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "ignore mouse events" );
+	m_ignore = Cvar_Get( "m_ignore", DEFAULT_M_IGNORE, FCVAR_ARCHIVE | FCVAR_FILTERABLE, "ignore mouse events" );
 
-	m_enginemouse = Cvar_Get( "m_enginemouse", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "read mouse events in engine instead of client" );
-	m_enginesens = Cvar_Get( "m_enginesens", "0.3", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "mouse sensitivity, when m_enginemouse enabled" );
-	m_pitch = Cvar_Get( "m_pitch", "0.022", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "mouse pitch value" );
-	m_yaw = Cvar_Get( "m_yaw", "0.022", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "mouse yaw value" );
-	look_filter = Cvar_Get( "look_filter", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "filter look events making it smoother" );
-	m_rawinput = Cvar_Get( "m_rawinput", "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable mouse raw input" );
+	m_enginemouse = Cvar_Get( "m_enginemouse", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "read mouse events in engine instead of client" );
+	m_enginesens = Cvar_Get( "m_enginesens", "0.3", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "mouse sensitivity, when m_enginemouse enabled" );
+	m_pitch = Cvar_Get( "m_pitch", "0.022", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "mouse pitch value" );
+	m_yaw = Cvar_Get( "m_yaw", "0.022", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "mouse yaw value" );
+	look_filter = Cvar_Get( "look_filter", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "filter look events making it smoother" );
+	m_rawinput = Cvar_Get( "m_rawinput", "1", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "enable mouse raw input" );
 
 	// You can use -nomouse argument to prevent using mouse from client
 	// -noenginemouse will disable all mouse input
@@ -462,9 +462,9 @@ IN_Init
 */
 void IN_Init( void )
 {
-	cl_forwardspeed	= Cvar_Get( "cl_forwardspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_PRIVILEGED, "Default forward move speed" );
-	cl_backspeed	= Cvar_Get( "cl_backspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_PRIVILEGED, "Default back move speed"  );
-	cl_sidespeed	= Cvar_Get( "cl_sidespeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_PRIVILEGED, "Default side move speed"  );
+	cl_forwardspeed	= Cvar_Get( "cl_forwardspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_FILTERABLE, "Default forward move speed" );
+	cl_backspeed	= Cvar_Get( "cl_backspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_FILTERABLE, "Default back move speed"  );
+	cl_sidespeed	= Cvar_Get( "cl_sidespeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_FILTERABLE, "Default side move speed"  );
 
 	if( !Host_IsDedicated() )
 	{

--- a/engine/client/input.c
+++ b/engine/client/input.c
@@ -111,14 +111,14 @@ IN_StartupMouse
 */
 void IN_StartupMouse( void )
 {
-	m_ignore = Cvar_Get( "m_ignore", DEFAULT_M_IGNORE, FCVAR_ARCHIVE , "ignore mouse events" );
+	m_ignore = Cvar_Get( "m_ignore", DEFAULT_M_IGNORE, FCVAR_ARCHIVE | FCVAR_LOCALONLY, "ignore mouse events" );
 
-	m_enginemouse = Cvar_Get( "m_enginemouse", "0", FCVAR_ARCHIVE, "read mouse events in engine instead of client" );
-	m_enginesens = Cvar_Get( "m_enginesens", "0.3", FCVAR_ARCHIVE, "mouse sensitivity, when m_enginemouse enabled" );
-	m_pitch = Cvar_Get( "m_pitch", "0.022", FCVAR_ARCHIVE, "mouse pitch value" );
-	m_yaw = Cvar_Get( "m_yaw", "0.022", FCVAR_ARCHIVE, "mouse yaw value" );
-	look_filter = Cvar_Get( "look_filter", "0", FCVAR_ARCHIVE, "filter look events making it smoother" );
-	m_rawinput = Cvar_Get( "m_rawinput", "1", FCVAR_ARCHIVE, "enable mouse raw input" );
+	m_enginemouse = Cvar_Get( "m_enginemouse", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "read mouse events in engine instead of client" );
+	m_enginesens = Cvar_Get( "m_enginesens", "0.3", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "mouse sensitivity, when m_enginemouse enabled" );
+	m_pitch = Cvar_Get( "m_pitch", "0.022", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "mouse pitch value" );
+	m_yaw = Cvar_Get( "m_yaw", "0.022", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "mouse yaw value" );
+	look_filter = Cvar_Get( "look_filter", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "filter look events making it smoother" );
+	m_rawinput = Cvar_Get( "m_rawinput", "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable mouse raw input" );
 
 	// You can use -nomouse argument to prevent using mouse from client
 	// -noenginemouse will disable all mouse input
@@ -462,9 +462,9 @@ IN_Init
 */
 void IN_Init( void )
 {
-	cl_forwardspeed	= Cvar_Get( "cl_forwardspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL, "Default forward move speed" );
-	cl_backspeed	= Cvar_Get( "cl_backspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL, "Default back move speed"  );
-	cl_sidespeed	= Cvar_Get( "cl_sidespeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL, "Default side move speed"  );
+	cl_forwardspeed	= Cvar_Get( "cl_forwardspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_LOCALONLY, "Default forward move speed" );
+	cl_backspeed	= Cvar_Get( "cl_backspeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_LOCALONLY, "Default back move speed"  );
+	cl_sidespeed	= Cvar_Get( "cl_sidespeed", "400", FCVAR_ARCHIVE | FCVAR_CLIENTDLL | FCVAR_LOCALONLY, "Default side move speed"  );
 
 	if( !Host_IsDedicated() )
 	{

--- a/engine/client/input.h
+++ b/engine/client/input.h
@@ -61,12 +61,9 @@ extern convar_t *touch_enable;
 extern convar_t *touch_emulate;
 
 void Touch_Draw( void );
-void Touch_SetClientOnly( qboolean state );
-void Touch_RemoveButton( const char *name );
-void Touch_HideButtons( const char *name, unsigned char hide );
-//void IN_TouchSetCommand( const char *name, const char *command );
-//void IN_TouchSetTexture( const char *name, const char *texture );
-//void IN_TouchSetColor( const char *name, byte *color );
+void Touch_SetClientOnly( byte state );
+void Touch_RemoveButton( const char *name, qboolean privileged );
+void Touch_HideButtons( const char *name, unsigned char hide, qboolean privileged );
 void Touch_AddClientButton( const char *name, const char *texture, const char *command, float x1, float y1, float x2, float y2, byte *color, int round, float aspect, int flags );
 void Touch_AddDefaultButton( const char *name, const char *texturefile, const char *command, float x1, float y1, float x2, float y2, byte *color, int round, float aspect, int flags );
 void Touch_WriteConfig( void );

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -522,8 +522,8 @@ void Key_Init( void )
 	// setup default binding. "unbindall" from config.cfg will be reset it
 	for( kn = keynames; kn->name; kn++ ) Key_SetBinding( kn->keynum, kn->binding );
 
-	osk_enable = Cvar_Get( "osk_enable", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable built-in on-screen keyboard" );
-	key_rotate = Cvar_Get( "key_rotate", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "rotate arrow keys (0-3)" );
+	osk_enable = Cvar_Get( "osk_enable", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "enable built-in on-screen keyboard" );
+	key_rotate = Cvar_Get( "key_rotate", "0", FCVAR_ARCHIVE | FCVAR_FILTERABLE, "rotate arrow keys (0-3)" );
 
 }
 

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -522,8 +522,8 @@ void Key_Init( void )
 	// setup default binding. "unbindall" from config.cfg will be reset it
 	for( kn = keynames; kn->name; kn++ ) Key_SetBinding( kn->keynum, kn->binding );
 
-	osk_enable = Cvar_Get( "osk_enable", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable built-in on-screen keyboard" );
-	key_rotate = Cvar_Get( "key_rotate", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "rotate arrow keys (0-3)" );
+	osk_enable = Cvar_Get( "osk_enable", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "enable built-in on-screen keyboard" );
+	key_rotate = Cvar_Get( "key_rotate", "0", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "rotate arrow keys (0-3)" );
 
 }
 

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -462,6 +462,7 @@ Writes lines containing "bind key value"
 void Key_WriteBindings( file_t *f )
 {
 	int	i;
+	string newCommand;
 
 	if( !f ) return;
 
@@ -472,7 +473,8 @@ void Key_WriteBindings( file_t *f )
 		if( !COM_CheckString( keys[i].binding ))
 			continue;
 
-		FS_Printf( f, "bind %s \"%s\"\n", Key_KeynumToString( i ), keys[i].binding );
+		Cmd_Escape( newCommand, keys[i].binding, sizeof( newCommand ));
+		FS_Printf( f, "bind %s \"%s\"\n", Key_KeynumToString( i ), newCommand );
 	}
 }
 

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -512,18 +512,18 @@ void Key_Init( void )
 	keyname_t	*kn;
 
 	// register our functions
-	Cmd_AddCommand( "bind", Key_Bind_f, "binds a command to the specified key in bindmap" );
-	Cmd_AddCommand( "unbind", Key_Unbind_f, "removes a command on the specified key in bindmap" );
-	Cmd_AddCommand( "unbindall", Key_Unbindall_f, "removes all commands from all keys in bindmap" );
-	Cmd_AddCommand( "resetkeys", Key_Reset_f, "reset all keys to their default values" );
+	Cmd_AddRestrictedCommand( "bind", Key_Bind_f, "binds a command to the specified key in bindmap" );
+	Cmd_AddRestrictedCommand( "unbind", Key_Unbind_f, "removes a command on the specified key in bindmap" );
+	Cmd_AddRestrictedCommand( "unbindall", Key_Unbindall_f, "removes all commands from all keys in bindmap" );
+	Cmd_AddRestrictedCommand( "resetkeys", Key_Reset_f, "reset all keys to their default values" );
 	Cmd_AddCommand( "bindlist", Key_Bindlist_f, "display current key bindings" );
 	Cmd_AddCommand( "makehelp", Key_EnumCmds_f, "write help.txt that contains all console cvars and cmds" );
 
 	// setup default binding. "unbindall" from config.cfg will be reset it
 	for( kn = keynames; kn->name; kn++ ) Key_SetBinding( kn->keynum, kn->binding );
 
-	osk_enable = Cvar_Get( "osk_enable", "0", FCVAR_ARCHIVE, "enable built-in on-screen keyboard" );
-	key_rotate = Cvar_Get( "key_rotate", "0", FCVAR_ARCHIVE, "rotate arrow keys (0-3)" );
+	osk_enable = Cvar_Get( "osk_enable", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "enable built-in on-screen keyboard" );
+	key_rotate = Cvar_Get( "key_rotate", "0", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "rotate arrow keys (0-3)" );
 
 }
 

--- a/engine/client/s_main.c
+++ b/engine/client/s_main.c
@@ -35,18 +35,18 @@ int		total_channels;
 int		soundtime;	// sample PAIRS
 int   		paintedtime; 	// sample PAIRS
 
-static CVAR_DEFINE( s_volume, "volume", "0.7", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "sound volume" );
-CVAR_DEFINE( s_musicvolume, "MP3Volume", "1.0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "background music volume" );
-static CVAR_DEFINE( s_mixahead, "_snd_mixahead", "0.12", FCVAR_PRIVILEGED, "how much sound to mix ahead of time" );
-static CVAR_DEFINE_AUTO( s_show, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "show playing sounds" );
-CVAR_DEFINE_AUTO( s_lerping, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "apply interpolation to sound output" );
-static CVAR_DEFINE( s_ambient_level, "ambient_level", "0.3", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "volume of environment noises (water and wind)" );
-static CVAR_DEFINE( s_ambient_fade, "ambient_fade", "1000", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "rate of volume fading when client is moving" );
-static CVAR_DEFINE_AUTO( s_combine_sounds, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "combine channels with same sounds" );
-CVAR_DEFINE_AUTO( snd_mute_losefocus, "1", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "silence the audio when game window loses focus" );
+static CVAR_DEFINE( s_volume, "volume", "0.7", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "sound volume" );
+CVAR_DEFINE( s_musicvolume, "MP3Volume", "1.0", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "background music volume" );
+static CVAR_DEFINE( s_mixahead, "_snd_mixahead", "0.12", FCVAR_FILTERABLE, "how much sound to mix ahead of time" );
+static CVAR_DEFINE_AUTO( s_show, "0", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "show playing sounds" );
+CVAR_DEFINE_AUTO( s_lerping, "0", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "apply interpolation to sound output" );
+static CVAR_DEFINE( s_ambient_level, "ambient_level", "0.3", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "volume of environment noises (water and wind)" );
+static CVAR_DEFINE( s_ambient_fade, "ambient_fade", "1000", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "rate of volume fading when client is moving" );
+static CVAR_DEFINE_AUTO( s_combine_sounds, "0", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "combine channels with same sounds" );
+CVAR_DEFINE_AUTO( snd_mute_losefocus, "1", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "silence the audio when game window loses focus" );
 CVAR_DEFINE_AUTO( s_test, "0", 0, "engine developer cvar for quick testing new features" );
-CVAR_DEFINE_AUTO( s_samplecount, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "sample count (0 for default value)" );
-CVAR_DEFINE_AUTO( s_warn_late_precache, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "warn about late precached sounds on client-side" );
+CVAR_DEFINE_AUTO( s_samplecount, "0", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "sample count (0 for default value)" );
+CVAR_DEFINE_AUTO( s_warn_late_precache, "0", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "warn about late precached sounds on client-side" );
 
 /*
 =============================================================================

--- a/engine/client/s_main.c
+++ b/engine/client/s_main.c
@@ -35,18 +35,18 @@ int		total_channels;
 int		soundtime;	// sample PAIRS
 int   		paintedtime; 	// sample PAIRS
 
-static CVAR_DEFINE( s_volume, "volume", "0.7", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "sound volume" );
-CVAR_DEFINE( s_musicvolume, "MP3Volume", "1.0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "background music volume" );
-static CVAR_DEFINE( s_mixahead, "_snd_mixahead", "0.12", FCVAR_LOCALONLY, "how much sound to mix ahead of time" );
-static CVAR_DEFINE_AUTO( s_show, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "show playing sounds" );
-CVAR_DEFINE_AUTO( s_lerping, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "apply interpolation to sound output" );
-static CVAR_DEFINE( s_ambient_level, "ambient_level", "0.3", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "volume of environment noises (water and wind)" );
-static CVAR_DEFINE( s_ambient_fade, "ambient_fade", "1000", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "rate of volume fading when client is moving" );
-static CVAR_DEFINE_AUTO( s_combine_sounds, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "combine channels with same sounds" );
-CVAR_DEFINE_AUTO( snd_mute_losefocus, "1", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "silence the audio when game window loses focus" );
+static CVAR_DEFINE( s_volume, "volume", "0.7", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "sound volume" );
+CVAR_DEFINE( s_musicvolume, "MP3Volume", "1.0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "background music volume" );
+static CVAR_DEFINE( s_mixahead, "_snd_mixahead", "0.12", FCVAR_PRIVILEGED, "how much sound to mix ahead of time" );
+static CVAR_DEFINE_AUTO( s_show, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "show playing sounds" );
+CVAR_DEFINE_AUTO( s_lerping, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "apply interpolation to sound output" );
+static CVAR_DEFINE( s_ambient_level, "ambient_level", "0.3", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "volume of environment noises (water and wind)" );
+static CVAR_DEFINE( s_ambient_fade, "ambient_fade", "1000", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "rate of volume fading when client is moving" );
+static CVAR_DEFINE_AUTO( s_combine_sounds, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "combine channels with same sounds" );
+CVAR_DEFINE_AUTO( snd_mute_losefocus, "1", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "silence the audio when game window loses focus" );
 CVAR_DEFINE_AUTO( s_test, "0", 0, "engine developer cvar for quick testing new features" );
-CVAR_DEFINE_AUTO( s_samplecount, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "sample count (0 for default value)" );
-CVAR_DEFINE_AUTO( s_warn_late_precache, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "warn about late precached sounds on client-side" );
+CVAR_DEFINE_AUTO( s_samplecount, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "sample count (0 for default value)" );
+CVAR_DEFINE_AUTO( s_warn_late_precache, "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "warn about late precached sounds on client-side" );
 
 /*
 =============================================================================

--- a/engine/client/s_main.c
+++ b/engine/client/s_main.c
@@ -35,18 +35,18 @@ int		total_channels;
 int		soundtime;	// sample PAIRS
 int   		paintedtime; 	// sample PAIRS
 
-static CVAR_DEFINE( s_volume, "volume", "0.7", FCVAR_ARCHIVE, "sound volume" );
-CVAR_DEFINE( s_musicvolume, "MP3Volume", "1.0", FCVAR_ARCHIVE, "background music volume" );
-static CVAR_DEFINE( s_mixahead, "_snd_mixahead", "0.12", 0, "how much sound to mix ahead of time" );
-static CVAR_DEFINE_AUTO( s_show, "0", FCVAR_ARCHIVE, "show playing sounds" );
-CVAR_DEFINE_AUTO( s_lerping, "0", FCVAR_ARCHIVE, "apply interpolation to sound output" );
-static CVAR_DEFINE( s_ambient_level, "ambient_level", "0.3", FCVAR_ARCHIVE, "volume of environment noises (water and wind)" );
-static CVAR_DEFINE( s_ambient_fade, "ambient_fade", "1000", FCVAR_ARCHIVE, "rate of volume fading when client is moving" );
-static CVAR_DEFINE_AUTO( s_combine_sounds, "0", FCVAR_ARCHIVE, "combine channels with same sounds" );
-CVAR_DEFINE_AUTO( snd_mute_losefocus, "1", FCVAR_ARCHIVE, "silence the audio when game window loses focus" );
+static CVAR_DEFINE( s_volume, "volume", "0.7", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "sound volume" );
+CVAR_DEFINE( s_musicvolume, "MP3Volume", "1.0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "background music volume" );
+static CVAR_DEFINE( s_mixahead, "_snd_mixahead", "0.12", FCVAR_LOCALONLY, "how much sound to mix ahead of time" );
+static CVAR_DEFINE_AUTO( s_show, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "show playing sounds" );
+CVAR_DEFINE_AUTO( s_lerping, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "apply interpolation to sound output" );
+static CVAR_DEFINE( s_ambient_level, "ambient_level", "0.3", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "volume of environment noises (water and wind)" );
+static CVAR_DEFINE( s_ambient_fade, "ambient_fade", "1000", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "rate of volume fading when client is moving" );
+static CVAR_DEFINE_AUTO( s_combine_sounds, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "combine channels with same sounds" );
+CVAR_DEFINE_AUTO( snd_mute_losefocus, "1", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "silence the audio when game window loses focus" );
 CVAR_DEFINE_AUTO( s_test, "0", 0, "engine developer cvar for quick testing new features" );
-CVAR_DEFINE_AUTO( s_samplecount, "0", FCVAR_ARCHIVE, "sample count (0 for default value)" );
-CVAR_DEFINE_AUTO( s_warn_late_precache, "0", FCVAR_ARCHIVE, "warn about late precached sounds on client-side" );
+CVAR_DEFINE_AUTO( s_samplecount, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "sample count (0 for default value)" );
+CVAR_DEFINE_AUTO( s_warn_late_precache, "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "warn about late precached sounds on client-side" );
 
 /*
 =============================================================================

--- a/engine/client/vid_common.c
+++ b/engine/client/vid_common.c
@@ -190,7 +190,7 @@ void VID_Init( void )
 
 	// a1ba: planned to be named vid_mode for compability
 	// but supported mode list is filled by backends, so numbers are not portable any more
-	Cmd_AddCommand( "vid_setmode", VID_Mode_f, "display video mode" );
+	Cmd_AddRestrictedCommand( "vid_setmode", VID_Mode_f, "display video mode" );
 
 	R_Init(); // init renderer
 }

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -983,7 +983,7 @@ static void Cmd_ExecuteStringWithPrivilegeCheck( const char *text, qboolean isPr
 	cmd_condlevel = 0;
 
 	// cvar value substitution
-	if( cmd_scripting && cmd_scripting->value )
+	if( CVAR_TO_BOOL( cmd_scripting ))
 	{
 		while( *text )
 		{
@@ -1331,8 +1331,42 @@ void Cmd_Null_f( void )
 }
 
 /*
+==========
+Cmd_Escape
+
+inserts escape sequences
+==========
+*/
+void Cmd_Escape( char *newCommand, const char *oldCommand, int len )
+{
+	int c;
+	int scripting = CVAR_TO_BOOL( cmd_scripting );
+
+	while( (c = *oldCommand++) && len > 1 )
+	{
+		if( c == '"' )
+		{
+			*newCommand++ = '\\';
+			len--;
+		}
+
+		if( scripting && c == '$')
+		{
+			*newCommand++ = '$';
+			len--;
+		}
+
+		*newCommand++ = c; len--;
+	}
+
+	*newCommand++ = 0;
+}
+
+
+/*
 ============
 Cmd_Init
+
 ============
 */
 void Cmd_Init( void )

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -747,7 +747,15 @@ Cmd_AddClientCommand
 */
 int GAME_EXPORT Cmd_AddClientCommand( const char *cmd_name, xcommand_t function )
 {
-	return Cmd_AddCommandEx( __FUNCTION__, cmd_name, function, "client command", CMD_CLIENTDLL );
+	int flags = CMD_CLIENTDLL;
+
+	// a1ba: try to mitigate outdated client.dll vulnerabilities
+	if( !Q_stricmp( cmd_name, "motd_write" ))
+	{
+		flags |= CMD_LOCALONLY;
+	}
+
+	return Cmd_AddCommandEx( __FUNCTION__, cmd_name, function, "client command", flags );
 }
 
 /*

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -727,7 +727,7 @@ Cmd_AddRestrictedCommand
 */
 void Cmd_AddRestrictedCommand( const char *cmd_name, xcommand_t function, const char *cmd_desc )
 {
-	Cmd_AddCommandEx( __FUNCTION__, cmd_name, function, cmd_desc, CMD_LOCALONLY );
+	Cmd_AddCommandEx( __FUNCTION__, cmd_name, function, cmd_desc, CMD_PRIVILEGED );
 }
 
 /*
@@ -752,7 +752,7 @@ int GAME_EXPORT Cmd_AddClientCommand( const char *cmd_name, xcommand_t function 
 	// a1ba: try to mitigate outdated client.dll vulnerabilities
 	if( !Q_stricmp( cmd_name, "motd_write" ))
 	{
-		flags |= CMD_LOCALONLY;
+		flags |= CMD_PRIVILEGED;
 	}
 
 	return Cmd_AddCommandEx( __FUNCTION__, cmd_name, function, "client command", flags );
@@ -945,7 +945,7 @@ static qboolean Cmd_ShouldAllowCommand( cmd_t *cmd, qboolean isPrivileged )
 		return true;
 
 	// never allow local only commands from remote
-	if( FBitSet( cmd->flags, CMD_LOCALONLY ))
+	if( FBitSet( cmd->flags, CMD_PRIVILEGED ))
 		return false;
 
 	// allow engine commands if user don't mind

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -256,7 +256,9 @@ Cbuf_Execute
 void Cbuf_Execute( void )
 {
 	Cbuf_ExecuteCommandsFromBuffer( &cmd_text, true, -1 );
+#if !XASH_DEDICATED
 	Cbuf_ExecuteCommandsFromBuffer( &filteredcmd_text, false, 1 );
+#endif
 }
 
 /*

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -257,7 +257,10 @@ void Cbuf_Execute( void )
 {
 	Cbuf_ExecuteCommandsFromBuffer( &cmd_text, true, -1 );
 #if !XASH_DEDICATED
-	Cbuf_ExecuteCommandsFromBuffer( &filteredcmd_text, false, 1 );
+	// a1ba: unlimited commands for filtered buffer per frame
+	// I don't see any sense in restricting that at this moment
+	// but in future we may limit this
+	Cbuf_ExecuteCommandsFromBuffer( &filteredcmd_text, false, -1 );
 #endif
 }
 

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -952,6 +952,9 @@ static qboolean Cmd_ShouldAllowCommand( cmd_t *cmd, qboolean isPrivileged )
 	if( cl_filterstuffcmd.value <= 0.0f )
 		return true;
 
+	if( FBitSet( cmd->flags, CMD_FILTERABLE ))
+		return false;
+
 	for( i = 0; i < ARRAYSIZE( prefixes ); i++ )
 	{
 		if( !Q_stricmp( cmd->name, prefixes[i] ))

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -888,7 +888,7 @@ cvar_t *pfnCvar_RegisterClientVariable( const char *szName, const char *szValue,
 {
 	// a1ba: try to mitigate outdated client.dll vulnerabilities
 	if( !Q_stricmp( szName, "motdfile" ))
-		flags |= FCVAR_LOCALONLY;
+		flags |= FCVAR_PRIVILEGED;
 
 	if( FBitSet( flags, FCVAR_GLCONFIG ))
 		return (cvar_t *)Cvar_Get( szName, szValue, flags, va( CVAR_GLCONFIG_DESCRIPTION, szName ));

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -886,6 +886,10 @@ pfnCvar_RegisterVariable
 */
 cvar_t *pfnCvar_RegisterClientVariable( const char *szName, const char *szValue, int flags )
 {
+	// a1ba: try to mitigate outdated client.dll vulnerabilities
+	if( !Q_stricmp( szName, "motdfile" ))
+		flags |= FCVAR_LOCALONLY;
+
 	if( FBitSet( flags, FCVAR_GLCONFIG ))
 		return (cvar_t *)Cvar_Get( szName, szValue, flags, va( CVAR_GLCONFIG_DESCRIPTION, szName ));
 	return (cvar_t *)Cvar_Get( szName, szValue, flags|FCVAR_CLIENTDLL, Cvar_BuildAutoDescription( flags|FCVAR_CLIENTDLL ));

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -480,6 +480,7 @@ void Cbuf_AddFilteredText( const char *text );
 void Cbuf_InsertText( const char *text );
 void Cbuf_ExecStuffCmds( void );
 void Cbuf_Execute (void);
+qboolean Cmd_CurrentCommandIsPrivileged( void );
 int Cmd_Argc( void );
 const char *Cmd_Args( void );
 const char *Cmd_Argv( int arg );

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -503,6 +503,7 @@ qboolean Cmd_GetMovieList( const char *s, char *completedname, int length );
 void Cmd_TokenizeString( const char *text );
 void Cmd_ExecuteString( const char *text );
 void Cmd_ForwardToServer( void );
+void Cmd_Escape( char *newCommand, const char *oldCommand, int len );
 
 //
 // zone.c

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -465,8 +465,9 @@ extern sysinfo_t	SI;
 #define CMD_SERVERDLL	BIT( 0 )		// added by server.dll
 #define CMD_CLIENTDLL	BIT( 1 )		// added by client.dll
 #define CMD_GAMEUIDLL	BIT( 2 )		// added by GameUI.dll
-#define CMD_LOCALONLY	BIT( 3 )		// restricted from server commands
-#define CMD_REFDLL		BIT( 4 )		// added by ref.dll
+#define CMD_PRIVILEGED	BIT( 3 )		// only available in privileged mode
+#define CMD_FILTERABLE  BIT( 4 )		// filtered in unprivileged mode if cl_filterstuffcmd is 1
+#define CMD_REFDLL	BIT( 5 )		// added by ref.dll
 
 typedef void (*xcommand_t)( void );
 

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -476,6 +476,7 @@ typedef void (*xcommand_t)( void );
 void Cbuf_Init( void );
 void Cbuf_Clear( void );
 void Cbuf_AddText( const char *text );
+void Cbuf_AddFilteredText( const char *text );
 void Cbuf_InsertText( const char *text );
 void Cbuf_ExecStuffCmds( void );
 void Cbuf_Execute (void);

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -184,6 +184,7 @@ extern convar_t	host_developer;
 extern convar_t	*host_limitlocal;
 extern convar_t	*host_framerate;
 extern convar_t	*host_maxfps;
+extern convar_t cl_filterstuffcmd;
 
 /*
 ==============================================================
@@ -465,7 +466,7 @@ extern sysinfo_t	SI;
 #define CMD_CLIENTDLL	BIT( 1 )		// added by client.dll
 #define CMD_GAMEUIDLL	BIT( 2 )		// added by GameUI.dll
 #define CMD_LOCALONLY	BIT( 3 )		// restricted from server commands
-#define CMD_REFDLL	BIT( 4 )		// added by ref.dll
+#define CMD_REFDLL		BIT( 4 )		// added by ref.dll
 
 typedef void (*xcommand_t)( void );
 

--- a/engine/common/cvar.c
+++ b/engine/common/cvar.c
@@ -769,15 +769,18 @@ static qboolean Cvar_ShouldSetCvar( convar_t *v, qboolean isPrivileged )
 	if( isPrivileged )
 		return true;
 
-	if( v->flags & FCVAR_PRIVILEGED )
+	if( FBitSet( v->flags, FCVAR_PRIVILEGED ))
 		return false;
 
 	if( cl_filterstuffcmd.value <= 0.0f )
 		return true;
 
+	if( FBitSet( v->flags, FCVAR_FILTERABLE ))
+		return false;
+
 	for( i = 0; i < ARRAYSIZE( prefixes ); i++ )
 	{
-		if( Q_stricmp( v->name, prefixes[i] ))
+		if( !Q_stricmp( v->name, prefixes[i] ))
 			return false;
 	}
 

--- a/engine/common/cvar.c
+++ b/engine/common/cvar.c
@@ -95,7 +95,7 @@ const char *Cvar_BuildAutoDescription( int flags )
 	if( FBitSet( flags, FCVAR_PROTECTED ))
 		Q_strncat( desc, "protected ", sizeof( desc ));
 
-	if( FBitSet( flags, FCVAR_LOCALONLY ))
+	if( FBitSet( flags, FCVAR_PRIVILEGED ))
 		Q_strncat( desc, "privileged ", sizeof( desc ));
 
 	Q_strncat( desc, "cvar", sizeof( desc ));
@@ -769,7 +769,7 @@ static qboolean Cvar_ShouldSetCvar( convar_t *v, qboolean isPrivileged )
 	if( isPrivileged )
 		return true;
 
-	if( v->flags & FCVAR_LOCALONLY )
+	if( v->flags & FCVAR_PRIVILEGED )
 		return false;
 
 	if( cl_filterstuffcmd.value <= 0.0f )
@@ -989,7 +989,7 @@ Reads in all archived cvars
 void Cvar_Init( void )
 {
 	cvar_vars = NULL;
-	cmd_scripting = Cvar_Get( "cmd_scripting", "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "enable simple condition checking and variable operations" );
+	cmd_scripting = Cvar_Get( "cmd_scripting", "0", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "enable simple condition checking and variable operations" );
 	Cvar_RegisterVariable (&host_developer); // early registering for dev
 
 	Cmd_AddRestrictedCommand( "setgl", Cvar_SetGL_f, "change the value of a opengl variable" );	// OBSOLETE

--- a/engine/common/cvar.c
+++ b/engine/common/cvar.c
@@ -769,20 +769,11 @@ static qboolean Cvar_ShouldSetCvar( convar_t *v, qboolean isPrivileged )
 	if( isPrivileged )
 		return true;
 
-	// TODO: figure this out
-	//if( v->flags & FCVAR_SERVER )
-	//	return false;
+	if( v->flags & FCVAR_LOCALONLY )
+		return false;
 
 	if( cl_filterstuffcmd.value <= 0.0f )
 		return true;
-
-	// TODO: figure this out too
-	//if( v->flags & FCVAR_EXTDLL )
-	//	return false;
-
-	// a1ba: xash3d-fwgs extension
-	if( v->flags & FCVAR_LOCALONLY )
-		return false;
 
 	for( i = 0; i < ARRAYSIZE( prefixes ); i++ )
 	{

--- a/engine/common/cvar.c
+++ b/engine/common/cvar.c
@@ -995,8 +995,8 @@ void Cvar_Init( void )
 	cmd_scripting = Cvar_Get( "cmd_scripting", "0", FCVAR_ARCHIVE, "enable simple condition checking and variable operations" );
 	Cvar_RegisterVariable (&host_developer); // early registering for dev
 
-	Cmd_AddCommand( "setgl", Cvar_SetGL_f, "change the value of a opengl variable" );	// OBSOLETE
-	Cmd_AddCommand( "toggle", Cvar_Toggle_f, "toggles a console variable's values (use for more info)" );
-	Cmd_AddCommand( "reset", Cvar_Reset_f, "reset any type variable to initial value" );
+	Cmd_AddRestrictedCommand( "setgl", Cvar_SetGL_f, "change the value of a opengl variable" );	// OBSOLETE
+	Cmd_AddRestrictedCommand( "toggle", Cvar_Toggle_f, "toggles a console variable's values (use for more info)" );
+	Cmd_AddRestrictedCommand( "reset", Cvar_Reset_f, "reset any type variable to initial value" );
 	Cmd_AddCommand( "cvarlist", Cvar_List_f, "display all console variables beginning with the specified prefix" );
 }

--- a/engine/common/cvar.c
+++ b/engine/common/cvar.c
@@ -72,7 +72,7 @@ build cvar auto description that based on the setup flags
 */
 const char *Cvar_BuildAutoDescription( int flags )
 {
-	static char	desc[128];
+	static char	desc[256];
 
 	desc[0] = '\0';
 
@@ -91,6 +91,12 @@ const char *Cvar_BuildAutoDescription( int flags )
 
 	if( FBitSet( flags, FCVAR_ARCHIVE ))
 		Q_strncat( desc, "archived ", sizeof( desc ));
+
+	if( FBitSet( flags, FCVAR_PROTECTED ))
+		Q_strncat( desc, "protected ", sizeof( desc ));
+
+	if( FBitSet( flags, FCVAR_LOCALONLY ))
+		Q_strncat( desc, "privileged ", sizeof( desc ));
 
 	Q_strncat( desc, "cvar", sizeof( desc ));
 
@@ -992,7 +998,7 @@ Reads in all archived cvars
 void Cvar_Init( void )
 {
 	cvar_vars = NULL;
-	cmd_scripting = Cvar_Get( "cmd_scripting", "0", FCVAR_ARCHIVE, "enable simple condition checking and variable operations" );
+	cmd_scripting = Cvar_Get( "cmd_scripting", "0", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "enable simple condition checking and variable operations" );
 	Cvar_RegisterVariable (&host_developer); // early registering for dev
 
 	Cmd_AddRestrictedCommand( "setgl", Cvar_SetGL_f, "change the value of a opengl variable" );	// OBSOLETE

--- a/engine/common/cvar.h
+++ b/engine/common/cvar.h
@@ -75,7 +75,7 @@ void Cvar_WriteVariables( file_t *f, int group );
 qboolean Cvar_Exists( const char *var_name );
 void Cvar_Reset( const char *var_name );
 void Cvar_SetCheatState( void );
-qboolean Cvar_Command( convar_t *v );
+qboolean Cvar_CommandWithPrivilegeCheck( convar_t *v, qboolean isPrivileged );
 void Cvar_Init( void );
 void Cvar_Unlink( int group );
 

--- a/engine/common/cvar.h
+++ b/engine/common/cvar.h
@@ -47,7 +47,7 @@ typedef struct convar_s
 #define FCVAR_ALLOCATED		(1<<19)	// this convar_t is fully dynamic allocated (include description)
 #define FCVAR_VIDRESTART		(1<<20)	// recreate the window is cvar with this flag was changed
 #define FCVAR_TEMPORARY		(1<<21)	// these cvars holds their values and can be unlink in any time
-#define FCVAR_LOCALONLY     (1<<22) // can be set only from local buffers
+#define FCVAR_MOVEVARS		(1<<22)	// this cvar is a part of movevars_t struct that shared between client and server
 
 #define CVAR_DEFINE( cv, cvname, cvstr, cvflags, cvdesc ) \
 	convar_t cv = { (char*)cvname, (char*)cvstr, cvflags, 0.0f, (void *)CVAR_SENTINEL, (char*)cvdesc, NULL }

--- a/engine/common/filesystem.c
+++ b/engine/common/filesystem.c
@@ -2061,9 +2061,9 @@ void FS_Init( void )
 
 	FS_InitMemory();
 
-	Cmd_AddCommand( "fs_rescan", FS_Rescan_f, "rescan filesystem search pathes" );
-	Cmd_AddCommand( "fs_path", FS_Path_f, "show filesystem search pathes" );
-	Cmd_AddCommand( "fs_clearpaths", FS_ClearPaths_f, "clear filesystem search pathes" );
+	Cmd_AddRestrictedCommand( "fs_rescan", FS_Rescan_f, "rescan filesystem search pathes" );
+	Cmd_AddRestrictedCommand( "fs_path", FS_Path_f, "show filesystem search pathes" );
+	Cmd_AddRestrictedCommand( "fs_clearpaths", FS_ClearPaths_f, "clear filesystem search pathes" );
 
 #if !XASH_WIN32
 	if( Sys_CheckParm( "-casesensitive" ) )

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -52,7 +52,7 @@ struct tests_stats_s tests_stats;
 
 CVAR_DEFINE( host_developer, "developer", "0", 0, "engine is in development-mode" );
 CVAR_DEFINE_AUTO( sys_ticrate, "100", 0, "framerate in dedicated mode" );
-CVAR_DEFINE_AUTO( cl_filterstuffcmd, "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "filter commands coming from server" );
+CVAR_DEFINE_AUTO( cl_filterstuffcmd, "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "filter commands coming from server" );
 
 convar_t	*host_serverstate;
 convar_t	*host_gameloaded;
@@ -1088,9 +1088,9 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 
 	Cvar_RegisterVariable( &cl_filterstuffcmd );
 	host_serverstate = Cvar_Get( "host_serverstate", "0", FCVAR_READ_ONLY, "displays current server state" );
-	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "host fps upper limit" );
-	host_framerate = Cvar_Get( "host_framerate", "0", FCVAR_LOCALONLY, "locks frame timing to this value in seconds" );
-	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
+	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "host fps upper limit" );
+	host_framerate = Cvar_Get( "host_framerate", "0", FCVAR_PRIVILEGED, "locks frame timing to this value in seconds" );
+	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
 	host_gameloaded = Cvar_Get( "host_gameloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded game.dll" );
 	host_clientloaded = Cvar_Get( "host_clientloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded client.dll" );
 	host_limitlocal = Cvar_Get( "host_limitlocal", "0", 0, "apply cl_cmdrate and rate to loopback connection" );

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -52,7 +52,6 @@ struct tests_stats_s tests_stats;
 
 CVAR_DEFINE( host_developer, "developer", "0", FCVAR_FILTERABLE, "engine is in development-mode" );
 CVAR_DEFINE_AUTO( sys_ticrate, "100", 0, "framerate in dedicated mode" );
-CVAR_DEFINE_AUTO( cl_filterstuffcmd, "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "filter commands coming from server" );
 
 convar_t	*host_serverstate;
 convar_t	*host_gameloaded;
@@ -819,6 +818,8 @@ static void Host_RunTests( int stage )
 		memset( &tests_stats, 0, sizeof( tests_stats ));
 		Test_RunLibCommon();
 		Test_RunCommon();
+		Test_RunCmd();
+		Test_RunCvar();
 		break;
 	case 1: // after FS load
 		Test_RunImagelib();
@@ -1086,7 +1087,6 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 		Cmd_AddRestrictedCommand ( "crash", Host_Crash_f, "a way to force a bus error for development reasons");
 	}
 
-	Cvar_RegisterVariable( &cl_filterstuffcmd );
 	host_serverstate = Cvar_Get( "host_serverstate", "0", FCVAR_READ_ONLY, "displays current server state" );
 	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "host fps upper limit" );
 	host_framerate = Cvar_Get( "host_framerate", "0", FCVAR_FILTERABLE, "locks frame timing to this value in seconds" );

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -1054,9 +1054,9 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 
 	Cvar_RegisterVariable( &cl_filterstuffcmd );
 	host_serverstate = Cvar_Get( "host_serverstate", "0", FCVAR_READ_ONLY, "displays current server state" );
-	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE, "host fps upper limit" );
-	host_framerate = Cvar_Get( "host_framerate", "0", 0, "locks frame timing to this value in seconds" );
-	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
+	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "host fps upper limit" );
+	host_framerate = Cvar_Get( "host_framerate", "0", FCVAR_LOCALONLY, "locks frame timing to this value in seconds" );
+	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE|FCVAR_LOCALONLY, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
 	host_gameloaded = Cvar_Get( "host_gameloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded game.dll" );
 	host_clientloaded = Cvar_Get( "host_clientloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded client.dll" );
 	host_limitlocal = Cvar_Get( "host_limitlocal", "0", 0, "apply cl_cmdrate and rate to loopback connection" );

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -52,6 +52,7 @@ struct tests_stats_s tests_stats;
 
 CVAR_DEFINE( host_developer, "developer", "0", 0, "engine is in development-mode" );
 CVAR_DEFINE_AUTO( sys_ticrate, "100", 0, "framerate in dedicated mode" );
+CVAR_DEFINE_AUTO( cl_filterstuffcmd, "1", FCVAR_ARCHIVE | FCVAR_LOCALONLY, "filter commands coming from server" );
 
 convar_t	*host_serverstate;
 convar_t	*host_gameloaded;
@@ -1051,6 +1052,7 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 		Cmd_AddCommand ( "crash", Host_Crash_f, "a way to force a bus error for development reasons");
 	}
 
+	Cvar_RegisterVariable( &cl_filterstuffcmd );
 	host_serverstate = Cvar_Get( "host_serverstate", "0", FCVAR_READ_ONLY, "displays current server state" );
 	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE, "host fps upper limit" );
 	host_framerate = Cvar_Get( "host_framerate", "0", 0, "locks frame timing to this value in seconds" );

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -989,9 +989,9 @@ void Host_InitCommon( int argc, char **argv, const char *progname, qboolean bCha
 
 	Sys_InitLog();
 
-	Cmd_AddCommand( "exec", Host_Exec_f, "execute a script file" );
+	Cmd_AddRestrictedCommand( "exec", Host_Exec_f, "execute a script file" );
 	Cmd_AddCommand( "memlist", Host_MemStats_f, "prints memory pool information" );
-	Cmd_AddCommand( "userconfigd", Host_Userconfigd_f, "execute all scripts from userconfig.d" );
+	Cmd_AddRestrictedCommand( "userconfigd", Host_Userconfigd_f, "execute all scripts from userconfig.d" );
 
 	FS_Init();
 	Image_Init();
@@ -1047,9 +1047,9 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 	// init commands and vars
 	if( host_developer.value >= DEV_EXTENDED )
 	{
-		Cmd_AddCommand ( "sys_error", Sys_Error_f, "just throw a fatal error to test shutdown procedures");
-		Cmd_AddCommand ( "host_error", Host_Error_f, "just throw a host error to test shutdown procedures");
-		Cmd_AddCommand ( "crash", Host_Crash_f, "a way to force a bus error for development reasons");
+		Cmd_AddRestrictedCommand ( "sys_error", Sys_Error_f, "just throw a fatal error to test shutdown procedures");
+		Cmd_AddRestrictedCommand ( "host_error", Host_Error_f, "just throw a host error to test shutdown procedures");
+		Cmd_AddRestrictedCommand ( "crash", Host_Crash_f, "a way to force a bus error for development reasons");
 	}
 
 	Cvar_RegisterVariable( &cl_filterstuffcmd );
@@ -1074,7 +1074,7 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 	// allow to change game from the console
 	if( pChangeGame != NULL )
 	{
-		Cmd_AddCommand( "game", Host_ChangeGame_f, "change game" );
+		Cmd_AddRestrictedCommand( "game", Host_ChangeGame_f, "change game" );
 		Cvar_Get( "host_allow_changegame", "1", FCVAR_READ_ONLY, "allows to change games" );
 	}
 	else
@@ -1094,10 +1094,10 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 		Wcon_InitConsoleCommands ();
 #endif
 
-		Cmd_AddCommand( "quit", Sys_Quit, "quit the game" );
-		Cmd_AddCommand( "exit", Sys_Quit, "quit the game" );
+		Cmd_AddRestrictedCommand( "quit", Sys_Quit, "quit the game" );
+		Cmd_AddRestrictedCommand( "exit", Sys_Quit, "quit the game" );
 	}
-	else Cmd_AddCommand( "minimize", Host_Minimize_f, "minimize main window to tray" );
+	else Cmd_AddRestrictedCommand( "minimize", Host_Minimize_f, "minimize main window to tray" );
 
 	host.errorframe = 0;
 

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -50,7 +50,7 @@ sysinfo_t		SI;
 struct tests_stats_s tests_stats;
 #endif
 
-CVAR_DEFINE( host_developer, "developer", "0", 0, "engine is in development-mode" );
+CVAR_DEFINE( host_developer, "developer", "0", FCVAR_FILTERABLE, "engine is in development-mode" );
 CVAR_DEFINE_AUTO( sys_ticrate, "100", 0, "framerate in dedicated mode" );
 CVAR_DEFINE_AUTO( cl_filterstuffcmd, "1", FCVAR_ARCHIVE | FCVAR_PRIVILEGED, "filter commands coming from server" );
 
@@ -1088,9 +1088,9 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 
 	Cvar_RegisterVariable( &cl_filterstuffcmd );
 	host_serverstate = Cvar_Get( "host_serverstate", "0", FCVAR_READ_ONLY, "displays current server state" );
-	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "host fps upper limit" );
-	host_framerate = Cvar_Get( "host_framerate", "0", FCVAR_PRIVILEGED, "locks frame timing to this value in seconds" );
-	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE|FCVAR_PRIVILEGED, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
+	host_maxfps = Cvar_Get( "fps_max", "72", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "host fps upper limit" );
+	host_framerate = Cvar_Get( "host_framerate", "0", FCVAR_FILTERABLE, "locks frame timing to this value in seconds" );
+	host_sleeptime = Cvar_Get( "sleeptime", "1", FCVAR_ARCHIVE|FCVAR_FILTERABLE, "milliseconds to sleep for each frame. higher values reduce fps accuracy" );
 	host_gameloaded = Cvar_Get( "host_gameloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded game.dll" );
 	host_clientloaded = Cvar_Get( "host_clientloaded", "0", FCVAR_READ_ONLY, "inidcates a loaded client.dll" );
 	host_limitlocal = Cvar_Get( "host_limitlocal", "0", 0, "apply cl_cmdrate and rate to loopback connection" );

--- a/engine/common/hpak.c
+++ b/engine/common/hpak.c
@@ -1077,10 +1077,10 @@ void HPAK_Validate_f( void )
 
 void HPAK_Init( void )
 {
-	Cmd_AddCommand( "hpklist", HPAK_List_f, "list all files in specified HPK-file" );
-	Cmd_AddCommand( "hpkremove", HPAK_Remove_f, "remove specified file from HPK-file" );
-	Cmd_AddCommand( "hpkval", HPAK_Validate_f, "validate specified HPK-file" );
-	Cmd_AddCommand( "hpkextract", HPAK_Extract_f, "extract all lumps from specified HPK-file" );
+	Cmd_AddRestrictedCommand( "hpklist", HPAK_List_f, "list all files in specified HPK-file" );
+	Cmd_AddRestrictedCommand( "hpkremove", HPAK_Remove_f, "remove specified file from HPK-file" );
+	Cmd_AddRestrictedCommand( "hpkval", HPAK_Validate_f, "validate specified HPK-file" );
+	Cmd_AddRestrictedCommand( "hpkextract", HPAK_Extract_f, "extract all lumps from specified HPK-file" );
 	hpk_maxsize = Cvar_Get( "hpk_maxsize", "0", FCVAR_ARCHIVE, "set limit by size for all HPK-files ( 0 - unlimited )" );
 
 	gp_hpak_queue = NULL;

--- a/engine/common/identification.c
+++ b/engine/common/identification.c
@@ -614,10 +614,10 @@ void ID_Init( void )
 	byte md5[16];
 	int i;
 
-	Cmd_AddCommand( "bloomfilter", ID_BloomFilter_f, "print bloomfilter raw value of arguments set");
-	Cmd_AddCommand( "verifyhex", ID_VerifyHEX_f, "check if id source seems to be fake" );
+	Cmd_AddRestrictedCommand( "bloomfilter", ID_BloomFilter_f, "print bloomfilter raw value of arguments set");
+	Cmd_AddRestrictedCommand( "verifyhex", ID_VerifyHEX_f, "check if id source seems to be fake" );
 #if XASH_LINUX
-	Cmd_AddCommand( "testcpuinfo", ID_TestCPUInfo_f, "try read cpu serial" );
+	Cmd_AddRestrictedCommand( "testcpuinfo", ID_TestCPUInfo_f, "try read cpu serial" );
 #endif
 
 #if XASH_ANDROID && !XASH_DEDICATED

--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -1693,15 +1693,15 @@ void NET_Init( void )
 
 	if( net.initialized ) return;
 
-	net_clockwindow = Cvar_Get( "clockwindow", "0.5", FCVAR_LOCALONLY, "timewindow to execute client moves" );
+	net_clockwindow = Cvar_Get( "clockwindow", "0.5", FCVAR_PRIVILEGED, "timewindow to execute client moves" );
 	net_address = Cvar_Get( "net_address", "0", FCVAR_READ_ONLY, "contain local address of current client" );
 	net_ipname = Cvar_Get( "ip", "localhost", FCVAR_READ_ONLY, "network ip address" );
 	net_iphostport = Cvar_Get( "ip_hostport", "0", FCVAR_READ_ONLY, "network ip host port" );
 	net_hostport = Cvar_Get( "hostport", va( "%i", PORT_SERVER ), FCVAR_READ_ONLY, "network default host port" );
 	net_ipclientport = Cvar_Get( "ip_clientport", "0", FCVAR_READ_ONLY, "network ip client port" );
 	net_clientport = Cvar_Get( "clientport", va( "%i", PORT_CLIENT ), FCVAR_READ_ONLY, "network default client port" );
-	net_fakelag = Cvar_Get( "fakelag", "0", FCVAR_LOCALONLY, "lag all incoming network data (including loopback) by xxx ms." );
-	net_fakeloss = Cvar_Get( "fakeloss", "0", FCVAR_LOCALONLY, "act like we dropped the packet this % of the time." );
+	net_fakelag = Cvar_Get( "fakelag", "0", FCVAR_PRIVILEGED, "lag all incoming network data (including loopback) by xxx ms." );
+	net_fakeloss = Cvar_Get( "fakeloss", "0", FCVAR_PRIVILEGED, "act like we dropped the packet this % of the time." );
 
 	// prepare some network data
 	for( i = 0; i < NS_COUNT; i++ )

--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -2543,10 +2543,10 @@ void HTTP_Init( void )
 
 	http.first_file = http.last_file = NULL;
 
-	Cmd_AddCommand("http_download", &HTTP_Download_f, "add file to download queue");
-	Cmd_AddCommand("http_skip", &HTTP_Skip_f, "skip current download server");
-	Cmd_AddCommand("http_cancel", &HTTP_Cancel_f, "cancel current download");
-	Cmd_AddCommand("http_clear", &HTTP_Clear_f, "cancel all downloads");
+	Cmd_AddRestrictedCommand("http_download", &HTTP_Download_f, "add file to download queue");
+	Cmd_AddRestrictedCommand("http_skip", &HTTP_Skip_f, "skip current download server");
+	Cmd_AddRestrictedCommand("http_cancel", &HTTP_Cancel_f, "cancel current download");
+	Cmd_AddRestrictedCommand("http_clear", &HTTP_Clear_f, "cancel all downloads");
 	Cmd_AddCommand("http_list", &HTTP_List_f, "list all queued downloads");
 	Cmd_AddCommand("http_addcustomserver", &HTTP_AddCustomServer_f, "add custom fastdl server");
 	http_useragent = Cvar_Get( "http_useragent", "xash3d", FCVAR_ARCHIVE, "User-Agent string" );

--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -1693,15 +1693,15 @@ void NET_Init( void )
 
 	if( net.initialized ) return;
 
-	net_clockwindow = Cvar_Get( "clockwindow", "0.5", 0, "timewindow to execute client moves" );
+	net_clockwindow = Cvar_Get( "clockwindow", "0.5", FCVAR_LOCALONLY, "timewindow to execute client moves" );
 	net_address = Cvar_Get( "net_address", "0", FCVAR_READ_ONLY, "contain local address of current client" );
 	net_ipname = Cvar_Get( "ip", "localhost", FCVAR_READ_ONLY, "network ip address" );
 	net_iphostport = Cvar_Get( "ip_hostport", "0", FCVAR_READ_ONLY, "network ip host port" );
 	net_hostport = Cvar_Get( "hostport", va( "%i", PORT_SERVER ), FCVAR_READ_ONLY, "network default host port" );
 	net_ipclientport = Cvar_Get( "ip_clientport", "0", FCVAR_READ_ONLY, "network ip client port" );
 	net_clientport = Cvar_Get( "clientport", va( "%i", PORT_CLIENT ), FCVAR_READ_ONLY, "network default client port" );
-	net_fakelag = Cvar_Get( "fakelag", "0", 0, "lag all incoming network data (including loopback) by xxx ms." );
-	net_fakeloss = Cvar_Get( "fakeloss", "0", 0, "act like we dropped the packet this % of the time." );
+	net_fakelag = Cvar_Get( "fakelag", "0", FCVAR_LOCALONLY, "lag all incoming network data (including loopback) by xxx ms." );
+	net_fakeloss = Cvar_Get( "fakeloss", "0", FCVAR_LOCALONLY, "act like we dropped the packet this % of the time." );
 
 	// prepare some network data
 	for( i = 0; i < NS_COUNT; i++ )

--- a/engine/common/tests.h
+++ b/engine/common/tests.h
@@ -24,6 +24,8 @@ extern struct tests_stats_s tests_stats;
 void Test_RunImagelib( void );
 void Test_RunLibCommon( void );
 void Test_RunCommon( void );
+void Test_RunCmd( void );
+void Test_RunCvar( void );
 
 #endif
 

--- a/engine/platform/linux/in_evdev.c
+++ b/engine/platform/linux/in_evdev.c
@@ -449,9 +449,9 @@ void Platfrom_MouseMove( float *yaw, float *pitch )
 
 void Evdev_Init( void )
 {
-	Cmd_AddCommand ("evdev_open", Evdev_OpenDevice_f, "Open event device");
-	Cmd_AddCommand ("evdev_close", Evdev_CloseDevice_f, "Close event device");
-	Cmd_AddCommand ("evdev_autodetect", Evdev_Autodetect_f, "Automaticly open mouses and keyboards");
+	Cmd_AddRestrictedCommand ("evdev_open", Evdev_OpenDevice_f, "Open event device");
+	Cmd_AddRestrictedCommand ("evdev_close", Evdev_CloseDevice_f, "Close event device");
+	Cmd_AddRestrictedCommand ("evdev_autodetect", Evdev_Autodetect_f, "Automaticly open mouses and keyboards");
 #if XASH_INPUT == INPUT_EVDEV
 	Evdev_Autodetect_f();
 #endif

--- a/engine/platform/linux/s_alsa.c
+++ b/engine/platform/linux/s_alsa.c
@@ -66,7 +66,7 @@ qboolean SNDDMA_Init( void )
 
 	Sys_GetParmFromCmdLine( "-alsadev", device );
 
-	Cmd_AddCommand("pcm_pause", SND_Pause_f, "set pcm pause (debug)" );
+	Cmd_AddRestrictedCommand("pcm_pause", SND_Pause_f, "set pcm pause (debug)" );
 
 	if( ( err = snd_pcm_open( &s_alsa.pcm_handle, device, SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK ) ) < 0)
 	{

--- a/engine/server/sv_cmds.c
+++ b/engine/server/sv_cmds.c
@@ -1002,19 +1002,19 @@ is available always
 */
 void SV_InitHostCommands( void )
 {
-	Cmd_AddCommand( "map", SV_Map_f, "start new level" );
+	Cmd_AddRestrictedCommand( "map", SV_Map_f, "start new level" );
 	Cmd_AddCommand( "maps", SV_Maps_f, "list maps" );
 
 	if( host.type == HOST_NORMAL )
 	{
-		Cmd_AddCommand( "newgame", SV_NewGame_f, "begin new game" );
-		Cmd_AddCommand( "hazardcourse", SV_HazardCourse_f, "starting a Hazard Course" );
-		Cmd_AddCommand( "map_background", SV_MapBackground_f, "set background map" );
-		Cmd_AddCommand( "load", SV_Load_f, "load a saved game file" );
-		Cmd_AddCommand( "loadquick", SV_QuickLoad_f, "load a quick-saved game file" );
-		Cmd_AddCommand( "reload", SV_Reload_f, "continue from latest save or restart level" );
-		Cmd_AddCommand( "killsave", SV_DeleteSave_f, "delete a saved game file and saveshot" );
-		Cmd_AddCommand( "nextmap", SV_NextMap_f, "load next level" );
+		Cmd_AddRestrictedCommand( "newgame", SV_NewGame_f, "begin new game" );
+		Cmd_AddRestrictedCommand( "hazardcourse", SV_HazardCourse_f, "starting a Hazard Course" );
+		Cmd_AddRestrictedCommand( "map_background", SV_MapBackground_f, "set background map" );
+		Cmd_AddRestrictedCommand( "load", SV_Load_f, "load a saved game file" );
+		Cmd_AddRestrictedCommand( "loadquick", SV_QuickLoad_f, "load a quick-saved game file" );
+		Cmd_AddRestrictedCommand( "reload", SV_Reload_f, "continue from latest save or restart level" );
+		Cmd_AddRestrictedCommand( "killsave", SV_DeleteSave_f, "delete a saved game file and saveshot" );
+		Cmd_AddRestrictedCommand( "nextmap", SV_NextMap_f, "load next level" );
 	}
 }
 

--- a/engine/server/sv_filter.c
+++ b/engine/server/sv_filter.c
@@ -426,14 +426,14 @@ static void SV_WriteIP_f( void )
 
 void SV_InitFilter( void )
 {
-	Cmd_AddCommand( "banid", SV_BanID_f, "ban player by ID" );
-	Cmd_AddCommand( "listid", SV_ListID_f, "list banned players" );
-	Cmd_AddCommand( "removeid", SV_RemoveID_f, "remove player from banned list" );
-	Cmd_AddCommand( "writeid", SV_WriteID_f, "write banned.cfg" );
-	Cmd_AddCommand( "addip", SV_AddIP_f, "add entry to IP filter" );
-	Cmd_AddCommand( "listip", SV_ListIP_f, "list current IP filter" );
-	Cmd_AddCommand( "removeip", SV_RemoveIP_f, "remove IP filter" );
-	Cmd_AddCommand( "writeip", SV_WriteIP_f, "write listip.cfg" );
+	Cmd_AddRestrictedCommand( "banid", SV_BanID_f, "ban player by ID" );
+	Cmd_AddRestrictedCommand( "listid", SV_ListID_f, "list banned players" );
+	Cmd_AddRestrictedCommand( "removeid", SV_RemoveID_f, "remove player from banned list" );
+	Cmd_AddRestrictedCommand( "writeid", SV_WriteID_f, "write banned.cfg" );
+	Cmd_AddRestrictedCommand( "addip", SV_AddIP_f, "add entry to IP filter" );
+	Cmd_AddRestrictedCommand( "listip", SV_ListIP_f, "list current IP filter" );
+	Cmd_AddRestrictedCommand( "removeip", SV_RemoveIP_f, "remove IP filter" );
+	Cmd_AddRestrictedCommand( "writeip", SV_WriteIP_f, "write listip.cfg" );
 }
 
 void SV_ShutdownFilter( void )


### PR DESCRIPTION
[ ] Select CVars and commands to protect
[ ] Decide what to do with touch cvars/commands, probably should be filtered by default. Or allowed but with unprivileged mode flag
[ ] Testing, testing, testing!