### PR TITLE
Player custom decals fixes #2

### DIFF
--- a/engine/client/cl_tent.c
+++ b/engine/client/cl_tent.c
@@ -2928,10 +2928,14 @@ void CL_PlayerDecal( int playernum, int customIndex, int entityIndex, float *pos
 		{
 			if( !pCust->nUserData1 )
 			{
-				qboolean updateSprayTexture;
+				int sprayTextureIndex;
 				const char *decalname = va( "player%dlogo%d", playernum, customIndex );
-				updateSprayTexture = ref.dllFuncs.GL_FindTexture( decalname ) != 0;
-				pCust->nUserData1 = ref.dllFuncs.GL_LoadTextureFromBuffer( decalname, pCust->pInfo, TF_DECAL, updateSprayTexture );
+				sprayTextureIndex = ref.dllFuncs.GL_FindTexture( decalname );
+				if( sprayTextureIndex != 0 )
+				{
+					ref.dllFuncs.GL_FreeTexture( sprayTextureIndex );
+				}
+				pCust->nUserData1 = GL_LoadTextureInternal( decalname, pCust->pInfo, TF_DECAL );
 			}
 			textureIndex = pCust->nUserData1;
 		}

--- a/engine/common/hpak.c
+++ b/engine/common/hpak.c
@@ -226,7 +226,7 @@ void HPAK_AddLump( qboolean bUseQueue, const char *name, resource_t *pResource, 
 	memset( &ctx, 0, sizeof( MD5Context_t ));
 	MD5Init( &ctx );
 
-	if( pData == NULL )
+	if( !pData )
 	{
 		byte		*temp;
 
@@ -327,9 +327,10 @@ void HPAK_AddLump( qboolean bUseQueue, const char *name, resource_t *pResource, 
 	dstpak.entries = Z_Malloc( sizeof( hpak_lump_t ) * dstpak.count );
 	memcpy( dstpak.entries, srcpak.entries, sizeof( hpak_lump_t ) * srcpak.count );
 
+	// check is there are entry with same hash
 	for( i = 0; i < srcpak.count; i++ )
 	{
-		if( memcmp( md5, srcpak.entries[i].resource.rgucMD5_hash, 16 ))
+		if( memcmp( md5, srcpak.entries[i].resource.rgucMD5_hash, 16 ) == 0 )
 		{
 			pCurrentEntry = &dstpak.entries[i];
 
@@ -347,8 +348,10 @@ void HPAK_AddLump( qboolean bUseQueue, const char *name, resource_t *pResource, 
 	pCurrentEntry->filepos = FS_Tell( file_dst );
 	pCurrentEntry->disksize = pResource->nDownloadSize;
 
-	if( !pData ) FS_FileCopy( file_dst, file_src, pCurrentEntry->disksize );
-	else FS_Write( file_dst, pData, pCurrentEntry->disksize );
+	if( !pData )
+		FS_FileCopy( file_dst, pFile, pCurrentEntry->disksize );
+	else
+		FS_Write( file_dst, pData, pCurrentEntry->disksize );
 
 	hash_pack_header.infotableofs = FS_Tell( file_dst );
 	FS_Write( file_dst, &dstpak.count, sizeof( dstpak.count ));


### PR DESCRIPTION
Now we can get rid of removing custom.hpk file in mainui, after changing player spray, because now it works as it should.