### PR TITLE
engine: added feature flag ENGINE_LINEAR_GAMMA_SPACE

### DIFF
--- a/common/enginefeatures.h
+++ b/common/enginefeatures.h
@@ -25,5 +25,6 @@ GNU General Public License for more details.
 #define ENGINE_COMPENSATE_QUAKE_BUG	(1<<5)	// compensate stupid quake bug (inverse pitch) for mods where this bug is fixed
 #define ENGINE_IMPROVED_LINETRACE	(1<<6)	// new traceline that tracing through alphatextures
 #define ENGINE_COMPUTE_STUDIO_LERP	(1<<7)	// enable MOVETYPE_STEP lerping back in engine
+#define ENGINE_LINEAR_GAMMA_SPACE	(1<<8)	// disable influence of gamma/brightness cvars to textures/lightmaps, for mods with custom renderer
 
 #endif//FEATURES_H

--- a/engine/common/gamma.c
+++ b/engine/common/gamma.c
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 
 #include "common.h"
 #include "xash3d_mathlib.h"
+#include "enginefeatures.h"
 
 //-----------------------------------------------------------------------------
 // Gamma conversion support
@@ -78,10 +79,16 @@ void BuildGammaTable( float lightgamma, float brightness )
 
 byte LightToTexGamma( byte b )
 {
-	return lightgammatable[b];
+	if( host.features & ENGINE_LINEAR_GAMMA_SPACE )
+		return b;
+	else
+		return lightgammatable[b];
 }
 
 byte TextureToGamma( byte b )
 {
-	return texgammatable[b];
+	if( host.features & ENGINE_LINEAR_GAMMA_SPACE )
+		return b;
+	else
+		return texgammatable[b];
 }


### PR DESCRIPTION
Необходимая фича для реализации нормальной гамма-коррекции/освещения в моде с кастомным рендером.
Уже протестил это всё, мне удалось внутри игры получить картинку в линейном пространстве. 
