### PR TITLE
Introduce bug-compatibility levels

### DIFF
--- a/Documentation/bug-compatibility.md
+++ b/Documentation/bug-compatibility.md
@@ -1,0 +1,17 @@
+# Bug-compatibility in Xash3D FWGS
+
+Xash3D FWGS has special mode for games that rely on original engine bugs.
+
+In this mode, we emulate the behaviour of selected functions that may help running mods relying on engine bugs, but enabling them by default may break majority of other games.
+
+At this time, we only have implemented GoldSrc bug-compatibility. It can be enabled with `-bugcomp` command line switch.
+
+## GoldSrc bug-compatibility
+
+### Emulated bugs
+
+* `pfnPEntityOfEntIndex` in GoldSrc returns NULL for last player due to incorrect player index comparison
+
+### Games and mods that require this
+
+* Counter-Strike: Condition Zero - Deleted Scenes

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -307,6 +307,16 @@ typedef struct
 	float		scale;		// curstate.scale
 } tentlist_t;
 
+typedef enum bugcomp_e
+{
+	// default mode, we assume that user dlls are not relying on engine bugs
+	BUGCOMP_OFF,
+
+	// GoldSrc mode, user dlls are relying on GoldSrc specific bugs
+	// but fixing them may break regular Xash games
+	BUGCOMP_GOLDSRC,
+} bugcomp_t;
+
 typedef struct host_parm_s
 {
 	HINSTANCE			hInst;
@@ -380,6 +390,9 @@ typedef struct host_parm_s
 
 	struct decallist_s	*decalList;	// used for keep decals, when renderer is restarted or changed
 	int		numdecals;
+
+	// bug compatibility level, for very "special" games
+	bugcomp_t bugcomp;
 
 } host_parm_t;
 

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -151,6 +151,8 @@ void Sys_PrintUsage( void )
 	O("-clientlib <path>","override client DLL path")
 #endif
 	O("-rodir <path>    ","set read-only base directory, experimental")
+	O("-bugcomp         ","enable precise bug compatibility. Will break games that don't require it")
+	O("                 ","Refer to engine documentation for more info")
 
 	O("-ip <ip>         ","set custom ip")
 	O("-port <port>     ","set custom host port")
@@ -859,10 +861,10 @@ void Host_InitCommon( int argc, char **argv, const char *progname, qboolean bCha
 
 	if( !Sys_CheckParm( "-disablehelp" ) )
 	{
-	    if( Sys_CheckParm( "-help" ) || Sys_CheckParm( "-h" ) || Sys_CheckParm( "--help" ) )
-	    {
+		 if( Sys_CheckParm( "-help" ) || Sys_CheckParm( "-h" ) || Sys_CheckParm( "--help" ) )
+		 {
 			Sys_PrintUsage();
-	    }
+		 }
 	}
 
 	if( !Sys_CheckParm( "-noch" ) )
@@ -940,6 +942,13 @@ void Host_InitCommon( int argc, char **argv, const char *progname, qboolean bCha
 
 	// member console allowing
 	host.allow_console_init = host.allow_console;
+
+	if( Sys_CheckParm( "-bugcomp" ))
+	{
+		// add argument check here when we add other levels
+		// of bugcompatibility
+		host.bugcomp = BUGCOMP_GOLDSRC;
+	}
 
 	// timeBeginPeriod( 1 ); // a1ba: Do we need this?
 

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -3375,7 +3375,9 @@ pfnPEntityOfEntIndex
 static edict_t *pfnPEntityOfEntIndex( int iEntIndex )
 {
 	// have to be bug-compatible with GoldSrc in this function
-	return SV_PEntityOfEntIndex( iEntIndex, false );
+	if( host.bugcomp == BUGCOMP_GOLDSRC )
+		return SV_PEntityOfEntIndex( iEntIndex, false );
+	return SV_PEntityOfEntIndex( iEntIndex, true );
 }
 
 /*


### PR DESCRIPTION
* for now we only have GoldSrc bug compatibility, can be used for
  games that require precise GoldSrc behaviour, like CSCZDS
* enabled with -bugcomp command line
