### PR TITLE
Directory entries caching for case-insensetive filesystem emulation

### DIFF
--- a/common/port.h
+++ b/common/port.h
@@ -19,6 +19,9 @@ GNU General Public License for more details.
 
 #include "build.h"
 
+#define PATH_SEPARATOR_NIX '/'
+#define PATH_SEPARATOR_WIN '\\'
+
 #if !XASH_WIN32
 	#if XASH_APPLE
 		#include <sys/syslimits.h>
@@ -41,14 +44,14 @@ GNU General Public License for more details.
 		#include <unistd.h>
 		#include <dlfcn.h>
 
-		#define PATH_SPLITTER "/"
+		#define PATH_SEPARATOR PATH_SEPARATOR_NIX
 		#define HAVE_DUP
 
 		#define O_BINARY    0
 		#define O_TEXT      0
 		#define _mkdir( x ) mkdir( x, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH )
 	#elif XASH_DOS4GW
-		#define PATH_SPLITTER "\\"
+		#define PATH_SEPARATOR PATH_SEPARATOR_WIN
 	#endif
 
 	typedef void* HANDLE;
@@ -59,7 +62,7 @@ GNU General Public License for more details.
 		int x, y;
 	} POINT;
 #else // WIN32
-	#define PATH_SPLITTER "\\"
+	#define PATH_SEPARATOR PATH_SEPARATOR_WIN
 	#ifdef __MINGW32__
 		#define _inline static inline
 		#define FORCEINLINE inline __attribute__((always_inline))
@@ -85,6 +88,12 @@ GNU General Public License for more details.
 
 #ifndef XASH_LOW_MEMORY
 #define XASH_LOW_MEMORY 0
+#endif
+
+#if PATH_SEPARATOR == PATH_SEPARATOR_WIN
+#define PATH_SEPARATOR_STR "\\"
+#else // PATH_SEPARATOR == PATH_SEPARATOR_NIX
+#define PATH_SEPARATOR_STR "/"
 #endif
 
 #include <stdlib.h>

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -1355,7 +1355,6 @@ void Host_FinalizeConfig( file_t *f, const char *config )
 	FS_Close( f );
 	FS_Delete( backup );
 	FS_Rename( config, backup );
-	FS_Delete( config );
 	FS_Rename( newcfg, config );
 }
 

--- a/filesystem/VFileSystem009.cpp
+++ b/filesystem/VFileSystem009.cpp
@@ -42,14 +42,14 @@ static inline qboolean IsIdGamedir( const char *id )
 		!Q_strcmp( id, "GAMEDOWNLOAD" );
 }
 
-static inline const char* IdToDir( const char *id )
+static inline const char *IdToDir( const char *id )
 {
 	if( !Q_strcmp( id, "GAME" ))
 		return GI->gamefolder;
 	else if( !Q_strcmp( id, "GAMEDOWNLOAD" ))
 		return va( "%s/downloaded", GI->gamefolder );
 	else if( !Q_strcmp( id, "GAMECONFIG" ))
-		return fs_writedir; // full path here so it's totally our write allowed directory
+		return fs_writepath->filename; // full path here so it's totally our write allowed directory
 	else if( !Q_strcmp( id, "PLATFORM" ))
 		return "platform"; // stub
 	else if( !Q_strcmp( id, "CONFIG" ))

--- a/filesystem/dir.c
+++ b/filesystem/dir.c
@@ -164,8 +164,8 @@ static void FS_MergeDirEntries( dir_t *dir, const stringlist_t *list )
 		}
 
 		// found directory, move all entries
-		temp.entries[j].numentries = dir->entries[j].numentries;
-		temp.entries[j].entries = dir->entries[j].entries;
+		temp.entries[j].numentries = dir->entries[i].numentries;
+		temp.entries[j].entries = dir->entries[i].entries;
 	}
 
 	// now we can free old tree and replace it with temporary

--- a/filesystem/dir.c
+++ b/filesystem/dir.c
@@ -234,6 +234,7 @@ qboolean FS_FixFileCase( dir_t *dir, const char *path, char *dst, size_t len, qb
 				Con_Printf( "%s: overflow while searching %s (caseinsensitive entry)\n", __FUNCTION__, path );
 				return false;
 			}
+			break;
 		}
 
 		// populate cache if needed

--- a/filesystem/dir.c
+++ b/filesystem/dir.c
@@ -1,5 +1,5 @@
 /*
-dir.c - directory operations
+dir.c - caseinsensitive directory operations
 Copyright (C) 2022 Alibek Omarov, Velaron
 
 This program is free software: you can redistribute it and/or modify
@@ -27,9 +27,309 @@ GNU General Public License for more details.
 #include "xash3d_mathlib.h"
 #include "common/com_strings.h"
 
+enum
+{
+	DIRENTRY_EMPTY_DIRECTORY = 0, // don't care if it's not directory or it's empty
+	DIRENTRY_NOT_SCANNED = -1,
+	DIRENTRY_CASEINSENSITIVE = -2, // directory is already caseinsensitive, just copy whatever is left
+};
+
+typedef struct dir_s
+{
+	string name;
+	int numentries;
+	struct dir_s *entries; // sorted
+} dir_t;
+
+static int FS_SortDir( const void *_a, const void *_b )
+{
+	const dir_t *a = _a;
+	const dir_t *b = _b;
+	return Q_stricmp( a->name, b->name );
+}
+
+static void FS_FreeDirEntries( dir_t *dir )
+{
+	if( dir->entries )
+	{
+		int i;
+		for( i = 0; i < dir->numentries; i++ )
+			FS_FreeDirEntries( &dir->entries[i] );
+		dir->entries = NULL;
+	}
+
+	dir->numentries = DIRENTRY_NOT_SCANNED;
+}
+
+static void FS_InitDirEntries( dir_t *dir, const stringlist_t *list )
+{
+	int i;
+
+	if( !list->numstrings )
+	{
+		dir->numentries = DIRENTRY_EMPTY_DIRECTORY;
+		dir->entries = NULL;
+		return;
+	}
+
+	dir->numentries = list->numstrings;
+	dir->entries = Mem_Malloc( fs_mempool, sizeof( dir_t ) * dir->numentries );
+
+	for( i = 0; i < list->numstrings; i++ )
+	{
+		dir_t *entry = &dir->entries[i];
+		Q_strncpy( entry->name, list->strings[i], sizeof( entry->name ));
+		entry->numentries = DIRENTRY_NOT_SCANNED;
+		entry->entries = NULL;
+	}
+
+	qsort( dir->entries, dir->numentries, sizeof( dir->entries[0] ), FS_SortDir );
+}
+
+static void FS_PopulateDirEntries( dir_t *dir, const char *path )
+{
+#if XASH_WIN32 // Windows is always case insensitive
+	dir->numentries = DIRENTRY_CASEINSENSITIVE;
+	dir->entries = NULL;
+#else
+	stringlist_t list;
+
+	if( !FS_SysFolderExists( path ))
+	{
+		dir->numentries = DIRENTRY_EMPTY_DIRECTORY;
+		dir->entries = NULL;
+		return;
+	}
+
+	stringlistinit( &list );
+	listdirectory( &list, path, false );
+	FS_InitDirEntries( dir, &list );
+	stringlistfreecontents( &list );
+#endif
+}
+
+static int FS_FindDirEntry( dir_t *dir, const char *name )
+{
+	int left, right;
+
+	if( dir->numentries < 0 )
+		return -1;
+
+	// look for the file (binary search)
+	left = 0;
+	right = dir->numentries - 1;
+	while( left <= right )
+	{
+		int   middle = (left + right) / 2;
+		int	diff;
+
+		diff = Q_stricmp( dir->entries[middle].name, name );
+
+		// found it
+		if( !diff )
+			return middle;
+
+		// if we're too far in the list
+		if( diff > 0 )
+			right = middle - 1;
+		else left = middle + 1;
+	}
+	return -1;
+}
+
+static void FS_MergeDirEntries( dir_t *dir, const stringlist_t *list )
+{
+	int i;
+	dir_t temp;
+
+	FS_InitDirEntries( &temp, list );
+
+	// copy all entries that has the same name and has subentries
+	for( i = 0; i < dir->numentries; i++ )
+	{
+		int j;
+
+		// don't care about directories without subentries
+		if( dir->entries == NULL )
+			continue;
+
+		// try to find this directory in new tree
+		j = FS_FindDirEntry( &temp, dir->entries[i].name );
+
+		// not found, free memory
+		if( j < 0 )
+		{
+			FS_FreeDirEntries( &dir->entries[i] );
+			continue;
+		}
+
+		// found directory, move all entries
+		temp.entries[j].numentries = dir->entries[j].numentries;
+		temp.entries[j].entries = dir->entries[j].entries;
+	}
+
+	// now we can free old tree and replace it with temporary
+	Mem_Free( dir->entries );
+	dir->numentries = temp.numentries;
+	dir->entries = temp.entries;
+}
+
+static int FS_MaybeUpdateDirEntries( dir_t *dir, const char *path, const char *entryname )
+{
+	stringlist_t list;
+	qboolean update = false;
+	int idx;
+
+	stringlistinit( &list );
+	listdirectory( &list, path, false );
+
+	// find the reason to update entries list
+	if( list.numstrings != dir->numentries )
+	{
+		// small optimization to not search string in the list
+		// and directly go updating entries
+		update = true;
+	}
+	else
+	{
+		for( idx = 0; idx < list.numstrings; idx++ )
+		{
+			if( !Q_stricmp( list.strings[idx], entryname ))
+			{
+				update = true;
+				break;
+			}
+		}
+	}
+
+	if( !update )
+	{
+		stringlistfreecontents( &list );
+		return -1;
+	}
+
+	FS_MergeDirEntries( dir, &list );
+	stringlistfreecontents( &list );
+	return FS_FindDirEntry( dir, entryname );
+}
+
+qboolean FS_FixFileCase( dir_t *dir, const char *path, char *dst, size_t len, qboolean createpath )
+{
+	const char *prev = path;
+	const char *next = Q_strchrnul( prev, PATH_SEPARATOR );
+	size_t i = Q_strlen( dst ); // dst is expected to have searchpath filename
+
+	while( true )
+	{
+		char entryname[MAX_SYSPATH];
+		int ret;
+
+		// this subdirectory is case insensitive, just slam everything that's left
+		if( dir->numentries == DIRENTRY_CASEINSENSITIVE )
+		{
+			i += Q_strncpy( &dst[i], prev, len - i );
+			if( i >= len )
+			{
+				Con_Printf( "%s: overflow while searching %s (caseinsensitive entry)\n", __FUNCTION__, path );
+				return false;
+			}
+		}
+
+		// populate cache if needed
+		if( dir->numentries == DIRENTRY_NOT_SCANNED )
+			FS_PopulateDirEntries( dir, dst );
+
+		// get our entry name
+		Q_strncpy( entryname, prev, next - prev + 1 );
+		ret = FS_FindDirEntry( dir, entryname );
+
+		// didn't found, but does it exists in FS?
+		if( ret < 0 )
+		{
+			ret = FS_MaybeUpdateDirEntries( dir, dst, entryname );
+
+			if( ret < 0 )
+			{
+				// if we're creating files or folders, we don't care if path doesn't exist
+				// so copy everything that's left and exit without an error
+				if( createpath )
+				{
+					i += Q_strncpy( &dst[i], prev, len - i );
+					if( i >= len )
+					{
+						Con_Printf( "%s: overflow while searching %s (create path)\n", __FUNCTION__, path );
+						return false;
+					}
+
+					return true;
+				}
+				return false;
+			}
+		}
+
+		dir = &dir->entries[ret];
+		ret = Q_strncpy( &dst[i], dir->name, len - i );
+
+		// file not found, rescan...
+		if( !FS_SysFileOrFolderExists( dst ))
+		{
+			// strip failed part
+			dst[i] = 0;
+
+			ret = FS_MaybeUpdateDirEntries( dir, dst, entryname );
+
+			// file not found, exit... =/
+			if( ret < 0 )
+			{
+				// if we're creating files or folders, we don't care if path doesn't exist
+				// so copy everything that's left and exit without an error
+				if( createpath )
+				{
+					i += Q_strncpy( &dst[i], prev, len - i );
+					if( i >= len )
+					{
+						Con_Printf( "%s: overflow while searching %s (create path 2)\n", __FUNCTION__, path );
+						return false;
+					}
+
+					return true;
+				}
+				return false;
+			}
+
+			dir = &dir->entries[ret];
+			ret = Q_strncpy( &dst[i], dir->name, len - i );
+		}
+
+		i += ret;
+		if( i >= len ) // overflow!
+		{
+			Con_Printf( "%s: overflow while searching %s (appending fixed file name)\n", __FUNCTION__, path );
+			return false;
+		}
+
+		// end of string, found file, return
+		if( next[0] == '\0' )
+			break;
+
+		// move pointer one character forward, find next path split character
+		prev = next + 1;
+		next = Q_strchrnul( prev, PATH_SEPARATOR );
+		i += Q_strncpy( &dst[i], PATH_SEPARATOR_STR, len - i );
+		if( i >= len ) // overflow!
+		{
+			Con_Printf( "%s: overflow while searching %s (path separator)\n", __FUNCTION__, path );
+			return false;
+		}
+	}
+
+	return true;
+}
+
 static void FS_Close_DIR( searchpath_t *search )
 {
-
+	FS_FreeDirEntries( search->dir );
+	Mem_Free( search->dir );
 }
 
 static void FS_PrintInfo_DIR( searchpath_t *search, char *dst, size_t size )
@@ -37,14 +337,21 @@ static void FS_PrintInfo_DIR( searchpath_t *search, char *dst, size_t size )
 	Q_strncpy( dst, search->filename, size );
 }
 
-static int FS_FindFile_DIR( searchpath_t *search, const char *path )
+static int FS_FindFile_DIR( searchpath_t *search, const char *path, char *fixedname, size_t len )
 {
 	char netpath[MAX_SYSPATH];
 
-	Q_snprintf( netpath, sizeof( netpath ), "%s%s", search->filename, path );
+	Q_strncpy( netpath, search->filename, sizeof( netpath ));
+	if( !FS_FixFileCase( search->dir, path, netpath, sizeof( netpath ), false ))
+		return -1;
 
-	if( FS_SysFileExists( netpath, !( search->flags & FS_CUSTOM_PATH ) ) )
+	if( FS_SysFileExists( netpath, !FBitSet( search->flags, FS_CUSTOM_PATH )))
+	{
+		// return fixed case file name only local for that searchpath
+		if( fixedname )
+			Q_strncpy( fixedname, netpath + Q_strlen( search->filename ), len );
 		return 0;
+	}
 
 	return -1;
 }
@@ -63,7 +370,7 @@ static void FS_Search_DIR( searchpath_t *search, stringlist_t *list, const char 
 
 	separator = Q_max( slash, backslash );
 	separator = Q_max( separator, colon );
-	
+
 	basepathlength = separator ? (separator + 1 - pattern) : 0;
 	basepath = Mem_Calloc( fs_mempool, basepathlength + 1 );
 	if( basepathlength ) memcpy( basepath, pattern, basepathlength );
@@ -100,6 +407,7 @@ static void FS_Search_DIR( searchpath_t *search, stringlist_t *list, const char 
 
 static int FS_FileTime_DIR( searchpath_t *search, const char *filename )
 {
+	int time;
 	char path[MAX_SYSPATH];
 
 	Q_snprintf( path, sizeof( path ), "%s%s", search->filename, filename );
@@ -127,9 +435,14 @@ void FS_InitDirectorySearchpath( searchpath_t *search, const char *path, int fla
 	search->pfnFileTime = FS_FileTime_DIR;
 	search->pfnFindFile = FS_FindFile_DIR;
 	search->pfnSearch = FS_Search_DIR;
+
+	// create cache root
+	search->dir = Mem_Malloc( fs_mempool, sizeof( dir_t ));
+	search->dir->name[0] = 0; // root has no filename, unused
+	FS_PopulateDirEntries( search->dir, path );
 }
 
-qboolean FS_AddDir_Fullpath( const char *path, qboolean *already_loaded, int flags )
+searchpath_t *FS_AddDir_Fullpath( const char *path, qboolean *already_loaded, int flags )
 {
 	searchpath_t *search;
 
@@ -139,7 +452,7 @@ qboolean FS_AddDir_Fullpath( const char *path, qboolean *already_loaded, int fla
 		{
 			if( already_loaded )
 				*already_loaded = true;
-			return true;
+			return search;
 		}
 	}
 
@@ -154,5 +467,5 @@ qboolean FS_AddDir_Fullpath( const char *path, qboolean *already_loaded, int fla
 
 	Con_Printf( "Adding directory: %s\n", path );
 
-	return true;
+	return search;
 }

--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -2731,7 +2731,7 @@ fs_api_t g_api =
 
 int EXPORT GetFSAPI( int version, fs_api_t *api, fs_globals_t **globals, fs_interface_t *engfuncs )
 {
-	if( !FS_InitInterface( version, engfuncs ))
+	if( engfuncs && !FS_InitInterface( version, engfuncs ))
 		return 0;
 
 	memcpy( api, &g_api, sizeof( *api ));

--- a/filesystem/filesystem_internal.h
+++ b/filesystem/filesystem_internal.h
@@ -70,7 +70,7 @@ typedef struct searchpath_s
 	string  filename;
 	int     type;
 	int     flags;
-	
+
 	union
 	{
 		dir_t   *dir;
@@ -91,12 +91,12 @@ typedef struct searchpath_s
 
 extern fs_globals_t  FI;
 extern searchpath_t *fs_searchpaths;
+extern searchpath_t *fs_writepath;
 extern poolhandle_t  fs_mempool;
 extern fs_interface_t g_engfuncs;
 extern qboolean      fs_ext_path;
 extern char          fs_rodir[MAX_SYSPATH];
 extern char          fs_rootdir[MAX_SYSPATH];
-extern char          fs_writedir[MAX_SYSPATH];
 extern fs_api_t      g_api;
 
 #define GI FI.GameInfo
@@ -164,7 +164,7 @@ void stringlistinit( stringlist_t *list );
 void stringlistfreecontents( stringlist_t *list );
 void stringlistappend( stringlist_t *list, char *text );
 void stringlistsort( stringlist_t *list );
-void listdirectory( stringlist_t *list, const char *path, qboolean lowercase );
+void listdirectory( stringlist_t *list, const char *path );
 
 // filesystem ops
 int FS_FileExists( const char *filename, int gamedironly );
@@ -212,6 +212,7 @@ qboolean FS_AddZip_Fullpath( const char *zipfile, qboolean *already_loaded, int 
 // dir.c
 //
 searchpath_t *FS_AddDir_Fullpath( const char *path, qboolean *already_loaded, int flags );
+qboolean FS_FixFileCase( dir_t *dir, const char *path, char *dst, const size_t len, qboolean createpath );
 void FS_InitDirectorySearchpath( searchpath_t *search, const char *path, int flags );
 
 #ifdef __cplusplus

--- a/filesystem/tests/caseinsensitive.c
+++ b/filesystem/tests/caseinsensitive.c
@@ -1,0 +1,122 @@
+#include "port.h"
+#include "build.h"
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "filesystem.h"
+#if XASH_POSIX
+#include <dlfcn.h>
+#define LoadLibrary( x ) dlopen( x, RTLD_NOW )
+#define GetProcAddress( x, y ) dlsym( x, y )
+#define FreeLibrary( x ) dlclose( x )
+#elif XASH_WIN32
+#include <windows.h>
+#endif
+
+void *g_hModule;
+FSAPI g_pfnGetFSAPI;
+fs_api_t g_fs;
+fs_globals_t *g_nullglobals;
+
+
+static qboolean LoadFilesystem( void )
+{
+	g_hModule = LoadLibrary( "filesystem_stdio." OS_LIB_EXT );
+	if( !g_hModule )
+		return false;
+
+	g_pfnGetFSAPI = (void*)GetProcAddress( g_hModule, GET_FS_API );
+	if( !g_pfnGetFSAPI )
+		return false;
+
+	if( !g_pfnGetFSAPI( FS_API_VERSION, &g_fs, &g_nullglobals, NULL ))
+		return false;
+
+	return true;
+}
+
+static qboolean CheckFileContents( const char *path, const void *buf, fs_offset_t size )
+{
+	fs_offset_t len;
+	byte *data;
+
+	data = g_fs.LoadFile( path, &len, true );
+	if( !data )
+	{
+		printf( "LoadFile fail\n" );
+		return false;
+	}
+
+	if( len != size )
+	{
+		printf( "LoadFile sizeof fail\n" );
+		free( data );
+		return false;
+	}
+
+	if( memcmp( data, buf, size ))
+	{
+		printf( "LoadFile magic fail\n" );
+		free( data );
+		return false;
+	}
+
+	free( data );
+	return true;
+}
+
+static qboolean TestCaseinsensitive( void )
+{
+	file_t *f1;
+	FILE *f2;
+	int magic = rand();
+
+	// create game dir for us
+	g_fs.AddGameDirectory( "./", FS_GAMEDIR_PATH );
+
+	// create some files first and write data
+	f1 = g_fs.Open( "FOO/Bar.bin", "wb", true );
+	g_fs.Write( f1, &magic, sizeof( magic ));
+	g_fs.Close( f1 );
+
+	// try to search it with different file name
+	if( !g_fs.FileExists( "fOO/baR.bin", true ))
+	{
+		printf( "FileExists fail\n" );
+		return false;
+	}
+
+	// create a file directly, to check if cache can re-read
+	f2 = fopen( "FOO/Baz.bin", "wb" );
+	fwrite( &magic, sizeof( magic ), 1, f2 );
+	fclose( f2 );
+
+	// try to open first file back but with different file name case
+	if( !CheckFileContents( "foo/bar.BIN", &magic, sizeof( magic )))
+		return false;
+
+	// try to open second file that we created directly
+	if( !CheckFileContents( "Foo/BaZ.Bin", &magic, sizeof( magic )))
+		return false;
+
+	g_fs.Delete( "foo/Baz.biN" );
+	g_fs.Delete( "foo/bar.bin" );
+	g_fs.Delete( "Foo" );
+
+	return true;
+}
+
+int main( void )
+{
+	if( !LoadFilesystem() )
+		return EXIT_FAILURE;
+
+	srand( time( NULL ));
+
+	if( !TestCaseinsensitive())
+		return EXIT_FAILURE;
+
+	printf( "success\n" );
+
+	return EXIT_SUCCESS;
+}

--- a/filesystem/wad.c
+++ b/filesystem/wad.c
@@ -299,10 +299,6 @@ static wfile_t *W_Open( const char *filename, int *error )
 
 	wad->handle = FS_Open( basename, "rb", false );
 
-	// HACKHACK: try to open WAD by full path for RoDir, when searchpaths are not ready
-	if( COM_CheckStringEmpty( fs_rodir ) && fs_ext_path && wad->handle == NULL )
-		wad->handle = FS_SysOpen( filename, "rb" );
-
 	if( wad->handle == NULL )
 	{
 		Con_Reportf( S_ERROR "W_Open: couldn't open %s\n", filename );
@@ -430,7 +426,7 @@ FS_FindFile_WAD
 
 ===========
 */
-static int FS_FindFile_WAD( searchpath_t *search, const char *path )
+static int FS_FindFile_WAD( searchpath_t *search, const char *path, char *fixedname, size_t len )
 {
 	dlumpinfo_t	*lump;
 	signed char		type = W_TypeFromExt( path );
@@ -469,6 +465,8 @@ static int FS_FindFile_WAD( searchpath_t *search, const char *path )
 
 	if( lump )
 	{
+		if( fixedname )
+			Q_strncpy( fixedname, lump->name, len );
 		return lump - search->wad->lumps;
 	}
 
@@ -677,7 +675,7 @@ byte *FS_LoadWADFile( const char *path, fs_offset_t *lumpsizeptr, qboolean gamed
 	searchpath_t	*search;
 	int		index;
 
-	search = FS_FindFile( path, &index, gamedironly );
+	search = FS_FindFile( path, &index, NULL, 0, gamedironly );
 	if( search && search->type == SEARCHPATH_WAD )
 		return W_ReadLump( search->wad, &search->wad->lumps[index], lumpsizeptr );
 	return NULL;

--- a/filesystem/wscript
+++ b/filesystem/wscript
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
+from waflib.Tools import waf_unit_test
+
 def options(opt):
-	pass
+	grp = opt.add_option_group('filesystem_stdio options')
+
+	grp.add_option('--enable-fs-tests', action='store_true', dest = 'FS_TESTS', default = False,
+		help = 'enable filesystem_stdio tests')
 
 def configure(conf):
 	nortti = {
@@ -9,6 +14,8 @@ def configure(conf):
 		'default': ['-fno-rtti', '-fno-exceptions']
 	}
 	conf.env.append_unique('CXXFLAGS', conf.get_flags_by_compiler(nortti, conf.env.COMPILER_CC))
+
+	conf.env.FS_TESTS = conf.options.FS_TESTS
 
 	if conf.env.DEST_OS != 'android':
 		if conf.env.cxxshlib_PATTERN.startswith('lib'):
@@ -22,3 +29,16 @@ def build(bld):
 		use = 'filesystem_includes public',
 		install_path = bld.env.LIBDIR,
 		subsystem = bld.env.MSVC_SUBSYSTEM)
+
+	if bld.env.FS_TESTS:
+		# build in same module, so dynamic linking will work
+		# for now (until we turn libpublic to shared module lol)
+		bld.program(features = 'test',
+			source = 'tests/caseinsensitive.c',
+			target = 'test_caseinsensitive',
+			use = 'filesystem_includes public DL',
+			rpath = '$ORIGIN',
+			subsystem = bld.env.CONSOLE_SUBSYSTEM,
+			install_path = None)
+		bld.add_post_fun(waf_unit_test.summary)
+		bld.add_post_fun(waf_unit_test.set_exit_code)

--- a/filesystem/zip.c
+++ b/filesystem/zip.c
@@ -202,15 +202,6 @@ static zip_t *FS_LoadZip( const char *zipfile, int *error )
 
 	zip->handle = open( zipfile, O_RDONLY|O_BINARY );
 
-#if !XASH_WIN32
-	if( zip->handle < 0 )
-	{
-		const char *fzipfile = FS_FixFileCase( zipfile );
-		if( fzipfile != zipfile )
-			zip->handle = open( fzipfile, O_RDONLY|O_BINARY );
-	}
-#endif
-
 	if( zip->handle < 0 )
 	{
 		Con_Reportf( S_ERROR "%s couldn't open\n", zipfile );
@@ -439,7 +430,7 @@ byte *FS_LoadZIPFile( const char *path, fs_offset_t *sizeptr, qboolean gamediron
 
 	if( sizeptr ) *sizeptr = 0;
 
-	search = FS_FindFile( path, &index, gamedironly );
+	search = FS_FindFile( path, &index, NULL, 0, gamedironly );
 
 	if( !search || search->type != SEARCHPATH_ZIP )
 		return  NULL;
@@ -593,7 +584,7 @@ FS_FindFile_ZIP
 
 ===========
 */
-int FS_FindFile_ZIP( searchpath_t *search, const char *path )
+int FS_FindFile_ZIP( searchpath_t *search, const char *path, char *fixedname, size_t len )
 {
 	int	left, right, middle;
 
@@ -609,7 +600,11 @@ int FS_FindFile_ZIP( searchpath_t *search, const char *path )
 
 		// Found it
 		if( !diff )
+		{
+			if( fixedname )
+				Q_strncpy( fixedname, search->zip->files[middle].name, len );
 			return middle;
+		}
 
 		// if we're too far in the list
 		if( diff > 0 )

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -824,8 +824,8 @@ void COM_FixSlashes( char *pname )
 {
 	while( *pname )
 	{
-		if( *pname == '\\' )
-			*pname = '/';
+		if( *pname == PATH_SEPARATOR_WIN )
+			*pname = PATH_SEPARATOR_NIX;
 		pname++;
 	}
 }

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -496,22 +496,6 @@ int Q_sprintf( char *buffer, const char *format, ... )
 	return result;
 }
 
-char *Q_strpbrk(const char *s, const char *accept)
-{
-	for( ; *s; s++ )
-	{
-		const char *k;
-
-		for( k = accept; *k; k++ )
-		{
-			if( *s == *k )
-				return (char*)s;
-		}
-	}
-
-	return NULL;
-}
-
 void COM_StripColors( const char *in, char *out )
 {
 	while ( *in )

--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -83,7 +83,7 @@ const char *Q_timestamp( int format );
 int Q_vsnprintf( char *buffer, size_t buffersize, const char *format, va_list args );
 int Q_snprintf( char *buffer, size_t buffersize, const char *format, ... ) _format( 3 );
 int Q_sprintf( char *buffer, const char *format, ... ) _format( 2 );
-char *Q_strpbrk(const char *s, const char *accept);
+#define Q_strpbrk strpbrk
 void COM_StripColors( const char *in, char *out );
 #define Q_memprint( val ) Q_pretifymem( val, 2 )
 char *Q_pretifymem( float value, int digitsafterdecimal );
@@ -160,6 +160,20 @@ static inline char *Q_stristr( const char *s1, const char *s2 )
 #else // defined( HAVE_STRCASESTR )
 char *Q_stristr( const char *s1, const char *s2 );
 #endif // defined( HAVE_STRCASESTR )
+
+#if defined( HAVE_STRCHRNUL )
+#define Q_strchrnul strchrnul
+#else
+static inline const char *Q_strchrnul( const char *s, int c )
+{
+	const char *p = Q_strchr( s, c );
+
+	if( p )
+		return p;
+
+	return s + Q_strlen( s );
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/scripts/cirrus/build_freebsd.sh
+++ b/scripts/cirrus/build_freebsd.sh
@@ -14,9 +14,9 @@ build_engine()
 	cd "$CIRRUS_WORKING_DIR" || die
 
 	if [ "$APP" = "xashds" ]; then
-		./waf configure -T release -d || die
+		./waf configure -T release -d --enable-fs-tests || die
 	elif [ "$APP" = "xash3d-fwgs" ]; then
-		./waf configure -T release --enable-stb --enable-utils --enable-gl4es --enable-gles1 --enable-gles2 || die
+		./waf configure -T release --enable-stb --enable-utils --enable-gl4es --enable-gles1 --enable-gles2 --enable-fs-tests || die
 	else
 		die
 	fi

--- a/scripts/gha/build_linux.sh
+++ b/scripts/gha/build_linux.sh
@@ -50,9 +50,9 @@ build_engine()
 	fi
 
 	if [ "$1" = "dedicated" ]; then
-		./waf configure -T release -d $AMD64 || die
+		./waf configure -T release -d $AMD64 --enable-fs-tests || die
 	elif [ "$1" = "full" ]; then
-		./waf configure --sdl2=SDL2_linux -T release --enable-stb $AMD64 --enable-utils || die
+		./waf configure --sdl2=SDL2_linux -T release --enable-stb $AMD64 --enable-utils --enable-fs-tests || die
 	else
 		die
 	fi

--- a/scripts/gha/build_win32.sh
+++ b/scripts/gha/build_win32.sh
@@ -11,7 +11,7 @@ fi
 
 # NOTE: to build with other version use --msvc_version during configuration
 # NOTE: sometimes you may need to add WinSDK to %PATH%
-./waf.bat configure -s "SDL2_VC" -T "release" --enable-utils --prefix=`pwd` $AMD64 || die
+./waf.bat configure -s "SDL2_VC" -T "release" --enable-utils --enable-fs-tests --prefix=`pwd` $AMD64 || die
 ./waf.bat build -v || die
 ./waf.bat install || die
 


### PR DESCRIPTION
Completely replaces old FixFileCase hack, and sits on top of DIR searchpaths, only kicking in where we really need it.

Also has very minor optimizations that's not specific for this branch.

Preliminary benchmarks results (on Black Ops Redux mod):
|Runs (naive) | time to first frame | level load | client connect 
|-----|---------------------|------------|---------------
|1 | 0.671 | 0.28 | 0.21
|2|0.667|0.27|0.22
|3|0.664|0.28|0.22
|4|0.836|0.28|0.23
|5|0.636|0.30|0.21

|Runs (cache) | time to first frame | level load | client connect 
|-----|---------------------|------------|---------------
|1 | 0.639 | 0.22 | 0.16
|2|0.637|0.21|0.16
|3|0.648|0.23|0.15
|4|0.629|0.22|0.16
|5|0.628|0.22|0.16

On master branch this mod doesn't even load :)

TODO:
- [x] Fix file case for CreatePath
- [ ] Unicode file names matching?..
- [x] Tests

Fixes #883, #755