### PR TITLE
engine: masterlist: replace master server domain by mentality.rip

### DIFF
--- a/engine/common/masterlist.c
+++ b/engine/common/masterlist.c
@@ -254,6 +254,5 @@ void NET_InitMasters( void )
 
 	// keep main master always there
 	NET_AddMaster( MASTERSERVER_ADR, false );
-	NET_AddMaster( MASTERSERVER_ADR2, false );
 	NET_LoadMasters( );
 }

--- a/engine/common/netchan.h
+++ b/engine/common/netchan.h
@@ -69,8 +69,7 @@ GNU General Public License for more details.
 //  bytes will be stripped by the networking channel layer
 #define NET_MAX_MESSAGE		PAD_NUMBER(( NET_MAX_PAYLOAD + HEADER_BYTES ), 16 )
 
-#define MASTERSERVER_ADR		"ms.xash.su:27010"
-#define MASTERSERVER_ADR2		"ms2.xash.su:27010"
+#define MASTERSERVER_ADR		"mentality.rip:27010"
 #define MS_SCAN_REQUEST		"1\xFF" "0.0.0.0:0\0"
 
 #define PORT_MASTER			27010


### PR DESCRIPTION
It is essentially the same as ms.xash.su but due to current situation, it is known to be blocked on some Ukrainian ISPs.

ms2.xash.su is retired for now.