### PR TITLE
add /fsanitize=address for msvc (windows) when sanitize

### DIFF
--- a/scripts/waifulib/compiler_optimizations.py
+++ b/scripts/waifulib/compiler_optimizations.py
@@ -41,6 +41,7 @@ LINKFLAGS = {
 	'sanitize': {
 		'clang': ['-fsanitize=undefined', '-fsanitize=address', '-pthread'],
 		'gcc':   ['-fsanitize=undefined', '-fsanitize=address', '-pthread'],
+		'msvc': ['/SAFESEH:NO']
 	},
 	'debug': {
 		'msvc': ['/INCREMENTAL', '/SAFESEH:NO']
@@ -81,7 +82,7 @@ CFLAGS = {
 		'default': ['-O0']
 	},
 	'sanitize': {
-		'msvc':    ['/Od', '/RTC1', '/Zi'],
+		'msvc':    ['/Od', '/RTC1', '/Zi', '/fsanitize=address'],
 		'gcc':     ['-O0', '-fsanitize=undefined', '-fsanitize=address', '-pthread'],
 		'clang':   ['-O0', '-fsanitize=undefined', '-fsanitize=address', '-pthread'],
 		'default': ['-O0']


### PR DESCRIPTION
Ловит некоторые ошибки в движке. При этом если не подключиться студией и загрузить какую-то карту игра вылезает без всяких ошибок. Если просто сидеть в меню, даже разглядывать там 3д модель персонажа, то не вылетает.

Когда подключаюсь к процессу в студии при переходе на карту там в начале ударяется в
Вызвано исключение по адресу 0x00007FF6632961BE в xash3d.exe: 0xC0000005: нарушение прав доступа при чтении по адресу 0x000011DA95AB5D2C.
`sv.time = svgame.globals->time = 1.0f;	// server spawn time it's always 1.0 second`
это в `qboolean SV_SpawnServer` в \engine\server\sv_init.c
Вызвано исключение: нарушение доступа для чтения.
aligned_beg было 0x11DA95A7D000.

И дальше там ещё другие ошибки начинаются в рендере, модели, спрайты...