### PR TITLE
filesystem: set root directory as static

### DIFF
--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -1452,7 +1452,7 @@ qboolean FS_InitStdio( qboolean caseinsensitive, const char *rootdir, const char
 	}
 
 	// build list of game directories here
-	FS_AddGameDirectory( "./", 0 );
+	FS_AddGameDirectory( "./", FS_STATIC_PATH );
 
 	for( i = 0; i < dirs.numstrings; i++ )
 	{


### PR DESCRIPTION
Counter-Strike uses COM_ExpandFileName to get full path to filesystem_stdio. When reading liblist.gam, the engine will clear the search path and the root search path will be cleared. Set it as static so it will be excluded from clearing.

First patch to prepare for VGUI2 support.