### PR TITLE
engine: workaround -Wstringop-overflow

### DIFF
--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -1170,7 +1170,8 @@ void CL_ParseBaseline( sizebuf_t *msg )
 			Host_Error( "CL_AllocEdict: no free edicts\n" );
 
 		ent = CL_EDICT_NUM( newnum );
-		memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
+		if ( ent ) // workaround -Wstringop-overflow
+			memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
 		ent->index = newnum;
 
 		MSG_ReadDeltaEntity( msg, &ent->prevstate, &ent->baseline, newnum, player, 1.0f );
@@ -2428,7 +2429,8 @@ void CL_LegacyParseBaseline( sizebuf_t *msg )
 		Host_Error( "CL_AllocEdict: no free edicts\n" );
 
 	ent = CL_EDICT_NUM( newnum );
-	memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
+	if ( ent ) // workaround -Wstringop-overflow
+		memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
 	ent->index = newnum;
 
 	MSG_ReadDeltaEntity( msg, &ent->prevstate, &ent->baseline, newnum, player, 1.0f );

--- a/engine/client/cl_qparse.c
+++ b/engine/client/cl_qparse.c
@@ -705,7 +705,8 @@ static void CL_ParseQuakeBaseline( sizebuf_t *msg )
 		Host_Error( "CL_AllocEdict: no free edicts\n" );
 
 	ent = CL_EDICT_NUM( newnum );
-	memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
+	if ( ent ) // workaround -Wstringop-overflow
+		memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
 	ent->index = newnum;
 
 	// parse baseline

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -979,7 +979,8 @@ void SV_InitEdict( edict_t *pEdict )
 	Assert( pEdict != NULL );
 
 	SV_FreePrivateData( pEdict );
-	memset( &pEdict->v, 0, sizeof( entvars_t ));
+	if ( pEdict ) // workaround -Wstringop-overflow
+		memset( &pEdict->v, 0, sizeof( entvars_t ));
 	pEdict->v.pContainingEntity = pEdict;
 	pEdict->v.controller[0] = 0x7F;
 	pEdict->v.controller[1] = 0x7F;


### PR DESCRIPTION
```
GCC 11.1 produces -Wstringop-overflow warnings on Linux, e.g.:

./engine/client/cl_parse.c:1173:17: warning: ‘memset’ writing 340 bytes
into a region of size 0 overflows the destination [-Wstringop-overflow=]
 1173 |        memset( &ent->prevstate, 0, sizeof( ent->prevstate ));
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Explicitly checking whether the pointer that is to be written into is
not null works it around.
```