### PR TITLE
Fix multiline CL_CenterPrint

### DIFF
--- a/engine/client/cl_font.c
+++ b/engine/client/cl_font.c
@@ -303,6 +303,7 @@ void CL_DrawStringLen( cl_font_t *font, const char *s, int *width, int *height, 
 			draw_len = 0;
 			if( !FBitSet( flags, FONT_DRAW_NOLF ))
 			{
+				clgame.centerPrint.lines++;
 				if( height )
 					*height += font->charHeight;
 			}


### PR DESCRIPTION
After recent refactoring it sets `clgame.centerPrint.lines` to 1 and doesn't update it anymore.

I'm not sure `cl_font.c` is supposed to be aware of `clgame`, so a better fix is probably to add an `int *lines` argument to `CL_DrawStringLen()`. Let me know if that's the case and I'll update the PR.