### PR TITLE
Internal vgui support rework

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -3063,9 +3063,6 @@ void Host_ClientFrame( void )
 	// catch changes video settings
 	VID_CheckChanges();
 
-	// process VGUI
-	VGui_RunFrame ();
-
 	// update the screen
 	SCR_UpdateScreen ();
 

--- a/engine/client/cl_scrn.c
+++ b/engine/client/cl_scrn.c
@@ -780,7 +780,6 @@ SCR_VidInit
 */
 void SCR_VidInit( void )
 {
-	string libpath;
 	if( !ref.initialized ) // don't call VidInit too soon
 		return;
 
@@ -795,8 +794,11 @@ void SCR_VidInit( void )
 		gameui.globals->scrHeight = refState.height;
 	}
 
-	COM_GetCommonLibraryPath( LIBRARY_CLIENT, libpath, sizeof( libpath ));
-	VGui_Startup( libpath, refState.width, refState.height );
+	// notify vgui about screen size change
+	if( clgame.hInstance )
+	{
+		VGui_Startup( refState.width, refState.height );
+	}
 
 	CL_ClearSpriteTextures(); // now all hud sprites are invalid
 

--- a/engine/client/vgui/vgui_draw.c
+++ b/engine/client/vgui/vgui_draw.c
@@ -23,93 +23,101 @@ GNU General Public License for more details.
 #include "input.h"
 #include "platform/platform.h"
 
-static enum VGUI_KeyCode s_pVirtualKeyTrans[256];
-static VGUI_DefaultCursor s_currentCursor = -1;
-static HINSTANCE s_pVGuiSupport; // vgui_support library
-static convar_t	*vgui_utf8 = NULL;
+CVAR_DEFINE_AUTO( vgui_utf8, "0", FCVAR_ARCHIVE, "enable utf-8 support for vgui text" );
 
-void GAME_EXPORT *VGUI_EngineMalloc(size_t size)
+static void GAME_EXPORT *VGUI_EngineMalloc( size_t size );
+static void GAME_EXPORT VGUI_GetMousePos( int *, int * );
+static void GAME_EXPORT VGUI_CursorSelect( VGUI_DefaultCursor );
+static byte GAME_EXPORT VGUI_GetColor( int, int );
+static int GAME_EXPORT VGUI_UtfProcessChar( int in );
+static qboolean GAME_EXPORT VGUI_IsInGame( void );
+
+static struct
+{
+	qboolean initialized;
+	vguiapi_t dllFuncs;
+	VGUI_DefaultCursor cursor;
+
+	HINSTANCE hInstance;
+
+	enum VGUI_KeyCode virtualKeyTrans[256];
+} vgui =
+{
+	false,
+	{
+		false, // Not initialized yet
+		NULL, // VGUI_DrawInit,
+		NULL, // VGUI_DrawShutdown,
+		NULL, // VGUI_SetupDrawingText,
+		NULL, // VGUI_SetupDrawingRect,
+		NULL, // VGUI_SetupDrawingImage,
+		NULL, // VGUI_BindTexture,
+		NULL, // VGUI_EnableTexture,
+		NULL, // VGUI_CreateTexture,
+		NULL, // VGUI_UploadTexture,
+		NULL, // VGUI_UploadTextureBlock,
+		NULL, // VGUI_DrawQuad,
+		NULL, // VGUI_GetTextureSizes,
+		NULL, // VGUI_GenerateTexture,
+		VGUI_EngineMalloc,
+		VGUI_CursorSelect,
+		VGUI_GetColor,
+		VGUI_IsInGame,
+		NULL,
+		VGUI_GetMousePos,
+		VGUI_UtfProcessChar,
+		Platform_GetClipboardText,
+		Platform_SetClipboardText,
+		Platform_GetKeyModifiers,
+	},
+	-1
+};
+
+static void GAME_EXPORT *VGUI_EngineMalloc( size_t size )
 {
 	return Z_Malloc( size );
 }
 
-qboolean GAME_EXPORT VGUI_IsInGame( void )
+static qboolean GAME_EXPORT VGUI_IsInGame( void )
 {
 	return cls.state == ca_active && cls.key_dest == key_game;
 }
 
-void GAME_EXPORT VGUI_GetMousePos( int *_x, int *_y )
+static void GAME_EXPORT VGUI_GetMousePos( int *_x, int *_y )
 {
 	float xscale = (float)refState.width / (float)clgame.scrInfo.iWidth;
 	float yscale = (float)refState.height / (float)clgame.scrInfo.iHeight;
 	int x, y;
 
 	Platform_GetMousePos( &x, &y );
-	*_x = x / xscale, *_y = y / yscale;
+	*_x = x / xscale;
+	*_y = y / yscale;
 }
 
-void GAME_EXPORT VGUI_CursorSelect( VGUI_DefaultCursor cursor )
+static void GAME_EXPORT VGUI_CursorSelect( VGUI_DefaultCursor cursor )
 {
-	if( s_currentCursor != cursor )
+	if( vgui.cursor != cursor )
 		Platform_SetCursorType( cursor );
 }
 
-byte GAME_EXPORT VGUI_GetColor( int i, int j)
+static byte GAME_EXPORT VGUI_GetColor( int i, int j )
 {
 	return g_color_table[i][j];
 }
 
-// Define and initialize vgui API
-int GAME_EXPORT VGUI_UtfProcessChar( int in )
+static int GAME_EXPORT VGUI_UtfProcessChar( int in )
 {
-	if( CVAR_TO_BOOL( vgui_utf8 ))
+	if( vgui_utf8.value )
 		return Con_UtfProcessCharForce( in );
-	else
-		return in;
+	return in;
 }
-
-vguiapi_t vgui =
-{
-	false, // Not initialized yet
-	NULL, // VGUI_DrawInit,
-	NULL, // VGUI_DrawShutdown,
-	NULL, // VGUI_SetupDrawingText,
-	NULL, // VGUI_SetupDrawingRect,
-	NULL, // VGUI_SetupDrawingImage,
-	NULL, // VGUI_BindTexture,
-	NULL, // VGUI_EnableTexture,
-	NULL, // VGUI_CreateTexture,
-	NULL, // VGUI_UploadTexture,
-	NULL, // VGUI_UploadTextureBlock,
-	NULL, // VGUI_DrawQuad,
-	NULL, // VGUI_GetTextureSizes,
-	NULL, // VGUI_GenerateTexture,
-	VGUI_EngineMalloc,
-	VGUI_CursorSelect,
-	VGUI_GetColor,
-	VGUI_IsInGame,
-	NULL,
-	VGUI_GetMousePos,
-	VGUI_UtfProcessChar,
-	Platform_GetClipboardText,
-	Platform_SetClipboardText,
-	Platform_GetKeyModifiers,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL
-};
 
 qboolean VGui_IsActive( void )
 {
 	return vgui.initialized;
 }
 
-void VGui_FillAPIFromRef( vguiapi_t *to, const ref_interface_t *from )
+static void VGui_FillAPIFromRef( vguiapi_t *to, const ref_interface_t *from )
 {
 	to->DrawInit = from->VGUI_DrawInit;
 	to->DrawShutdown = from->VGUI_DrawShutdown;
@@ -126,136 +134,86 @@ void VGui_FillAPIFromRef( vguiapi_t *to, const ref_interface_t *from )
 	to->GenerateTexture = from->VGUI_GenerateTexture;
 }
 
+void VGui_RegisterCvars( void )
+{
+	Cvar_RegisterVariable( &vgui_utf8 );
+}
+
+qboolean VGui_LoadProgs( HINSTANCE hInstance )
+{
+	void (*F)( vguiapi_t* );
+	qboolean client = hInstance != NULL;
+
+	// not loading interface from client.dll, load vgui_support.dll instead
+	if( !client )
+	{
+		string vguiloader, vguilib;
+
+		// HACKHACK: try to load path from custom path
+		// to support having different versions of VGUI
+		if( Sys_GetParmFromCmdLine( "-vguilib", vguilib ) && !COM_LoadLibrary( vguilib, false, false ))
+		{
+			Con_Reportf( S_WARN "VGUI preloading failed. Default library will be used! Reason: %s", COM_GetLibraryError());
+		}
+
+		if( !Sys_GetParmFromCmdLine( "-vguiloader", vguiloader ))
+		{
+			Q_strncpy( vguiloader, VGUI_SUPPORT_DLL, sizeof( vguiloader ));
+		}
+
+		hInstance = vgui.hInstance = COM_LoadLibrary( vguiloader, false, false );
+
+		if( !vgui.hInstance )
+		{
+			if( FS_FileExists( vguiloader, false ))
+				Con_Reportf( S_ERROR "Failed to load vgui_support library: %s\n", COM_GetLibraryError() );
+			else Con_Reportf( "vgui_support: not found\n" );
+
+			return false;
+		}
+	}
+
+	// try legacy API first
+	F = COM_GetProcAddress( hInstance, client ? "InitVGUISupportAPI" : "InitAPI" );
+
+	if( F )
+	{
+		VGui_FillAPIFromRef( &vgui.dllFuncs, &ref.dllFuncs );
+		F( &vgui.dllFuncs );
+
+		vgui.initialized = vgui.dllFuncs.initialized = true;
+		Con_Reportf( "vgui_support: initialized legacy API in %s module\n", client ? "client" : "support" );
+
+		return true;
+	}
+
+	Con_Reportf( S_ERROR "Failed to find VGUI support API entry point in %s module\n", client ? "client" : "support" );
+	return false;
+}
+
 /*
 ================
 VGui_Startup
 
-Load vgui_support library and call VGui_Startup
 ================
 */
-void VGui_Startup( const char *clientlib, int width, int height )
+void VGui_Startup( int width, int height )
 {
-	static qboolean failed = false;
-
-	void (*F) ( vguiapi_t * );
-	char vguiloader[256];
-	char vguilib[256];
-
-	vguiloader[0] = vguilib[0] = '\0';
-
-	if( failed )
+	// vgui not initialized from both support and client modules, skip
+	if( !vgui.initialized )
 		return;
 
-	if( !vgui.initialized )
-	{
-		vgui_utf8 = Cvar_Get( "vgui_utf8", "0", FCVAR_ARCHIVE, "enable utf-8 support for vgui text" );
+	height = Q_min( 480, height );
 
-		VGui_FillAPIFromRef( &vgui, &ref.dllFuncs );
+	if( width <= 640 ) width = 640;
+	else if( width <= 800 ) width = 800;
+	else if( width <= 1024 ) width = 1024;
+	else if( width <= 1152 ) width = 1152;
+	else if( width <= 1280 ) width = 1280;
+	else if( width <= 1600 ) width = 1600;
 
-		s_pVGuiSupport = COM_LoadLibrary( clientlib, false, false );
-
-		if( s_pVGuiSupport )
-		{
-			F = COM_GetProcAddress( s_pVGuiSupport, "InitVGUISupportAPI" );
-			if( F )
-			{
-				F( &vgui );
-				vgui.initialized = true;
-				Con_Reportf( "vgui_support: found internal client support\n" );
-			}
-			else
-			{
-				COM_FreeLibrary( s_pVGuiSupport );
-			}
-		}
-
-		if( !vgui.initialized )
-		{
-			// HACKHACK: load vgui with correct path first if specified.
-			// it will be reused while resolving vgui support and client deps
-			if( Sys_GetParmFromCmdLine( "-vguilib", vguilib ))
-			{
-				if( Q_strstr( vguilib, ".dll" ))
-					Q_strncpy( vguiloader, "vgui_support.dll", 256 );
-				else
-					Q_strncpy( vguiloader, VGUI_SUPPORT_DLL, 256 );
-
-				if( !COM_LoadLibrary( vguilib, false, false ))
-					Con_Reportf( S_WARN "VGUI preloading failed. Default library will be used! Reason: %s\n", COM_GetLibraryError() );
-			}
-
-			if( Q_strstr( clientlib, ".dll" ))
-				Q_strncpy( vguiloader, "vgui_support.dll", 256 );
-
-			if( !vguiloader[0] && !Sys_GetParmFromCmdLine( "-vguiloader", vguiloader ))
-				Q_strncpy( vguiloader, VGUI_SUPPORT_DLL, 256 );
-
-			s_pVGuiSupport = COM_LoadLibrary( vguiloader, false, false );
-
-			if( !s_pVGuiSupport )
-			{
-				s_pVGuiSupport = COM_LoadLibrary( va( "../%s", vguiloader ), false, false );
-			}
-
-			if( !s_pVGuiSupport )
-			{
-				if( FS_FileExists( vguiloader, false ))
-				{
-					Con_Reportf( S_ERROR "Failed to load vgui_support library: %s\n", COM_GetLibraryError() );
-				}
-				else
-				{
-					Con_Reportf( "vgui_support: not found\n" );
-				}
-				failed = true;
-			}
-			else
-			{
-				F = COM_GetProcAddress( s_pVGuiSupport, "InitAPI" );
-				if( F )
-				{
-					F( &vgui );
-					vgui.initialized = true;
-				}
-				else
-				{
-					Con_Reportf( S_ERROR "Failed to find vgui_support library entry point!\n" );
-					failed = true;
-					COM_FreeLibrary( s_pVGuiSupport );
-				}
-			}
-		}
-	}
-
-	if( height < 480 )
-		height = 480;
-
-	if( width <= 640 )
-		width = 640;
-	else if( width <= 800 )
-		width = 800;
-	else if( width <= 1024 )
-		width = 1024;
-	else if( width <= 1152 )
-		width = 1152;
-	else if( width <= 1280 )
-		width = 1280;
-	else if( width <= 1600 )
-		width = 1600;
-#ifdef XASH_DLL_LOADER
-	else if ( Q_strstr( vguiloader, ".dll" ) )
-		width = 1600;
-#endif
-
-
-	if( vgui.initialized )
-	{
-		vgui.Startup( width, height );
-	}
-	else if ( COM_CheckString( clientlib ) )
-	{
-		failed = true;
-	}
+	if( vgui.dllFuncs.Startup )
+		vgui.dllFuncs.Startup( width, height );
 }
 
 
@@ -269,146 +227,138 @@ Unload vgui_support library and call VGui_Shutdown
 */
 void VGui_Shutdown( void )
 {
-	if( vgui.Shutdown )
-		vgui.Shutdown();
+	if( vgui.dllFuncs.Shutdown )
+		vgui.dllFuncs.Shutdown();
 
-	if( s_pVGuiSupport )
-		COM_FreeLibrary( s_pVGuiSupport );
-	s_pVGuiSupport = NULL;
+	if( vgui.hInstance )
+		COM_FreeLibrary( vgui.hInstance );
 
+	vgui.hInstance = NULL;
 	vgui.initialized = false;
 }
 
 
-void VGUI_InitKeyTranslationTable( void )
+static void VGUI_InitKeyTranslationTable( void )
 {
-	static qboolean bInitted = false;
+	static qboolean initialized = false;
 
-	if( bInitted )
-		return;
-	bInitted = true;
+	if( initialized ) return;
+
+	initialized = true;
 
 	// set virtual key translation table
-	memset( s_pVirtualKeyTrans, -1, sizeof( s_pVirtualKeyTrans ) );
+	memset( vgui.virtualKeyTrans, -1, sizeof( vgui.virtualKeyTrans ) );
 
-	s_pVirtualKeyTrans['0'] = KEY_0;
-	s_pVirtualKeyTrans['1'] = KEY_1;
-	s_pVirtualKeyTrans['2'] = KEY_2;
-	s_pVirtualKeyTrans['3'] = KEY_3;
-	s_pVirtualKeyTrans['4'] = KEY_4;
-	s_pVirtualKeyTrans['5'] = KEY_5;
-	s_pVirtualKeyTrans['6'] = KEY_6;
-	s_pVirtualKeyTrans['7'] = KEY_7;
-	s_pVirtualKeyTrans['8'] = KEY_8;
-	s_pVirtualKeyTrans['9'] = KEY_9;
-	s_pVirtualKeyTrans['A'] = s_pVirtualKeyTrans['a'] = KEY_A;
-	s_pVirtualKeyTrans['B'] = s_pVirtualKeyTrans['b'] = KEY_B;
-	s_pVirtualKeyTrans['C'] = s_pVirtualKeyTrans['c'] = KEY_C;
-	s_pVirtualKeyTrans['D'] = s_pVirtualKeyTrans['d'] = KEY_D;
-	s_pVirtualKeyTrans['E'] = s_pVirtualKeyTrans['e'] = KEY_E;
-	s_pVirtualKeyTrans['F'] = s_pVirtualKeyTrans['f'] = KEY_F;
-	s_pVirtualKeyTrans['G'] = s_pVirtualKeyTrans['g'] = KEY_G;
-	s_pVirtualKeyTrans['H'] = s_pVirtualKeyTrans['h'] = KEY_H;
-	s_pVirtualKeyTrans['I'] = s_pVirtualKeyTrans['i'] = KEY_I;
-	s_pVirtualKeyTrans['J'] = s_pVirtualKeyTrans['j'] = KEY_J;
-	s_pVirtualKeyTrans['K'] = s_pVirtualKeyTrans['k'] = KEY_K;
-	s_pVirtualKeyTrans['L'] = s_pVirtualKeyTrans['l'] = KEY_L;
-	s_pVirtualKeyTrans['M'] = s_pVirtualKeyTrans['m'] = KEY_M;
-	s_pVirtualKeyTrans['N'] = s_pVirtualKeyTrans['n'] = KEY_N;
-	s_pVirtualKeyTrans['O'] = s_pVirtualKeyTrans['o'] = KEY_O;
-	s_pVirtualKeyTrans['P'] = s_pVirtualKeyTrans['p'] = KEY_P;
-	s_pVirtualKeyTrans['Q'] = s_pVirtualKeyTrans['q'] = KEY_Q;
-	s_pVirtualKeyTrans['R'] = s_pVirtualKeyTrans['r'] = KEY_R;
-	s_pVirtualKeyTrans['S'] = s_pVirtualKeyTrans['s'] = KEY_S;
-	s_pVirtualKeyTrans['T'] = s_pVirtualKeyTrans['t'] = KEY_T;
-	s_pVirtualKeyTrans['U'] = s_pVirtualKeyTrans['u'] = KEY_U;
-	s_pVirtualKeyTrans['V'] = s_pVirtualKeyTrans['v'] = KEY_V;
-	s_pVirtualKeyTrans['W'] = s_pVirtualKeyTrans['w'] = KEY_W;
-	s_pVirtualKeyTrans['X'] = s_pVirtualKeyTrans['x'] = KEY_X;
-	s_pVirtualKeyTrans['Y'] = s_pVirtualKeyTrans['y'] = KEY_Y;
-	s_pVirtualKeyTrans['Z'] = s_pVirtualKeyTrans['z'] = KEY_Z;
+	// TODO: engine keys are not enough here!
+	// make crossplatform way to pass SDL keys here
 
-	s_pVirtualKeyTrans[K_KP_5 - 5] = KEY_PAD_0;
-	s_pVirtualKeyTrans[K_KP_5 - 4] = KEY_PAD_1;
-	s_pVirtualKeyTrans[K_KP_5 - 3] = KEY_PAD_2;
-	s_pVirtualKeyTrans[K_KP_5 - 2] = KEY_PAD_3;
-	s_pVirtualKeyTrans[K_KP_5 - 1] = KEY_PAD_4;
-	s_pVirtualKeyTrans[K_KP_5 - 0] = KEY_PAD_5;
-	s_pVirtualKeyTrans[K_KP_5 + 1] = KEY_PAD_6;
-	s_pVirtualKeyTrans[K_KP_5 + 2] = KEY_PAD_7;
-	s_pVirtualKeyTrans[K_KP_5 + 3] = KEY_PAD_8;
-	s_pVirtualKeyTrans[K_KP_5 + 4] = KEY_PAD_9;
-	s_pVirtualKeyTrans[K_KP_SLASH]	= KEY_PAD_DIVIDE;
-	s_pVirtualKeyTrans['*'] = KEY_PAD_MULTIPLY;
-	s_pVirtualKeyTrans[K_KP_MINUS] = KEY_PAD_MINUS;
-	s_pVirtualKeyTrans[K_KP_PLUS] = KEY_PAD_PLUS;
-	s_pVirtualKeyTrans[K_KP_ENTER]	= KEY_PAD_ENTER;
-	//s_pVirtualKeyTrans[K_KP_DECIMAL] = KEY_PAD_DECIMAL;
-	s_pVirtualKeyTrans['['] = KEY_LBRACKET;
-	s_pVirtualKeyTrans[']'] = KEY_RBRACKET;
-	s_pVirtualKeyTrans[';'] = KEY_SEMICOLON;
-	s_pVirtualKeyTrans['\''] = KEY_APOSTROPHE;
-	s_pVirtualKeyTrans['`'] = KEY_BACKQUOTE;
-	s_pVirtualKeyTrans[','] = KEY_COMMA;
-	s_pVirtualKeyTrans['.'] = KEY_PERIOD;
-	s_pVirtualKeyTrans[K_KP_SLASH] = KEY_SLASH;
-	s_pVirtualKeyTrans['\\'] = KEY_BACKSLASH;
-	s_pVirtualKeyTrans['-'] = KEY_MINUS;
-	s_pVirtualKeyTrans['='] = KEY_EQUAL;
-	s_pVirtualKeyTrans[K_ENTER]	= KEY_ENTER;
-	s_pVirtualKeyTrans[K_SPACE] = KEY_SPACE;
-	s_pVirtualKeyTrans[K_BACKSPACE] = KEY_BACKSPACE;
-	s_pVirtualKeyTrans[K_TAB] = KEY_TAB;
-	s_pVirtualKeyTrans[K_CAPSLOCK] = KEY_CAPSLOCK;
-	s_pVirtualKeyTrans[K_KP_NUMLOCK] = KEY_NUMLOCK;
-	s_pVirtualKeyTrans[K_ESCAPE]	= KEY_ESCAPE;
-	//s_pVirtualKeyTrans[K_KP_SCROLLLOCK]	= KEY_SCROLLLOCK;
-	s_pVirtualKeyTrans[K_INS]	= KEY_INSERT;
-	s_pVirtualKeyTrans[K_DEL]	= KEY_DELETE;
-	s_pVirtualKeyTrans[K_HOME] = KEY_HOME;
-	s_pVirtualKeyTrans[K_END] = KEY_END;
-	s_pVirtualKeyTrans[K_PGUP] = KEY_PAGEUP;
-	s_pVirtualKeyTrans[K_PGDN] = KEY_PAGEDOWN;
-	s_pVirtualKeyTrans[K_PAUSE] = KEY_BREAK;
-	//s_pVirtualKeyTrans[K_SHIFT] = KEY_RSHIFT;
-	s_pVirtualKeyTrans[K_SHIFT] = KEY_LSHIFT;	// SHIFT -> left SHIFT
-	//s_pVirtualKeyTrans[SDLK_RALT] = KEY_RALT;
-	s_pVirtualKeyTrans[K_ALT] = KEY_LALT;		// ALT -> left ALT
-	//s_pVirtualKeyTrans[SDLK_RCTRL] = KEY_RCONTROL;
-	s_pVirtualKeyTrans[K_CTRL] = KEY_LCONTROL;	// CTRL -> left CTRL
-	s_pVirtualKeyTrans[K_WIN] = KEY_LWIN;
-	//s_pVirtualKeyTrans[SDLK_APPLICATION] = KEY_RWIN;
-	//s_pVirtualKeyTrans[K_WIN] = KEY_APP;
-	s_pVirtualKeyTrans[K_UPARROW] = KEY_UP;
-	s_pVirtualKeyTrans[K_LEFTARROW] = KEY_LEFT;
-	s_pVirtualKeyTrans[K_DOWNARROW] = KEY_DOWN;
-	s_pVirtualKeyTrans[K_RIGHTARROW] = KEY_RIGHT;
-	s_pVirtualKeyTrans[K_F1] = KEY_F1;
-	s_pVirtualKeyTrans[K_F2] = KEY_F2;
-	s_pVirtualKeyTrans[K_F3] = KEY_F3;
-	s_pVirtualKeyTrans[K_F4] = KEY_F4;
-	s_pVirtualKeyTrans[K_F5] = KEY_F5;
-	s_pVirtualKeyTrans[K_F6] = KEY_F6;
-	s_pVirtualKeyTrans[K_F7] = KEY_F7;
-	s_pVirtualKeyTrans[K_F8] = KEY_F8;
-	s_pVirtualKeyTrans[K_F9] = KEY_F9;
-	s_pVirtualKeyTrans[K_F10] = KEY_F10;
-	s_pVirtualKeyTrans[K_F11] = KEY_F11;
-	s_pVirtualKeyTrans[K_F12] = KEY_F12;
+	vgui.virtualKeyTrans['0'] = KEY_0;
+	vgui.virtualKeyTrans['1'] = KEY_1;
+	vgui.virtualKeyTrans['2'] = KEY_2;
+	vgui.virtualKeyTrans['3'] = KEY_3;
+	vgui.virtualKeyTrans['4'] = KEY_4;
+	vgui.virtualKeyTrans['5'] = KEY_5;
+	vgui.virtualKeyTrans['6'] = KEY_6;
+	vgui.virtualKeyTrans['7'] = KEY_7;
+	vgui.virtualKeyTrans['8'] = KEY_8;
+	vgui.virtualKeyTrans['9'] = KEY_9;
+	vgui.virtualKeyTrans['A'] = vgui.virtualKeyTrans['a'] = KEY_A;
+	vgui.virtualKeyTrans['B'] = vgui.virtualKeyTrans['b'] = KEY_B;
+	vgui.virtualKeyTrans['C'] = vgui.virtualKeyTrans['c'] = KEY_C;
+	vgui.virtualKeyTrans['D'] = vgui.virtualKeyTrans['d'] = KEY_D;
+	vgui.virtualKeyTrans['E'] = vgui.virtualKeyTrans['e'] = KEY_E;
+	vgui.virtualKeyTrans['F'] = vgui.virtualKeyTrans['f'] = KEY_F;
+	vgui.virtualKeyTrans['G'] = vgui.virtualKeyTrans['g'] = KEY_G;
+	vgui.virtualKeyTrans['H'] = vgui.virtualKeyTrans['h'] = KEY_H;
+	vgui.virtualKeyTrans['I'] = vgui.virtualKeyTrans['i'] = KEY_I;
+	vgui.virtualKeyTrans['J'] = vgui.virtualKeyTrans['j'] = KEY_J;
+	vgui.virtualKeyTrans['K'] = vgui.virtualKeyTrans['k'] = KEY_K;
+	vgui.virtualKeyTrans['L'] = vgui.virtualKeyTrans['l'] = KEY_L;
+	vgui.virtualKeyTrans['M'] = vgui.virtualKeyTrans['m'] = KEY_M;
+	vgui.virtualKeyTrans['N'] = vgui.virtualKeyTrans['n'] = KEY_N;
+	vgui.virtualKeyTrans['O'] = vgui.virtualKeyTrans['o'] = KEY_O;
+	vgui.virtualKeyTrans['P'] = vgui.virtualKeyTrans['p'] = KEY_P;
+	vgui.virtualKeyTrans['Q'] = vgui.virtualKeyTrans['q'] = KEY_Q;
+	vgui.virtualKeyTrans['R'] = vgui.virtualKeyTrans['r'] = KEY_R;
+	vgui.virtualKeyTrans['S'] = vgui.virtualKeyTrans['s'] = KEY_S;
+	vgui.virtualKeyTrans['T'] = vgui.virtualKeyTrans['t'] = KEY_T;
+	vgui.virtualKeyTrans['U'] = vgui.virtualKeyTrans['u'] = KEY_U;
+	vgui.virtualKeyTrans['V'] = vgui.virtualKeyTrans['v'] = KEY_V;
+	vgui.virtualKeyTrans['W'] = vgui.virtualKeyTrans['w'] = KEY_W;
+	vgui.virtualKeyTrans['X'] = vgui.virtualKeyTrans['x'] = KEY_X;
+	vgui.virtualKeyTrans['Y'] = vgui.virtualKeyTrans['y'] = KEY_Y;
+	vgui.virtualKeyTrans['Z'] = vgui.virtualKeyTrans['z'] = KEY_Z;
+
+	vgui.virtualKeyTrans[K_KP_5 - 5] = KEY_PAD_0;
+	vgui.virtualKeyTrans[K_KP_5 - 4] = KEY_PAD_1;
+	vgui.virtualKeyTrans[K_KP_5 - 3] = KEY_PAD_2;
+	vgui.virtualKeyTrans[K_KP_5 - 2] = KEY_PAD_3;
+	vgui.virtualKeyTrans[K_KP_5 - 1] = KEY_PAD_4;
+	vgui.virtualKeyTrans[K_KP_5 - 0] = KEY_PAD_5;
+	vgui.virtualKeyTrans[K_KP_5 + 1] = KEY_PAD_6;
+	vgui.virtualKeyTrans[K_KP_5 + 2] = KEY_PAD_7;
+	vgui.virtualKeyTrans[K_KP_5 + 3] = KEY_PAD_8;
+	vgui.virtualKeyTrans[K_KP_5 + 4] = KEY_PAD_9;
+	vgui.virtualKeyTrans[K_KP_SLASH] = KEY_PAD_DIVIDE;
+	vgui.virtualKeyTrans['*']        = KEY_PAD_MULTIPLY;
+	vgui.virtualKeyTrans[K_KP_MINUS] = KEY_PAD_MINUS;
+	vgui.virtualKeyTrans[K_KP_PLUS]  = KEY_PAD_PLUS;
+	vgui.virtualKeyTrans[K_KP_ENTER] = KEY_PAD_ENTER;
+	vgui.virtualKeyTrans[K_KP_NUMLOCK] = KEY_NUMLOCK;
+	vgui.virtualKeyTrans['['] = KEY_LBRACKET;
+	vgui.virtualKeyTrans[']'] = KEY_RBRACKET;
+	vgui.virtualKeyTrans[';'] = KEY_SEMICOLON;
+	vgui.virtualKeyTrans['`'] = KEY_BACKQUOTE;
+	vgui.virtualKeyTrans[','] = KEY_COMMA;
+	vgui.virtualKeyTrans['.'] = KEY_PERIOD;
+	vgui.virtualKeyTrans['-'] = KEY_MINUS;
+	vgui.virtualKeyTrans['='] = KEY_EQUAL;
+	vgui.virtualKeyTrans['/'] = KEY_SLASH;
+	vgui.virtualKeyTrans['\\'] = KEY_BACKSLASH;
+	vgui.virtualKeyTrans['\''] = KEY_APOSTROPHE;
+	vgui.virtualKeyTrans[K_TAB] = KEY_TAB;
+	vgui.virtualKeyTrans[K_ENTER] = KEY_ENTER;
+	vgui.virtualKeyTrans[K_SPACE] = KEY_SPACE;
+	vgui.virtualKeyTrans[K_CAPSLOCK] = KEY_CAPSLOCK;
+	vgui.virtualKeyTrans[K_BACKSPACE] = KEY_BACKSPACE;
+	vgui.virtualKeyTrans[K_ESCAPE]	= KEY_ESCAPE;
+	vgui.virtualKeyTrans[K_INS] = KEY_INSERT;
+	vgui.virtualKeyTrans[K_DEL] = KEY_DELETE;
+	vgui.virtualKeyTrans[K_HOME] = KEY_HOME;
+	vgui.virtualKeyTrans[K_END] = KEY_END;
+	vgui.virtualKeyTrans[K_PGUP] = KEY_PAGEUP;
+	vgui.virtualKeyTrans[K_PGDN] = KEY_PAGEDOWN;
+	vgui.virtualKeyTrans[K_PAUSE] = KEY_BREAK;
+	vgui.virtualKeyTrans[K_SHIFT] = KEY_LSHIFT;	// SHIFT -> left SHIFT
+	vgui.virtualKeyTrans[K_ALT] = KEY_LALT;		// ALT -> left ALT
+	vgui.virtualKeyTrans[K_CTRL] = KEY_LCONTROL;	// CTRL -> left CTRL
+	vgui.virtualKeyTrans[K_WIN] = KEY_LWIN;
+	vgui.virtualKeyTrans[K_UPARROW] = KEY_UP;
+	vgui.virtualKeyTrans[K_LEFTARROW] = KEY_LEFT;
+	vgui.virtualKeyTrans[K_DOWNARROW] = KEY_DOWN;
+	vgui.virtualKeyTrans[K_RIGHTARROW] = KEY_RIGHT;
+	vgui.virtualKeyTrans[K_F1] = KEY_F1;
+	vgui.virtualKeyTrans[K_F2] = KEY_F2;
+	vgui.virtualKeyTrans[K_F3] = KEY_F3;
+	vgui.virtualKeyTrans[K_F4] = KEY_F4;
+	vgui.virtualKeyTrans[K_F5] = KEY_F5;
+	vgui.virtualKeyTrans[K_F6] = KEY_F6;
+	vgui.virtualKeyTrans[K_F7] = KEY_F7;
+	vgui.virtualKeyTrans[K_F8] = KEY_F8;
+	vgui.virtualKeyTrans[K_F9] = KEY_F9;
+	vgui.virtualKeyTrans[K_F10] = KEY_F10;
+	vgui.virtualKeyTrans[K_F11] = KEY_F11;
+	vgui.virtualKeyTrans[K_F12] = KEY_F12;
 }
 
-enum VGUI_KeyCode VGUI_MapKey( int keyCode )
+static enum VGUI_KeyCode VGUI_MapKey( int keyCode )
 {
 	VGUI_InitKeyTranslationTable();
 
-	if( keyCode < 0 || keyCode >= ARRAYSIZE( s_pVirtualKeyTrans ))
-	{
-		return (enum VGUI_KeyCode)-1;
-	}
-	else
-	{
-		return s_pVirtualKeyTrans[keyCode];
-	}
+	if( keyCode >= 0 && keyCode < ARRAYSIZE( vgui.virtualKeyTrans ))
+		return vgui.virtualKeyTrans[keyCode];
+
+	return (enum VGUI_KeyCode)-1;
 }
 
 void VGui_MouseEvent( int key, int clicks )
@@ -416,7 +366,7 @@ void VGui_MouseEvent( int key, int clicks )
 	enum VGUI_MouseAction mact;
 	enum VGUI_MouseCode   code;
 
-	if( !vgui.initialized )
+	if( !vgui.dllFuncs.Mouse )
 		return;
 
 	switch( key )
@@ -434,22 +384,22 @@ void VGui_MouseEvent( int key, int clicks )
 	else
 		mact = MA_RELEASED;
 
-	vgui.Mouse( mact, code );
+	vgui.dllFuncs.Mouse( mact, code );
 }
 
 void VGui_MWheelEvent( int y )
 {
-	if( !vgui.initialized )
+	if( !vgui.dllFuncs.Mouse )
 		return;
 
-	vgui.Mouse( MA_WHEEL, y );
+	vgui.dllFuncs.Mouse( MA_WHEEL, y );
 }
 
 void VGui_KeyEvent( int key, int down )
 {
 	enum VGUI_KeyCode code;
 
-	if( !vgui.initialized )
+	if( !vgui.dllFuncs.Key )
 		return;
 
 	if(( code = VGUI_MapKey( key )) < 0 )
@@ -457,47 +407,43 @@ void VGui_KeyEvent( int key, int down )
 
 	if( down )
 	{
-		vgui.Key( KA_PRESSED, code );
-		vgui.Key( KA_TYPED, code );
+		vgui.dllFuncs.Key( KA_PRESSED, code );
+		vgui.dllFuncs.Key( KA_TYPED, code );
 	}
-	else vgui.Key( KA_RELEASED, code );
+	else vgui.dllFuncs.Key( KA_RELEASED, code );
 }
 
 void VGui_MouseMove( int x, int y )
 {
-	if( vgui.initialized )
+	if( vgui.dllFuncs.MouseMove )
 	{
 		float xscale = (float)refState.width / (float)clgame.scrInfo.iWidth;
 		float yscale = (float)refState.height / (float)clgame.scrInfo.iHeight;
-		vgui.MouseMove( x / xscale, y / yscale );
+		vgui.dllFuncs.MouseMove( x / xscale, y / yscale );
 	}
 }
 
 void VGui_Paint( void )
 {
-	if( vgui.initialized )
-		vgui.Paint();
-}
-
-void VGui_RunFrame( void )
-{
-	//stub
+	if( vgui.dllFuncs.Paint )
+		vgui.dllFuncs.Paint();
 }
 
 void VGui_UpdateInternalCursorState( VGUI_DefaultCursor cursorType )
 {
-	s_currentCursor = cursorType;
+	vgui.cursor = cursorType;
 }
 
 void *GAME_EXPORT VGui_GetPanel( void )
 {
-	if( vgui.initialized )
-		return vgui.GetPanel();
+	if( vgui.dllFuncs.GetPanel )
+		return vgui.dllFuncs.GetPanel();
 	return NULL;
 }
 
 void VGui_ReportTextInput( const char *text )
 {
-	if ( vgui.initialized )
-		vgui.TextInput( text );
+	if( vgui.dllFuncs.TextInput )
+		vgui.dllFuncs.TextInput( text );
 }
+

--- a/engine/client/vgui/vgui_draw.h
+++ b/engine/client/vgui/vgui_draw.h
@@ -16,16 +16,12 @@ GNU General Public License for more details.
 #ifndef VGUI_DRAW_H
 #define VGUI_DRAW_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "port.h"
-
 //
 // vgui_draw.c
 //
-void VGui_Startup( const char *clientlib, int width, int height );
+void VGui_RegisterCvars( void );
+qboolean VGui_LoadProgs( HINSTANCE hInstance );
+void VGui_Startup( int width, int height );
 void VGui_Shutdown( void );
 void VGui_Paint( void );
 void VGui_RunFrame( void );
@@ -37,7 +33,5 @@ qboolean VGui_IsActive( void );
 void *VGui_GetPanel( void );
 void VGui_ReportTextInput( const char *text );
 void VGui_UpdateInternalCursorState( VGUI_DefaultCursor cursorType );
-#ifdef __cplusplus
-}
-#endif
-#endif//VGUI_DRAW_H
+
+#endif // VGUI_DRAW_H

--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -918,6 +918,11 @@ void FS_ParseGenericGameInfo( gameinfo_t *GameInfo, const char *buf, const qbool
 				pfile = COM_ParseFile( pfile, token, sizeof( token ));
 				GameInfo->render_picbutton_text = Q_atoi( token );
 			}
+			else if( !Q_stricmp( token, "internal_vgui_support" ))
+			{
+				pfile = COM_ParseFile( pfile, token, sizeof( token ));
+				GameInfo->internal_vgui_support = Q_atoi( token );
+			}
 		}
 	}
 

--- a/filesystem/filesystem.h
+++ b/filesystem/filesystem.h
@@ -76,10 +76,11 @@ typedef struct gameinfo_s
 	size_t		size;
 
 	int		gamemode;
-	qboolean		secure;		// prevent to console acess
-	qboolean		nomodels;		// don't let player to choose model (use player.mdl always)
-	qboolean		noskills;		// disable skill menu selection
-	qboolean		render_picbutton_text; // use font renderer to render WON buttons
+	qboolean	secure;		// prevent to console acess
+	qboolean	nomodels;		// don't let player to choose model (use player.mdl always)
+	qboolean	noskills;		// disable skill menu selection
+	qboolean	render_picbutton_text; // use font renderer to render WON buttons
+	qboolean	internal_vgui_support; // skip loading VGUI, pass ingame UI support API to client
 
 	char		sp_entity[32];	// e.g. info_player_start
 	char		mp_entity[32];	// e.g. info_player_deathmatch


### PR DESCRIPTION
VGUI part of #947 

This PR introduces new `internal_vgui_support` key in `gameinfo.txt` that signals the engine to skip loading VGUI until the client.dll is loaded.

Linking vgui_support code into client.dll makes sense if game developer want to replace VGUI by something else, or include a specific version of it. Like PrimeXT uses ImGUI now by re-using VGUI support APIs, and tf15-client statically links with OpenVGUI to have same interface across all platforms.

cc @SNMetamorph @Velaron 

also cc @kungfulon, we need to decide on VGUI startup sequence. VGUI1 cannot be loaded after client.dll. In mods, VGUI1 can be called in C++ constructors, before API was initialized. I placed a check in SCR_VidInit so VGUI1 won't get loaded here. 

