### PR TITLE
engine: make pfnDrawString & pfnDrawStringReverse return width

### DIFF
--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -2929,15 +2929,16 @@ pfnDrawString
 */
 static int GAME_EXPORT pfnDrawString( int x, int y, const char *str, int r, int g, int b )
 {
+	int iWidth = 0;
 	Con_UtfProcessChar(0);
 
 	// draw the string until we hit the null character or a newline character
 	for ( ; *str != 0 && *str != '\n'; str++ )
 	{
-		x += pfnVGUI2DrawCharacterAdditive( x, y, (unsigned char)*str, r, g, b, 0 );
+		iWidth += pfnVGUI2DrawCharacterAdditive( x + iWidth, y, (unsigned char)*str, r, g, b, 0 );
 	}
 
-	return x;
+	return iWidth;
 }
 
 /*
@@ -2952,8 +2953,7 @@ static int GAME_EXPORT pfnDrawStringReverse( int x, int y, const char *str, int 
 	char *szIt;
 	for( szIt = (char*)str; *szIt != 0; szIt++ )
 		x -= clgame.scrInfo.charWidths[ (unsigned char) *szIt ];
-	pfnDrawString( x, y, str, r, g, b );
-	return x;
+	return pfnDrawString( x, y, str, r, g, b );
 }
 
 /*


### PR DESCRIPTION
Looking at https://github.com/ValveSoftware/halflife/blob/master/cl_dll/hud_redraw.cpp:

```cpp
int CHud :: DrawHudString(int xpos, int ypos, int iMaxX, char *szIt, int r, int g, int b )
{
	return xpos + gEngfuncs.pfnDrawString( xpos, ypos, szIt, r, g, b);
}
```

```cpp
int CHud :: DrawHudStringReverse( int xpos, int ypos, int iMinX, char *szString, int r, int g, int b )
{
	return xpos - gEngfuncs.pfnDrawStringReverse( xpos, ypos, szString, r, g, b);
}
```

We can see that `pfnDrawString` and `pfnDrawStringReverse` are supposed to return width instead of new X position.

I checked the behavior by using current Half-Life `client.dll`. I sent `ShowMenu` message to draw this titles entry:

```
Team_Menu_Join_IG
{
\wa\db\yc\rd\wa\db\yc\rd\wa\db\yc\rd\wa\db\yc\rd\wa\db\yc\rd\wa\db\yc\rd\wa\db\yc\rd
}
```

Result using current Xash3D master:

![bad_menu](https://user-images.githubusercontent.com/1312612/151621581-4bca1a86-e4cf-4151-b11d-8a2506d49580.png)

Result using this patch:

![good_menu](https://user-images.githubusercontent.com/1312612/151621644-a12daf9e-1f60-49b4-9226-006d5ed8982c.png)