### PR TITLE
engine: try to detect LoadLibrary/FreeLibrary leaks

### DIFF
--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -330,7 +330,7 @@ static ref_api_t gEngfuncs =
 	_Mem_Realloc,
 	_Mem_Free,
 
-	COM_LoadLibrary,
+	_COM_LoadLibrary,
 	COM_FreeLibrary,
 	COM_GetProcAddress,
 

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -1197,6 +1197,8 @@ int EXPORT Host_Main( int argc, char **argv, const char *progname, int bChangeGa
 	return 0;
 }
 
+void DLL_PrintLeaks( void );
+
 /*
 =================
 Host_Shutdown
@@ -1224,6 +1226,8 @@ void EXPORT Host_Shutdown( void )
 	HTTP_Shutdown();
 	Host_FreeCommon();
 	Platform_Shutdown();
+
+	DLL_PrintLeaks();
 
 	// must be last, console uses this
 	Mem_FreePool( &host.mempool );

--- a/engine/common/library.h
+++ b/engine/common/library.h
@@ -35,7 +35,11 @@ typedef struct dll_user_s
 } dll_user_t;
 
 dll_user_t *FS_FindLibrary( const char *dllname, qboolean directpath );
-void *COM_LoadLibrary( const char *dllname, int build_ordinals_table, qboolean directpath );
+
+#define COM_LoadLibrary( dllname, build_ordinals_table, directpath ) \
+	_COM_LoadLibrary( dllname, build_ordinals_table, directpath, __FILE__, __LINE__ )
+
+void *_COM_LoadLibrary( const char *dllname, int build_ordinals_table, qboolean directpath, const char *name, int line );
 void *COM_GetProcAddress( void *hInstance, const char *name );
 const char *COM_NameForFunction( void *hInstance, void *function );
 void *COM_FunctionFromName_SR( void *hInstance, const char *pName ); // Save/Restore version

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -363,7 +363,7 @@ typedef struct ref_api_s
 	void  (*_Mem_Free)( void *data, const char *filename, int fileline );
 
 	// library management
-	void *(*COM_LoadLibrary)( const char *name, int build_ordinals_table, qboolean directpath );
+	void *(*COM_LoadLibrary)( const char *name, int build_ordinals_table, qboolean directpath, const char *file, int line );
 	void  (*COM_FreeLibrary)( void *handle );
 	void *(*COM_GetProcAddress)( void *handle, const char *name );
 


### PR DESCRIPTION
Should be moved out of lib_posix.c to generic lib_common utils, to enable it for most platforms.

IMHO, it is a purely an engine development debugging tool, so must be disabled by default.