### PR TITLE
Fix console attaching to existing

### DIFF
--- a/engine/platform/win32/con_win.c
+++ b/engine/platform/win32/con_win.c
@@ -581,6 +581,8 @@ destroy win32 console
 */
 void Wcon_DestroyConsole( void )
 {
+	int return_key = VK_RETURN;
+
 	// last text message into console or log
 	Con_Reportf( "Sys_FreeLibrary: Unloading xash.dll\n" );
 
@@ -595,6 +597,7 @@ void Wcon_DestroyConsole( void )
 	if( s_wcd.is_attached )
 	{
 		SetConsoleTitle( &s_wcd.old_title );
+		SendMessage( s_wcd.hWnd, WM_CHAR, &return_key, 0 );
 	}
 
 	FreeConsole();

--- a/engine/platform/win32/con_win.c
+++ b/engine/platform/win32/con_win.c
@@ -494,6 +494,8 @@ create win32 console
 */
 void Wcon_CreateConsole( void )
 {
+	qboolean is_attached;
+
 	if( Sys_CheckParm( "-log" ))
 		s_wcd.log_active = true;
 
@@ -509,7 +511,11 @@ void Wcon_CreateConsole( void )
 		s_wcd.log_active = true; // always make log
 	}
 
-	AllocConsole();
+	is_attached = ( AttachConsole( ATTACH_PARENT_PROCESS ) != 0 );
+	
+	if( !is_attached )
+		AllocConsole();
+
 	SetConsoleTitle( s_wcd.title );
 	SetConsoleCP( CP_UTF8 );
 	SetConsoleOutputCP( CP_UTF8 );
@@ -525,7 +531,8 @@ void Wcon_CreateConsole( void )
 		return;
 	}
 
-	SetWindowPos( s_wcd.hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOREPOSITION | SWP_SHOWWINDOW );
+	if( !is_attached )
+		SetWindowPos( s_wcd.hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOREPOSITION | SWP_SHOWWINDOW );
 
 	// show console if needed
 	if( host.con_showalways )

--- a/engine/platform/win32/con_win.c
+++ b/engine/platform/win32/con_win.c
@@ -31,6 +31,7 @@ typedef struct
 {
 	qboolean    is_attached;
 
+	char        old_title[512];
 	char		title[64];
 	HWND		hWnd;
 	HANDLE		hInput;
@@ -512,10 +513,16 @@ void Wcon_CreateConsole( void )
 	}
 
 	s_wcd.is_attached = ( AttachConsole( ATTACH_PARENT_PROCESS ) != 0 );
-	if( !s_wcd.is_attached )
+	if( s_wcd.is_attached )
+	{
+		GetConsoleTitle( &s_wcd.old_title, sizeof(s_wcd.old_title) );
+	}
+	else
+	{
 		AllocConsole();
+	}
 
-	SetConsoleTitle( s_wcd.title );
+	SetConsoleTitle( &s_wcd.title );
 	SetConsoleCP( CP_UTF8 );
 	SetConsoleOutputCP( CP_UTF8 );
 
@@ -583,6 +590,11 @@ void Wcon_DestroyConsole( void )
 	{
 		ShowWindow( s_wcd.hWnd, SW_HIDE );
 		s_wcd.hWnd = 0;
+	}
+
+	if( s_wcd.is_attached )
+	{
+		SetConsoleTitle( &s_wcd.old_title );
 	}
 
 	FreeConsole();

--- a/engine/platform/win32/con_win.c
+++ b/engine/platform/win32/con_win.c
@@ -31,7 +31,7 @@ typedef struct
 {
 	qboolean    is_attached;
 
-	char        old_title[512];
+	string      old_title;
 	char		title[64];
 	HWND		hWnd;
 	HANDLE		hInput;


### PR DESCRIPTION
## Описание

Исправляет создание новой консоли, если Xash запускается из командной строки.

Сначала происходит вызов `AttachConsole` и только если он завершается ошибкой, вызывается `AllocConsole`

## Скриншот

Было:

![image](https://user-images.githubusercontent.com/60278551/167317318-3e041eee-e4be-4722-9241-560a80696b39.png)

Стало:

![image](https://user-images.githubusercontent.com/60278551/167317350-58d9c774-9562-4ee0-9370-da362ee81a7a.png)

## Баги

- [x] После запуска движок убивает консоль, даже если мы запускались из командной строки
- [x] Восстановление заголовка после закрытия движка
- [x] Отображение prompt и нормализация положения курсора