### PR TITLE
Preliminary support for SGI IRIX

### DIFF
--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -4,6 +4,10 @@
 
 #include "build.h"
 
+#if XASH_IRIX
+#include <port.h>
+#endif
+
 #if XASH_WIN32
 #include <wchar.h> // off_t
 #endif // _WIN32
@@ -120,7 +124,7 @@ typedef uint64_t longtime_t;
 #define LittleLongSW(x) (x = LittleLong(x) )
 #define LittleShort(x) ((short)( (((short)(x) >> 8) & 255) + (((short)(x) & 255) << 8)))
 #define LittleShortSW(x) (x = LittleShort(x) )
-static inline float LittleFloat( float f )
+_inline float LittleFloat( float f )
 {
 	union
 	{

--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -120,7 +120,7 @@ typedef uint64_t longtime_t;
 #define LittleLongSW(x) (x = LittleLong(x) )
 #define LittleShort(x) ((short)( (((short)(x) >> 8) & 255) + (((short)(x) & 255) << 8)))
 #define LittleShortSW(x) (x = LittleShort(x) )
-_inline float LittleFloat( float f )
+static inline float LittleFloat( float f )
 {
 	union
 	{

--- a/engine/common/sys_con.c
+++ b/engine/common/sys_con.c
@@ -22,6 +22,9 @@ GNU General Public License for more details.
 #endif
 #include <string.h>
 #include <errno.h>
+#if XASH_IRIX
+#include <sys/time.h>
+#endif
 
 // do not waste precious CPU cycles on mobiles or low memory devices
 #if !XASH_WIN32 && !XASH_MOBILE_PLATFORM && !XASH_LOW_MEMORY

--- a/engine/common/whereami.c
+++ b/engine/common/whereami.c
@@ -795,6 +795,33 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
   return length;
 }
 
+#elif defined(__sgi)
+
+/* 
+ * These functions are stubbed for now to get the code compiling.
+ * In the future it may be possible to get these working in some way.
+ * Current ideas are checking the working directory for a binary with
+ * the same executed name and reading links, or worst case just searching
+ * through the entirety of the filesystem that's readable by the user.
+ *
+ * I'm not sure it's actually possible to find the absolute path via a
+ * direct method on IRIX. Its implementation of /proc is a fairly barebones
+ * SVR4 implementation. Other UNIXes (e.g. Solaris) have extensions to /proc
+ * that make finding the absolute path possible but these don't exist on IRIX.
+ */
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+	return -1;
+}
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+	return -1;
+}
+
 #else
 
 #error unsupported platform

--- a/engine/platform/irix/dladdr.c
+++ b/engine/platform/irix/dladdr.c
@@ -1,0 +1,26 @@
+/*
+ * From SGI IRIX's 'man dladdr'
+ *
+ * <dlfcn.h> does not contain a prototype for dladdr or definition of
+ * Dl_info. The #include <dlfcn.h> in the SYNOPSIS line is traditional,
+ * but contains no dladdr prototype and no IRIX library contains an
+ * implementation. Write your own declaration based on the code below.
+ *
+ * The following code is dependent on internal interfaces that are not
+ * part of the IRIX compatibility guarantee; however, there is no future
+ * intention to change this interface, so on a practical level, the code
+ * below is safe to use on IRIX.
+ *
+ * 
+ *
+ * The following code has been reproduced from the manpage.
+ */ 
+
+#include "dladdr.h"
+
+int dladdr(void *address, Dl_info* dl)
+{
+	void *v;
+	v = _rld_new_interface(_RLD_DLADDR, address, dl);
+	return (int)v;
+}

--- a/engine/platform/irix/dladdr.c
+++ b/engine/platform/irix/dladdr.c
@@ -1,4 +1,17 @@
 /*
+dladdr.c - dladdr implementation for SGI IRIX
+Copyright (C) 2022 Xav101
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*/
+
+/*
  * From SGI IRIX's 'man dladdr'
  *
  * <dlfcn.h> does not contain a prototype for dladdr or definition of

--- a/engine/platform/irix/dladdr.h
+++ b/engine/platform/irix/dladdr.h
@@ -1,3 +1,18 @@
+/*
+dladdr.h - dladdr prototypes for SGI IRIX
+Copyright (C) 2022 Xav101
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*/
+
+/* See engine/platform/irix/dladdr.c for the requirement for this implementation */
+
 #ifndef DLADDR_IRIX_H
 #define DLADDR_IRIX_H
 

--- a/engine/platform/irix/dladdr.h
+++ b/engine/platform/irix/dladdr.h
@@ -1,0 +1,20 @@
+#ifndef DLADDR_IRIX_H
+#define DLADDR_IRIX_H
+
+#include <rld_interface.h>
+#ifndef _RLD_INTERFACE_DLFCN_H_DLADDR
+#define _RLD_INTERFACE_DLFCN_H_DLADDR
+typedef struct Dl_info {
+	const char * dli_fname;
+	void       * dli_fbase;
+	const char * dli_saddr;
+	int          dli_version;
+	int          dli_reserved1;
+	long         dli_reserved[4];
+} Dl_info;
+#endif
+#define _RLD_DLADDR 14
+
+int dladdr(void *address, Dl_info* dl);
+
+#endif

--- a/engine/platform/irix/xash-exec
+++ b/engine/platform/irix/xash-exec
@@ -1,0 +1,9 @@
+#!/usr/sgug/bin/bash
+
+# Build path
+export LD_LIBRARYN32_PATH=$PWD/filesystem:$LD_LIBRARYN32_PATH
+
+# Install path
+export LD_LIBRARYN32_PATH=$PWD:$LD_LIBRARYN32_PATH
+
+exec $PWD/build/engine/xash

--- a/engine/platform/posix/lib_posix.c
+++ b/engine/platform/posix/lib_posix.c
@@ -17,7 +17,6 @@ GNU General Public License for more details.
 #if XASH_LIB == LIB_POSIX
 #include <dlfcn.h>
 #ifdef XASH_IRIX
-#pragma message "Included"
 #include "platform/irix/dladdr.h"
 #endif
 #include "common.h"

--- a/engine/platform/posix/lib_posix.c
+++ b/engine/platform/posix/lib_posix.c
@@ -16,6 +16,10 @@ GNU General Public License for more details.
 #include "platform/platform.h"
 #if XASH_LIB == LIB_POSIX
 #include <dlfcn.h>
+#ifdef XASH_IRIX
+#pragma message "Included"
+#include "platform/irix/dladdr.h"
+#endif
 #include "common.h"
 #include "library.h"
 #include "filesystem.h"

--- a/engine/platform/posix/net.h
+++ b/engine/platform/posix/net.h
@@ -24,6 +24,9 @@ GNU General Public License for more details.
 #include <netdb.h>
 #include <errno.h>
 #include <fcntl.h>
+#if XASH_IRIX
+#include <sys/time.h>
+#endif
 
 #define WSAGetLastError()  errno
 #define WSAEINTR           EINTR

--- a/engine/platform/posix/sys_posix.c
+++ b/engine/platform/posix/sys_posix.c
@@ -158,11 +158,11 @@ void Platform_Shutdown( void ) {}
 double Platform_DoubleTime( void )
 {
 	struct timespec ts;
-	#if XASH_IRIX
-	clock_gettime(CLOCK_SGI_CYCLE, &ts);
- 	#else	
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	#endif
+#if XASH_IRIX
+	clock_gettime( CLOCK_SGI_CYCLE, &ts );
+#else	
+	clock_gettime( CLOCK_MONOTONIC, &ts );
+#endif
 	return (double) ts.tv_sec + (double) ts.tv_nsec/1000000000.0;
 }
 

--- a/engine/platform/posix/sys_posix.c
+++ b/engine/platform/posix/sys_posix.c
@@ -158,9 +158,11 @@ void Platform_Shutdown( void ) {}
 double Platform_DoubleTime( void )
 {
 	struct timespec ts;
-
+	#if XASH_IRIX
+	clock_gettime(CLOCK_SGI_CYCLE, &ts);
+ 	#else	
 	clock_gettime(CLOCK_MONOTONIC, &ts);
-
+	#endif
 	return (double) ts.tv_sec + (double) ts.tv_nsec/1000000000.0;
 }
 

--- a/engine/wscript
+++ b/engine/wscript
@@ -132,6 +132,9 @@ def build(bld):
 	if bld.env.DEST_OS == 'linux':
 		source += bld.path.ant_glob(['platform/linux/*.c'])
 
+	if bld.env.DEST_OS == 'irix':
+		source += bld.path.ant_glob(['platform/irix/*.c'])
+
 	if bld.env.DEST_OS == 'dos':
 		source += bld.path.ant_glob(['platform/dos/*.c'])
 		source += bld.path.ant_glob(['platform/stub/s_stub.c'])

--- a/public/build.c
+++ b/public/build.c
@@ -107,6 +107,8 @@ const char *Q_PlatformStringByID( const int platform )
 		return "haiku";
 	case PLATFORM_SERENITY:
 		return "serenity";
+	case PLATFORM_IRIX:
+		return "irix";
 	}
 
 	assert( 0 );

--- a/public/build.h
+++ b/public/build.h
@@ -66,6 +66,7 @@ Then you can use another oneliner to query all variables:
 #undef XASH_FREEBSD
 #undef XASH_HAIKU
 #undef XASH_IOS
+#undef XASH_IRIX
 #undef XASH_JS
 #undef XASH_LINUX
 #undef XASH_LITTLE_ENDIAN
@@ -110,6 +111,8 @@ Then you can use another oneliner to query all variables:
 		#define XASH_HAIKU 1
 	#elif defined __serenity__
 		#define XASH_SERENITY 1
+	#elif defined __sgi
+		#define XASH_IRIX 1
 	#elif defined __APPLE__
 		#include <TargetConditionals.h>
 		#define XASH_APPLE 1

--- a/public/buildenums.h
+++ b/public/buildenums.h
@@ -38,6 +38,7 @@ GNU General Public License for more details.
 #define PLATFORM_DOS4GW     9
 #define PLATFORM_HAIKU      10
 #define PLATFORM_SERENITY   11
+#define PLATFORM_IRIX       12
 
 #if XASH_WIN32
 	#define XASH_PLATFORM PLATFORM_WIN32
@@ -61,6 +62,8 @@ GNU General Public License for more details.
 	#define XASH_PLATFORM PLATFORM_HAIKU
 #elif XASH_SERENITY
 	#define XASH_PLATFORM PLATFORM_SERENITY
+#elif XASH_IRIX
+	#define XASH_PLATFORM PLATFORM_IRIX
 #else
 	#error
 #endif

--- a/public/xash3d_mathlib.h
+++ b/public/xash3d_mathlib.h
@@ -77,6 +77,9 @@ GNU General Public License for more details.
 #define Q_round( x, y )	(floor( x / y + 0.5f ) * y )
 #define Q_rint(x)		((x) < 0.0f ? ((int)((x)-0.5f)) : ((int)((x)+0.5f)))
 
+#ifdef XASH_IRIX
+#undef isnan
+#endif
 #ifdef isnan // check for C99 isnan
 #define IS_NAN isnan
 #else

--- a/wscript
+++ b/wscript
@@ -244,16 +244,13 @@ def configure(conf):
 		cxxflags += conf.filter_cxxflags(compiler_optional_flags, cflags)
 		cflags += conf.filter_cflags(compiler_optional_flags + c_compiler_optional_flags, cflags)
 
-        # check if we need to use irix linkflags
-        print(conf.env.DEST_OS)
-        print(conf.env.COMPILER_CC)
-        if conf.env.DEST_OS == 'irix' and conf.env.COMPILER_CC == 'gcc':
-                linkflags.remove('-Wl,--no-undefined')
-                linkflags.append('-Wl,--unresolved-symbols=ignore-all')
-                # check if we're in a sgug environment
-                if 'sgug' in os.environ['LD_LIBRARYN32_PATH']:
-                        linkflags.append('-lc')
-        
+		# check if we need to use irix linkflags
+		if conf.env.DEST_OS == 'irix' and conf.env.COMPILER_CC == 'gcc':
+			linkflags.remove('-Wl,--no-undefined')
+			linkflags.append('-Wl,--unresolved-symbols=ignore-all')
+			# check if we're in a sgug environment
+			if 'sgug' in os.environ['LD_LIBRARYN32_PATH']:
+				linkflags.append('-lc')
 
 	conf.env.append_unique('CFLAGS', cflags)
 	conf.env.append_unique('CXXFLAGS', cxxflags)

--- a/wscript
+++ b/wscript
@@ -245,13 +245,11 @@ def configure(conf):
 		cflags += conf.filter_cflags(compiler_optional_flags + c_compiler_optional_flags, cflags)
 
         # check if we need to use irix linkflags
-        print("Here!")
         print(conf.env.DEST_OS)
         print(conf.env.COMPILER_CC)
         if conf.env.DEST_OS == 'irix' and conf.env.COMPILER_CC == 'gcc':
                 linkflags.remove('-Wl,--no-undefined')
                 linkflags.append('-Wl,--unresolved-symbols=ignore-all')
-                print("irix and gcc")
                 # check if we're in a sgug environment
                 if 'sgug' in os.environ['LD_LIBRARYN32_PATH']:
                         print("sgug")

--- a/wscript
+++ b/wscript
@@ -244,6 +244,20 @@ def configure(conf):
 		cxxflags += conf.filter_cxxflags(compiler_optional_flags, cflags)
 		cflags += conf.filter_cflags(compiler_optional_flags + c_compiler_optional_flags, cflags)
 
+        # check if we need to use irix linkflags
+        print("Here!")
+        print(conf.env.DEST_OS)
+        print(conf.env.COMPILER_CC)
+        if conf.env.DEST_OS == 'irix' and conf.env.COMPILER_CC == 'gcc':
+                linkflags.remove('-Wl,--no-undefined')
+                linkflags.append('-Wl,--unresolved-symbols=ignore-all')
+                print("irix and gcc")
+                # check if we're in a sgug environment
+                if 'sgug' in os.environ['LD_LIBRARYN32_PATH']:
+                        print("sgug")
+                        linkflags.append('-lc')
+        
+
 	conf.env.append_unique('CFLAGS', cflags)
 	conf.env.append_unique('CXXFLAGS', cxxflags)
 	conf.env.append_unique('LINKFLAGS', linkflags)

--- a/wscript
+++ b/wscript
@@ -252,7 +252,6 @@ def configure(conf):
                 linkflags.append('-Wl,--unresolved-symbols=ignore-all')
                 # check if we're in a sgug environment
                 if 'sgug' in os.environ['LD_LIBRARYN32_PATH']:
-                        print("sgug")
                         linkflags.append('-lc')
         
 

--- a/xash-exec
+++ b/xash-exec
@@ -1,0 +1,7 @@
+#!/usr/sgug/bin/bash
+
+
+# Testing path
+export LD_LIBRARYN32_PATH=$PWD/build/filesystem:$LD_LIBRARYN32_PATH
+
+exec $PWD/build/engine/xash

--- a/xash-exec
+++ b/xash-exec
@@ -1,7 +1,0 @@
-#!/usr/sgug/bin/bash
-
-
-# Testing path
-export LD_LIBRARYN32_PATH=$PWD/build/filesystem:$LD_LIBRARYN32_PATH
-
-exec $PWD/build/engine/xash


### PR DESCRIPTION
This is a series of patches to get the Xash3D dedicated server compiling on SGI IRIX 6.5.22 through 6.5.30. The next steps will be to improve engine support to get the server functional.