### PR TITLE
Updating VGUI cursor state when cursor changed from engine

### DIFF
--- a/engine/client/vgui/vgui_draw.c
+++ b/engine/client/vgui/vgui_draw.c
@@ -51,11 +51,7 @@ void GAME_EXPORT VGUI_GetMousePos( int *_x, int *_y )
 void GAME_EXPORT VGUI_CursorSelect( VGUI_DefaultCursor cursor )
 {
 	if( s_currentCursor != cursor )
-	{
 		Platform_SetCursorType( cursor );
-
-		s_currentCursor = cursor;
-	}
 }
 
 byte GAME_EXPORT VGUI_GetColor( int i, int j)
@@ -488,6 +484,10 @@ void VGui_RunFrame( void )
 	//stub
 }
 
+void VGui_UpdateInternalCursorState( VGUI_DefaultCursor cursorType )
+{
+	s_currentCursor = cursorType;
+}
 
 void *GAME_EXPORT VGui_GetPanel( void )
 {

--- a/engine/client/vgui/vgui_draw.h
+++ b/engine/client/vgui/vgui_draw.h
@@ -36,6 +36,7 @@ void VGui_MouseMove( int x, int y );
 qboolean VGui_IsActive( void );
 void *VGui_GetPanel( void );
 void VGui_ReportTextInput( const char *text );
+void VGui_UpdateInternalCursorState( VGUI_DefaultCursor cursorType );
 #ifdef __cplusplus
 }
 #endif

--- a/engine/platform/sdl/in_sdl.c
+++ b/engine/platform/sdl/in_sdl.c
@@ -335,6 +335,7 @@ void Platform_SetCursorType( VGUI_DefaultCursor type )
 		return;
 
 	host.mouse_visible = visible;
+	VGui_UpdateInternalCursorState( type );
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
 	if( host.mouse_visible )


### PR DESCRIPTION
To syncronize VGUI and engine cursor state and avoid potential cursor problems (faced with one in PrimeXT)