### PR TITLE
common: com_model: changed common structs reserved fields type to intptr_t

### DIFF
--- a/Documentation/extensions/expanded-common-structures.md
+++ b/Documentation/extensions/expanded-common-structures.md
@@ -1,0 +1,8 @@
+# Expanded structures that used by engine and mods
+To make porting and developing mods on 64-bit platforms less painful, we decided to expand size of several structures.
+This information important in case you are using codebase like XashXT, Paranoia 2: Savior and want to compile your mod for platform with 64-bit pointer size: you should replace old definitions with new ones, otherwise your mod will not work with Xash3D FWGS (typically, it's just crashing when starting map).
+| Structure name | Locates in file | Original size on 64-bit | Current size on 64-bit |
+|----------------|-----------------|-------------------------|------------------------|
+|`mfaceinfo_t` | `common/com_model.h` | 176 bytes |  304 bytes |
+|`decal_s` | `common/com_model.h` | 72 bytes |  88 bytes |
+|`mextrasurf_t` | `common/com_model.h` | 376 bytes |  504 bytes |

--- a/common/com_model.h
+++ b/common/com_model.h
@@ -105,7 +105,7 @@ typedef struct
 
 	vec3_t		mins, maxs;	// terrain bounds (fill by user)
 
-	int		reserved[32];	// just for future expansions or mod-makers
+	intptr_t	reserved[32];	// just for future expansions or mod-makers
 } mfaceinfo_t;
 
 typedef struct
@@ -173,8 +173,8 @@ struct decal_s
 	short		entityIndex;	// Entity this is attached to
 // Xash3D specific
 	vec3_t		position;		// location of the decal center in world space.
-	glpoly_t		*polys;		// precomputed decal vertices
-	int		reserved[4];	// just for future expansions or mod-makers
+	glpoly_t	*polys;		// precomputed decal vertices
+	intptr_t	reserved[4];	// just for future expansions or mod-makers
 };
 
 typedef struct mleaf_s
@@ -228,7 +228,7 @@ typedef struct mextrasurf_s
 	unsigned short	numverts;		// world->vertexes[]
 	int		firstvertex;	// fisrt look up in tr.tbn_vectors[], then acess to world->vertexes[]
 
-	int		reserved[32];	// just for future expansions or mod-makers
+	intptr_t	reserved[32];	// just for future expansions or mod-makers
 } mextrasurf_t;
 
 struct msurface_s


### PR DESCRIPTION
To make porting mod to 64-bit less painful