### PR TITLE
Drop string function without size argument

### DIFF
--- a/engine/client/avi/avi_win.c
+++ b/engine/client/avi/avi_win.c
@@ -658,7 +658,7 @@ movie_state_t *AVI_LoadVideo( const char *filename, qboolean load_audio )
 
 	// open cinematic
 	Q_snprintf( path, sizeof( path ), "media/%s", filename );
-	COM_DefaultExtension( path, ".avi" );
+	COM_DefaultExtension( path, ".avi", sizeof( path ));
 	fullpath = FS_GetDiskPath( path, false );
 
 	if( FS_FileExists( path, false ) && !fullpath )

--- a/engine/client/cl_cmds.c
+++ b/engine/client/cl_cmds.c
@@ -145,7 +145,7 @@ void CL_PlayCDTrack_f( void )
 CL_ScreenshotGetName
 ==================
 */
-qboolean CL_ScreenshotGetName( int lastnum, char *filename )
+static qboolean CL_ScreenshotGetName( int lastnum, char *filename, size_t size )
 {
 	if( lastnum < 0 || lastnum > 9999 )
 	{
@@ -153,9 +153,7 @@ qboolean CL_ScreenshotGetName( int lastnum, char *filename )
 		return false;
 	}
 
-	Q_sprintf( filename, "scrshots/%s_shot%04d.png", clgame.mapname, lastnum );
-
-	return true;
+	return Q_snprintf( filename, size, "scrshots/%s_shot%04d.png", clgame.mapname, lastnum ) > 0;
 }
 
 /*
@@ -163,7 +161,7 @@ qboolean CL_ScreenshotGetName( int lastnum, char *filename )
 CL_SnapshotGetName
 ==================
 */
-qboolean CL_SnapshotGetName( int lastnum, char *filename )
+static qboolean CL_SnapshotGetName( int lastnum, char *filename, size_t size )
 {
 	if( lastnum < 0 || lastnum > 9999 )
 	{
@@ -172,9 +170,7 @@ qboolean CL_SnapshotGetName( int lastnum, char *filename )
 		return false;
 	}
 
-	Q_sprintf( filename, "../%s_%04d.png", clgame.mapname, lastnum );
-
-	return true;
+	return Q_snprintf( filename, size, "../%s_%04d.png", clgame.mapname, lastnum ) > 0;
 }
 
 /*
@@ -207,7 +203,7 @@ void CL_ScreenShot_f( void )
 		// scan for a free filename
 		for( i = 0; i < 9999; i++ )
 		{
-			if( !CL_ScreenshotGetName( i, checkname ))
+			if( !CL_ScreenshotGetName( i, checkname, sizeof( checkname )))
 				return;	// no namespace
 
 			if( !FS_FileExists( checkname, false ))
@@ -247,7 +243,7 @@ void CL_SnapShot_f( void )
 		// scan for a free filename
 		for( i = 0; i < 9999; i++ )
 		{
-			if( !CL_SnapshotGetName( i, checkname ))
+			if( !CL_SnapshotGetName( i, checkname, sizeof( checkname )))
 				return;	// no namespace
 
 			if( !FS_FileExists( checkname, false ))
@@ -278,7 +274,7 @@ void CL_EnvShot_f( void )
 		return;
 	}
 
-	Q_sprintf( cls.shotname, "gfx/env/%s", Cmd_Argv( 1 ));
+	Q_snprintf( cls.shotname, sizeof( cls.shotname ), "gfx/env/%s", Cmd_Argv( 1 ));
 	cls.scrshot_action = scrshot_envshot;	// build new frame for envshot
 	cls.envshot_vieworg = NULL; // no custom view
 	cls.envshot_viewsize = 0;
@@ -299,7 +295,7 @@ void CL_SkyShot_f( void )
 		return;
 	}
 
-	Q_sprintf( cls.shotname, "gfx/env/%s", Cmd_Argv( 1 ));
+	Q_snprintf( cls.shotname, sizeof( cls.shotname ),"gfx/env/%s", Cmd_Argv( 1 ));
 	cls.scrshot_action = scrshot_skyshot;	// build new frame for skyshot
 	cls.envshot_vieworg = NULL; // no custom view
 	cls.envshot_viewsize = 0;
@@ -323,7 +319,8 @@ void CL_LevelShot_f( void )
 	// check for exist
 	if( cls.demoplayback && ( cls.demonum != -1 ))
 	{
-		Q_sprintf( cls.shotname, "levelshots/%s_%s.bmp", cls.demoname, refState.wideScreen ? "16x9" : "4x3" );
+		Q_snprintf( cls.shotname, sizeof( cls.shotname ),
+			"levelshots/%s_%s.bmp", cls.demoname, refState.wideScreen ? "16x9" : "4x3" );
 		Q_snprintf( filename, sizeof( filename ), "%s.dem", cls.demoname );
 
 		// make sure what levelshot is newer than demo
@@ -332,7 +329,8 @@ void CL_LevelShot_f( void )
 	}
 	else
 	{
-		Q_sprintf( cls.shotname, "levelshots/%s_%s.bmp", clgame.mapname, refState.wideScreen ? "16x9" : "4x3" );
+		Q_snprintf( cls.shotname, sizeof( cls.shotname ),
+			"levelshots/%s_%s.bmp", clgame.mapname, refState.wideScreen ? "16x9" : "4x3" );
 
 		// make sure what levelshot is newer than bsp
 		ft1 = FS_FileTime( cl.worldmodel->name, false );
@@ -360,7 +358,7 @@ void CL_SaveShot_f( void )
 		return;
 	}
 
-	Q_sprintf( cls.shotname, DEFAULT_SAVE_DIRECTORY "%s.bmp", Cmd_Argv( 1 ));
+	Q_snprintf( cls.shotname, sizeof( cls.shotname ), DEFAULT_SAVE_DIRECTORY "%s.bmp", Cmd_Argv( 1 ));
 	cls.scrshot_action = scrshot_savegame;	// build new frame for saveshot
 }
 

--- a/engine/client/cl_debug.c
+++ b/engine/client/cl_debug.c
@@ -45,7 +45,7 @@ const char *CL_MsgInfo( int cmd )
 {
 	static string	sz;
 
-	Q_strcpy( sz, "???" );
+	Q_strncpy( sz, "???", sizeof( sz ));
 
 	if( cmd >= 0 && cmd <= svc_lastmsg )
 	{

--- a/engine/client/cl_demo.c
+++ b/engine/client/cl_demo.c
@@ -1317,16 +1317,16 @@ void CL_CheckStartupDemos( void )
 CL_DemoGetName
 ==================
 */
-static void CL_DemoGetName( int lastnum, char *filename )
+static void CL_DemoGetName( int lastnum, char *filename, size_t size )
 {
 	if( lastnum < 0 || lastnum > 9999 )
 	{
 		// bound
-		Q_strcpy( filename, "demo9999" );
+		Q_strncpy( filename, "demo9999.dem", size );
 		return;
 	}
 
-	Q_sprintf( filename, "demo%04d", lastnum );
+	Q_snprintf( filename, size, "demo%04d.dem", lastnum );
 }
 
 /*
@@ -1380,8 +1380,8 @@ void CL_Record_f( void )
 		// scan for a free filename
 		for( n = 0; n < 10000; n++ )
 		{
-			CL_DemoGetName( n, demoname );
-			if( !FS_FileExists( va( "%s.dem", demoname ), true ))
+			CL_DemoGetName( n, demoname, sizeof( demoname ));
+			if( !FS_FileExists( demoname, true ))
 				break;
 		}
 
@@ -1394,7 +1394,7 @@ void CL_Record_f( void )
 	else Q_strncpy( demoname, name, sizeof( demoname ));
 
 	// open the demo file
-	Q_sprintf( demopath, "%s.dem", demoname );
+	Q_snprintf( demopath, sizeof( demopath ), "%s.dem", demoname );
 
 	// make sure that old demo is removed
 	if( FS_FileExists( demopath, false ))

--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -2569,7 +2569,7 @@ const char *pfnGetGameDirectory( void )
 {
 	static char	szGetGameDir[MAX_SYSPATH];
 
-	Q_strcpy( szGetGameDir, GI->gamefolder );
+	Q_strncpy( szGetGameDir, GI->gamefolder, sizeof( szGetGameDir ));
 	return szGetGameDir;
 }
 

--- a/engine/client/cl_gameui.c
+++ b/engine/client/cl_gameui.c
@@ -309,7 +309,7 @@ static void GAME_EXPORT UI_DrawLogo( const char *filename, float x, float y, flo
 
 		// run cinematic if not
 		Q_snprintf( path, sizeof( path ), "media/%s", filename );
-		COM_DefaultExtension( path, ".avi" );
+		COM_DefaultExtension( path, ".avi", sizeof( path ));
 		fullpath = FS_GetDiskPath( path, false );
 
 		if( FS_FileExists( path, false ) && !fullpath )

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -1294,15 +1294,15 @@ void CL_Rcon_f( void )
 
 	NET_Config( true, false );	// allow remote
 
-	Q_strcat( message, "rcon " );
-	Q_strcat( message, rcon_password.string );
-	Q_strcat( message, " " );
+	Q_strncat( message, "rcon ", sizeof( message ));
+	Q_strncat( message, rcon_password.string, sizeof( message ));
+	Q_strncat( message, " ", sizeof( message ) );
 
 	for( i = 1; i < Cmd_Argc(); i++ )
 	{
 		Cmd_Escape( command, Cmd_Argv( i ), sizeof( command ));
-		Q_strcat( message, command );
-		Q_strcat( message, " " );
+		Q_strncat( message, command, sizeof( message ));
+		Q_strncat( message, " ", sizeof( message ));
 	}
 
 	if( cls.state >= ca_connected )

--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -2007,7 +2007,7 @@ void CL_ParseExec( sizebuf_t *msg )
 	{
 		Cbuf_AddText( "exec mapdefault.cfg\n" );
 
-		COM_FileBase( clgame.mapname, mapname );
+		COM_FileBase( clgame.mapname, mapname, sizeof( mapname ));
 
 		if ( COM_CheckString( mapname ) )
 			Cbuf_AddTextf( "exec %s.cfg\n", mapname );

--- a/engine/client/cl_remap.c
+++ b/engine/client/cl_remap.c
@@ -157,7 +157,7 @@ void CL_UpdateStudioTexture( cl_entity_t *entity, mstudiotexture_t *ptexture, in
 
 	// build name of original texture
 	Q_strncpy( mdlname, entity->model->name, sizeof( mdlname ));
-	COM_FileBase( ptexture->name, name );
+	COM_FileBase( ptexture->name, name, sizeof( name ));
 	COM_StripExtension( mdlname );
 
 	Q_snprintf( texname, sizeof( texname ), "#%s/%s.mdl", mdlname, name );

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -1498,9 +1498,9 @@ static void Touch_EditMove( touchEventType type, int fingerID, float x, float y,
 				touch.hidebutton->flags &= ~TOUCH_FL_HIDE;
 
 				if( FBitSet( button->flags, TOUCH_FL_HIDE ))
-					Q_strcpy( touch.hidebutton->texturefile, "touch_default/edit_show" );
+					Q_strncpy( touch.hidebutton->texturefile, "touch_default/edit_show", sizeof( touch.hidebutton->texturefile ));
 				else
-					Q_strcpy( touch.hidebutton->texturefile, "touch_default/edit_hide" );
+					Q_strncpy( touch.hidebutton->texturefile, "touch_default/edit_hide", sizeof( touch.hidebutton->texturefile ));
 			}
 		}
 		if( type == event_motion ) // shutdown button move

--- a/engine/client/in_touch.c
+++ b/engine/client/in_touch.c
@@ -340,7 +340,7 @@ static void Touch_ExportConfig_f( void )
 
 	if( Q_strstr( name, "touch_presets/" ))
 	{
-		COM_FileBase( name, profilebase );
+		COM_FileBase( name, profilebase, sizeof( profilebase ));
 		Q_snprintf( profilename, sizeof( profilebase ), "touch_profiles/%s (copy).cfg", profilebase );
 	}
 	else Q_strncpy( profilename, name, sizeof( profilename ));

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -434,8 +434,8 @@ void Key_Bind_f( void )
 
 	for( i = 2; i < c; i++ )
 	{
-		Q_strcat( cmd, Cmd_Argv( i ));
-		if( i != ( c - 1 )) Q_strcat( cmd, " " );
+		Q_strncat( cmd, Cmd_Argv( i ), sizeof( cmd ));
+		if( i != ( c - 1 )) Q_strncat( cmd, " ", sizeof( cmd ));
 	}
 
 	Key_SetBinding( b, cmd );
@@ -541,8 +541,8 @@ void Key_AddKeyCommands( int key, const char *kb, qboolean down )
 			if( button[0] == '+' )
 			{
 				// button commands add keynum as a parm
-				if( down ) Q_sprintf( cmd, "%s %i\n", button, key );
-				else Q_sprintf( cmd, "-%s %i\n", button + 1, key );
+				if( down ) Q_snprintf( cmd, sizeof( cmd ), "%s %i\n", button, key );
+				else Q_snprintf( cmd, sizeof( cmd ), "-%s %i\n", button + 1, key );
 				Cbuf_AddText( cmd );
 			}
 			else if( down )

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -512,7 +512,7 @@ static void R_GetRendererName( char *dest, size_t size, const char *opt )
 	else
 	{
 		// full path
-		Q_strcpy( dest, opt );
+		Q_strncpy( dest, opt, size );
 	}
 }
 

--- a/engine/client/s_vox.c
+++ b/engine/client/s_vox.c
@@ -142,7 +142,7 @@ static const char *VOX_GetDirectory( char *szpath, const char *psz, int nsize )
 
 	if( !p )
 	{
-		Q_strcpy( szpath, "vox/" );
+		Q_strncpy( szpath, "vox/", nsize );
 		return psz;
 	}
 

--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -1162,13 +1162,13 @@ void Cmd_ForwardToServer( void )
 	str[0] = 0;
 	if( Q_stricmp( Cmd_Argv( 0 ), "cmd" ))
 	{
-		Q_strcat( str, Cmd_Argv( 0 ));
-		Q_strcat( str, " " );
+		Q_strncat( str, Cmd_Argv( 0 ), sizeof( str ));
+		Q_strncat( str, " ", sizeof( str ));
 	}
 
 	if( Cmd_Argc() > 1 )
-		Q_strcat( str, Cmd_Args( ));
-	else Q_strcat( str, "\n" );
+		Q_strncat( str, Cmd_Args( ), sizeof( str ));
+	else Q_strncat( str, "\n", sizeof( str ));
 
 	MSG_WriteString( &cls.netchan.message, str );
 }

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -564,7 +564,7 @@ int GAME_EXPORT COM_ExpandFilename( const char *fileName, char *nameOutBuffer, i
 	// models\barney.mdl - D:\Xash3D\bshift\models\barney.mdl
 	if(( path = FS_GetDiskPath( fileName, false )) != NULL )
 	{
-		Q_sprintf( result, "%s/%s", host.rootdir, path );
+		Q_snprintf( result, sizeof( result ), "%s/%s", host.rootdir, path );
 
 		// check for enough room
 		if( Q_strlen( result ) > nameOutBufferSize )

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -1006,7 +1006,7 @@ pfnGetGameDir
 void GAME_EXPORT pfnGetGameDir( char *szGetGameDir )
 {
 	if( !szGetGameDir ) return;
-	Q_strcpy( szGetGameDir, GI->gamefolder );
+	Q_strncpy( szGetGameDir, GI->gamefolder, sizeof( GI->gamefolder ));
 }
 
 qboolean COM_IsSafeFileToDownload( const char *filename )
@@ -1070,13 +1070,15 @@ const char *COM_GetResourceTypeName( resourcetype_t restype )
 
 char *_copystring( poolhandle_t mempool, const char *s, const char *filename, int fileline )
 {
+	size_t	size;
 	char	*b;
 
 	if( !s ) return NULL;
 	if( !mempool ) mempool = host.mempool;
 
-	b = _Mem_Alloc( mempool, Q_strlen( s ) + 1, false, filename, fileline );
-	Q_strcpy( b, s );
+	size = Q_strlen( s ) + 1;
+	b = _Mem_Alloc( mempool, size, false, filename, fileline );
+	Q_strncpy( b, s, size );
 
 	return b;
 }
@@ -1100,7 +1102,6 @@ used by CS:CZ
 void *GAME_EXPORT pfnSequenceGet( const char *fileName, const char *entryName )
 {
 	Msg( "Sequence_Get: file %s, entry %s\n", fileName, entryName );
-
 
 	return Sequence_Get( fileName, entryName );
 }

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -861,6 +861,7 @@ qboolean Cmd_CheckMapsList_R( qboolean fRefresh, qboolean onlyingamedir )
 	byte	buf[MAX_SYSPATH];
 	string	mpfilter;
 	char	*buffer;
+	size_t	buffersize;
 	string	result;
 	int	i, size;
 	search_t	*t;
@@ -883,7 +884,8 @@ qboolean Cmd_CheckMapsList_R( qboolean fRefresh, qboolean onlyingamedir )
 		return false;
 	}
 
-	buffer = Mem_Calloc( host.mempool, t->numfilenames * 2 * sizeof( result ));
+	buffersize = t->numfilenames * 2 * sizeof( result );
+	buffer = Mem_Calloc( host.mempool, buffersize );
 	use_filter = COM_CheckStringEmpty( GI->mp_filter ) ? true : false;
 
 	for( i = 0; i < t->numfilenames; i++ )
@@ -969,8 +971,8 @@ qboolean Cmd_CheckMapsList_R( qboolean fRefresh, qboolean onlyingamedir )
 			if( num_spawnpoints )
 			{
 				// format: mapname "maptitle"\n
-				Q_sprintf( result, "%s \"%s\"\n", mapname, message );
-				Q_strcat( buffer, result ); // add new string
+				Q_snprintf( result, sizeof( result ), "%s \"%s\"\n", mapname, message );
+				Q_strncat( buffer, result, buffersize ); // add new string
 			}
 		}
 	}

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -146,7 +146,7 @@ int Cmd_ListMaps( search_t *t, char *lastmapname, size_t len )
 		}
 
 		if( f ) FS_Close(f);
-		COM_FileBase( t->filenames[i], mapname );
+		COM_FileBase( t->filenames[i], mapname, sizeof( mapname ));
 
 		switch( ver )
 		{
@@ -194,7 +194,7 @@ qboolean Cmd_GetMapList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "maps/%s*.bsp", s ), true, con_gamemaps->value );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -231,7 +231,7 @@ qboolean Cmd_GetDemoList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "%s*.dem", s ), true, true );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -241,7 +241,7 @@ qboolean Cmd_GetDemoList( const char *s, char *completedname, int length )
 		if( Q_stricmp( COM_FileExtension( t->filenames[i] ), "dem" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		numdems++;
 	}
@@ -277,7 +277,7 @@ qboolean Cmd_GetMovieList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "media/%s*.avi", s ), true, false );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -287,7 +287,7 @@ qboolean Cmd_GetMovieList( const char *s, char *completedname, int length )
 		if( Q_stricmp( COM_FileExtension( t->filenames[i] ), "avi" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		nummovies++;
 	}
@@ -324,7 +324,7 @@ qboolean Cmd_GetMusicList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "media/%s*.*", s ), true, false );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -336,7 +336,7 @@ qboolean Cmd_GetMusicList( const char *s, char *completedname, int length )
 		if( Q_stricmp( ext, "wav" ) && Q_stricmp( ext, "mp3" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		numtracks++;
 	}
@@ -372,7 +372,7 @@ qboolean Cmd_GetSavesList( const char *s, char *completedname, int length )
 	t = FS_Search( va( DEFAULT_SAVE_DIRECTORY "%s*.sav", s ), true, true );	// lookup only in gamedir
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -382,7 +382,7 @@ qboolean Cmd_GetSavesList( const char *s, char *completedname, int length )
 		if( Q_stricmp( COM_FileExtension( t->filenames[i] ), "sav" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		numsaves++;
 	}
@@ -419,7 +419,7 @@ qboolean Cmd_GetConfigList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "%s*.cfg", s ), true, false );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -429,7 +429,7 @@ qboolean Cmd_GetConfigList( const char *s, char *completedname, int length )
 		if( Q_stricmp( COM_FileExtension( t->filenames[i] ), "cfg" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		numconfigs++;
 	}
@@ -519,7 +519,7 @@ qboolean Cmd_GetItemsList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "%s/%s*.txt", clgame.itemspath, s ), true, false );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -529,7 +529,7 @@ qboolean Cmd_GetItemsList( const char *s, char *completedname, int length )
 		if( Q_stricmp( COM_FileExtension( t->filenames[i] ), "txt" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		numitems++;
 	}
@@ -711,7 +711,7 @@ qboolean Cmd_GetCustomList( const char *s, char *completedname, int length )
 	t = FS_Search( va( "%s*.hpk", s ), true, false );
 	if( !t ) return false;
 
-	COM_FileBase( t->filenames[0], matchbuf );
+	COM_FileBase( t->filenames[0], matchbuf, sizeof( matchbuf ));
 	if( completedname && length )
 		Q_strncpy( completedname, matchbuf, length );
 	if( t->numfilenames == 1 ) return true;
@@ -721,7 +721,7 @@ qboolean Cmd_GetCustomList( const char *s, char *completedname, int length )
 		if( Q_stricmp( COM_FileExtension( t->filenames[i] ), "hpk" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], matchbuf );
+		COM_FileBase( t->filenames[i], matchbuf, sizeof( matchbuf ));
 		Con_Printf( "%16s\n", matchbuf );
 		numitems++;
 	}
@@ -901,7 +901,7 @@ qboolean Cmd_CheckMapsList_R( qboolean fRefresh, qboolean onlyingamedir )
 			continue;
 
 		f = FS_Open( t->filenames[i], "rb", onlyingamedir );
-		COM_FileBase( t->filenames[i], mapname );
+		COM_FileBase( t->filenames[i], mapname, sizeof( mapname ));
 
 		if( f )
 		{

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -101,8 +101,7 @@ int Cmd_ListMaps( search_t *t, char *lastmapname, size_t len )
 			if( hdrext->id == IDEXTRAHEADER ) version = hdrext->version;
 
 			Q_strncpy( entfilename, t->filenames[i], sizeof( entfilename ));
-			COM_StripExtension( entfilename );
-			COM_DefaultExtension( entfilename, ".ent" );
+			COM_ReplaceExtension( entfilename, ".ent", sizeof( entfilename ));
 			ents = (char *)FS_LoadFile( entfilename, NULL, true );
 
 			if( !ents && lumplen >= 10 )
@@ -925,8 +924,7 @@ qboolean Cmd_CheckMapsList_R( qboolean fRefresh, qboolean onlyingamedir )
 			lumplen = entities.filelen;
 
 			Q_strncpy( entfilename, t->filenames[i], sizeof( entfilename ));
-			COM_StripExtension( entfilename );
-			COM_DefaultExtension( entfilename, ".ent" );
+			COM_ReplaceExtension( entfilename, ".ent", sizeof( entfilename ));
 			ents = (char *)FS_LoadFile( entfilename, NULL, true );
 
 			if( !ents && lumplen >= 10 )

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -571,7 +571,7 @@ qboolean Cmd_GetKeysList( const char *s, char *completedname, int length )
 		const char *keyname = Key_KeynumToString( i );
 
 		if(( *s == '*' ) || !Q_strnicmp( keyname, s, len))
-			Q_strcpy( keys[numkeys++], keyname );
+			Q_strncpy( keys[numkeys++], keyname, sizeof( keys[0] ));
 	}
 
 	if( !numkeys ) return false;
@@ -765,7 +765,7 @@ qboolean Cmd_GetGamesList( const char *s, char *completedname, int length )
 	for( i = 0, numgamedirs = 0; i < FI->numgames; i++ )
 	{
 		if(( *s == '*' ) || !Q_strnicmp( FI->games[i]->gamefolder, s, len))
-			Q_strcpy( gamedirs[numgamedirs++], FI->games[i]->gamefolder );
+			Q_strncpy( gamedirs[numgamedirs++], FI->games[i]->gamefolder, sizeof( gamedirs[0] ));
 	}
 
 	if( !numgamedirs ) return false;
@@ -826,7 +826,7 @@ qboolean Cmd_GetCDList( const char *s, char *completedname, int length )
 	for( i = 0, numcdcommands = 0; i < 8; i++ )
 	{
 		if(( *s == '*' ) || !Q_strnicmp( cd_command[i], s, len))
-			Q_strcpy( cdcommands[numcdcommands++], cd_command[i] );
+			Q_strncpy( cdcommands[numcdcommands++], cd_command[i], sizeof( cdcommands[0] ));
 	}
 
 	if( !numcdcommands ) return false;

--- a/engine/common/crashhandler.c
+++ b/engine/common/crashhandler.c
@@ -193,8 +193,10 @@ static void Sys_StackTrace( PEXCEPTION_POINTERS pInfo )
 
 static void Sys_GetProcessName( char *processName, size_t bufferSize )
 {
-	GetModuleBaseName( GetCurrentProcess(), NULL, processName, bufferSize - 1 );
-	COM_FileBase( processName, processName );
+	char fullpath[MAX_PATH];
+
+	GetModuleBaseName( GetCurrentProcess(), NULL, fullpath, sizeof( fullpath ) - 1 );
+	COM_FileBase( fullpath, processName, bufferSize );
 }
 
 static void Sys_GetMinidumpFileName( const char *processName, char *mdmpFileName, size_t bufferSize )

--- a/engine/common/cvar.c
+++ b/engine/common/cvar.c
@@ -1119,8 +1119,8 @@ void Cvar_Set_f( void )
 		len = Q_strlen( Cmd_Argv(i) + 1 );
 		if( l + len >= MAX_CMD_TOKENS - 2 )
 			break;
-		Q_strcat( combined, Cmd_Argv( i ));
-		if( i != c-1 ) Q_strcat( combined, " " );
+		Q_strncat( combined, Cmd_Argv( i ), sizeof( combined ));
+		if( i != c-1 ) Q_strncat( combined, " ", sizeof( combined ));
 		l += len;
 	}
 

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -415,7 +415,7 @@ void Host_Exec_f( void )
 	}
 
 	Q_strncpy( cfgpath, arg, sizeof( cfgpath ));
-	COM_DefaultExtension( cfgpath, ".cfg" ); // append as default
+	COM_DefaultExtension( cfgpath, ".cfg", sizeof( cfgpath )); // append as default
 
 	f = FS_LoadFile( cfgpath, &len, false );
 	if( !f )

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -769,7 +769,7 @@ void GAME_EXPORT Host_Error( const char *error, ... )
 	recursive = true;
 	Q_strncpy( hosterror2, hosterror1, MAX_SYSPATH );
 	host.errorframe = host.framecount; // to avoid multply calls per frame
-	Q_sprintf( host.finalmsg, "Server crashed: %s", hosterror1 );
+	Q_snprintf( host.finalmsg, sizeof( host.finalmsg ), "Server crashed: %s", hosterror1 );
 
 	// clearing cmd buffer to prevent execute any commands
 	COM_InitHostState();

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -509,7 +509,7 @@ qboolean Host_RegisterDecal( const char *name, int *count )
 	if( !COM_CheckString( name ))
 		return 0;
 
-	COM_FileBase( name, shortname );
+	COM_FileBase( name, shortname, sizeof( shortname ));
 
 	for( i = 1; i < MAX_DECALS && host.draw_decals[i][0]; i++ )
 	{

--- a/engine/common/hpak.c
+++ b/engine/common/hpak.c
@@ -938,7 +938,7 @@ void HPAK_List_f( void )
 	for( nCurrent = 0; nCurrent < directory.count; nCurrent++ )
 	{
 		entry = &directory.entries[nCurrent];
-		COM_FileBase( entry->resource.szFileName, lumpname );
+		COM_FileBase( entry->resource.szFileName, lumpname, sizeof( lumpname ));
 		type = HPAK_TypeFromIndex( entry->resource.type );
 		size = Q_memprint( entry->resource.nDownloadSize );
 
@@ -1033,7 +1033,7 @@ void HPAK_Extract_f( void )
 		if( nIndex != -1 && nIndex != nCurrent )
 			continue;
 
-		COM_FileBase( entry->resource.szFileName, lumpname );
+		COM_FileBase( entry->resource.szFileName, lumpname, sizeof( lumpname ) );
 		type = HPAK_TypeFromIndex( entry->resource.type );
 		size = Q_memprint( entry->resource.nDownloadSize );
 

--- a/engine/common/hpak.c
+++ b/engine/common/hpak.c
@@ -109,7 +109,7 @@ void HPAK_CreatePak( const char *filename, resource_t *pResource, byte *pData, f
 		return;
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	Con_Printf( "creating HPAK %s.\n", pakname );
 
@@ -257,7 +257,7 @@ void HPAK_AddLump( qboolean bUseQueue, const char *name, resource_t *pResource, 
 	}
 
 	Q_strncpy( srcname, name, sizeof( srcname ));
-	COM_ReplaceExtension( srcname, ".hpk" );
+	COM_ReplaceExtension( srcname, ".hpk", sizeof( srcname ));
 
 	file_src = FS_Open( srcname, "rb", true );
 
@@ -269,7 +269,7 @@ void HPAK_AddLump( qboolean bUseQueue, const char *name, resource_t *pResource, 
 	}
 
 	Q_strncpy( dstname, srcname, sizeof( dstname ));
-	COM_ReplaceExtension( dstname, ".hp2" );
+	COM_ReplaceExtension( dstname, ".hp2", sizeof( dstname ));
 
 	file_dst = FS_Open( dstname, "wb", true );
 
@@ -395,7 +395,7 @@ static qboolean HPAK_Validate( const char *filename, qboolean quiet, qboolean de
 		return true;
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	f = FS_Open( pakname, "rb", true );
 	if( !f )
@@ -497,7 +497,7 @@ void HPAK_CheckIntegrity( const char *filename )
 		return;
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	HPAK_Validate( pakname, true, true );
 }
@@ -514,7 +514,7 @@ void HPAK_CheckSize( const char *filename )
 		return;
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	if( FS_FileSize( pakname, false ) > ( maxsize * 1048576 ))
 	{
@@ -547,7 +547,7 @@ qboolean HPAK_ResourceForHash( const char *filename, byte *hash, resource_t *pRe
 	}
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	f = FS_Open( pakname, "rb", true );
 	if( !f ) return false;
@@ -595,7 +595,7 @@ static qboolean HPAK_ResourceForIndex( const char *filename, int index, resource
 		return false;
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	f = FS_Open( pakname, "rb", true );
 	if( !f )
@@ -681,7 +681,7 @@ qboolean HPAK_GetDataPointer( const char *filename, resource_t *pResource, byte 
 	}
 
 	Q_strncpy( pakname, filename, sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
 	f = FS_Open( pakname, "rb", true );
 	if( !f ) return false;
@@ -764,7 +764,7 @@ void HPAK_RemoveLump( const char *name, resource_t *pResource )
 	HPAK_FlushHostQueue();
 
 	Q_strncpy( read_path, name, sizeof( read_path ));
-	COM_ReplaceExtension( read_path, ".hpk" );
+	COM_ReplaceExtension( read_path, ".hpk", sizeof( read_path ));
 
 	file_src = FS_Open( read_path, "rb", true );
 	if( !file_src )
@@ -774,7 +774,7 @@ void HPAK_RemoveLump( const char *name, resource_t *pResource )
 	}
 
 	Q_strncpy( save_path, read_path, sizeof( save_path ));
-	COM_ReplaceExtension( save_path, ".hp2" );
+	COM_ReplaceExtension( save_path, ".hp2", sizeof( save_path ));
 	file_dst = FS_Open( save_path, "wb", true );
 
 	if( !file_dst )
@@ -893,7 +893,7 @@ void HPAK_List_f( void )
 	HPAK_FlushHostQueue();
 
 	Q_strncpy( pakname, Cmd_Argv( 1 ), sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 	Con_Printf( "Contents for %s.\n", pakname );
 
 	f = FS_Open( pakname, "rb", true );
@@ -984,7 +984,7 @@ void HPAK_Extract_f( void )
 	HPAK_FlushHostQueue();
 
 	Q_strncpy( pakname, Cmd_Argv( 1 ), sizeof( pakname ));
-	COM_ReplaceExtension( pakname, ".hpk" );
+	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 	Con_Printf( "Contents for %s.\n", pakname );
 
 	f = FS_Open( pakname, "rb", true );

--- a/engine/common/identification.c
+++ b/engine/common/identification.c
@@ -677,7 +677,7 @@ void ID_Init( void )
 	MD5Final( (byte*)md5, &hash );
 
 	for( i = 0; i < 16; i++ )
-		Q_sprintf( &id_md5[i*2], "%02hhx", md5[i] );
+		Q_snprintf( &id_md5[i*2], sizeof( id_md5 ) - i * 2, "%02hhx", md5[i] );
 
 #if XASH_ANDROID && !XASH_DEDICATED
 	Android_SaveID( va("%016llX", id^SYSTEM_XOR_MASK ) );

--- a/engine/common/imagelib/img_main.c
+++ b/engine/common/imagelib/img_main.c
@@ -422,7 +422,8 @@ qboolean FS_SaveImage( const char *filename, rgbdata_t *pix )
 			{
 				for( i = 0; i < 6; i++ )
 				{
-					Q_sprintf( path, format->formatstring, savename, box[i].suf, format->ext );
+					Q_snprintf( path, sizeof( path ),
+						format->formatstring, savename, box[i].suf, format->ext );
 					if( !format->savefunc( path, pix )) break; // there were errors
 					pix->buffer += pix->size; // move pointer
 				}
@@ -444,7 +445,8 @@ qboolean FS_SaveImage( const char *filename, rgbdata_t *pix )
 		{
 			if( !Q_stricmp( ext, format->ext ))
 			{
-				Q_sprintf( path, format->formatstring, savename, "", format->ext );
+				Q_snprintf( path, sizeof( path ),
+					format->formatstring, savename, "", format->ext );
 				if( format->savefunc( path, pix ))
 				{
 					// clear any force flags

--- a/engine/common/infostring.c
+++ b/engine/common/infostring.c
@@ -277,7 +277,9 @@ qboolean GAME_EXPORT Info_RemoveKey( char *s, const char *key )
 
 		if( !Q_strncmp( key, pkey, cmpsize ))
 		{
-			Q_strcpy( start, s ); // remove this part
+			size_t size = Q_strlen( s ) + 1;
+
+			memmove( start, s, size ); // remove this part
 			return true;
 		}
 

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -1483,7 +1483,7 @@ static qboolean Mod_LoadColoredLighting( dbspmodel_t *bmod )
 	fs_offset_t	litdatasize;
 	byte	*in;
 
-	COM_FileBase( loadmodel->name, modelname );
+	COM_FileBase( loadmodel->name, modelname, sizeof( modelname ));
 	Q_snprintf( path, sizeof( path ), "maps/%s.lit", modelname );
 
 	// make sure what deluxemap is actual
@@ -1538,7 +1538,7 @@ static void Mod_LoadDeluxemap( dbspmodel_t *bmod )
 	if( !FBitSet( host.features, ENGINE_LOAD_DELUXEDATA ))
 		return;
 
-	COM_FileBase( loadmodel->name, modelname );
+	COM_FileBase( loadmodel->name, modelname, sizeof( modelname ));
 	Q_snprintf( path, sizeof( path ), "maps/%s.dlit", modelname );
 
 	// make sure what deluxemap is actual
@@ -1833,7 +1833,7 @@ static void Mod_LoadEntities( dbspmodel_t *bmod )
 				for( pszWadFile = strtok( wadstring, ";" ); pszWadFile != NULL; pszWadFile = strtok( NULL, ";" ))
 				{
 					COM_FixSlashes( pszWadFile );
-					COM_FileBase( pszWadFile, token );
+					COM_FileBase( pszWadFile, token, sizeof( token ));
 
 					// make sure what wad is really exist
 					if( FS_FileExists( va( "%s.wad", token ), false ))

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -1764,7 +1764,7 @@ static void Mod_LoadEntities( dbspmodel_t *bmod )
 
 		// world is check for entfile too
 		Q_strncpy( entfilename, loadmodel->name, sizeof( entfilename ));
-		COM_ReplaceExtension( entfilename, ".ent" );
+		COM_ReplaceExtension( entfilename, ".ent", sizeof( entfilename ));
 
 		// make sure what entity patch is never than bsp
 		ft1 = FS_FileTime( loadmodel->name, false );

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -1827,7 +1827,7 @@ static void Mod_LoadEntities( dbspmodel_t *bmod )
 				wadstring[MAX_TOKEN - 2] = 0;
 
 				if( !Q_strchr( wadstring, ';' ))
-					Q_strcat( wadstring, ";" );
+					Q_strncat( wadstring, ";", sizeof( wadstring ));
 
 				// parse wad pathes
 				for( pszWadFile = strtok( wadstring, ";" ); pszWadFile != NULL; pszWadFile = strtok( NULL, ";" ))

--- a/engine/common/mod_studio.c
+++ b/engine/common/mod_studio.c
@@ -429,7 +429,7 @@ void *R_StudioGetAnim( studiohdr_t *m_pStudioHeader, model_t *m_pSubModel, mstud
 	{
 		string	filepath, modelname, modelpath;
 
-		COM_FileBase( m_pSubModel->name, modelname );
+		COM_FileBase( m_pSubModel->name, modelname, sizeof( modelname ));
 		COM_ExtractFilePath( m_pSubModel->name, modelpath );
 
 		// NOTE: here we build real sub-animation filename because stupid user may rename model without recompile

--- a/engine/common/net_chan.c
+++ b/engine/common/net_chan.c
@@ -973,7 +973,7 @@ int Netchan_CreateFileFragments( netchan_t *chan, const char *filename )
 	else chunksize = FRAGMENT_MAX_SIZE; // fallback
 
 	Q_strncpy( compressedfilename, filename, sizeof( compressedfilename ));
-	COM_ReplaceExtension( compressedfilename, ".ztmp" );
+	COM_ReplaceExtension( compressedfilename, ".ztmp", sizeof( compressedfilename ));
 	compressedFileTime = FS_FileTime( compressedfilename, false );
 	fileTime = FS_FileTime( filename, false );
 
@@ -1559,7 +1559,7 @@ void Netchan_TransmitBits( netchan_t *chan, int length, byte *data )
 						char	compressedfilename[MAX_OSPATH];
 
 						Q_strncpy( compressedfilename, pbuf->filename, sizeof( compressedfilename ));
-						COM_ReplaceExtension( compressedfilename, ".ztmp" );
+						COM_ReplaceExtension( compressedfilename, ".ztmp", sizeof( compressedfilename ));
 						file = FS_Open( compressedfilename, "rb", false );
 					}
 					else file = FS_Open( pbuf->filename, "rb", false );

--- a/engine/common/net_chan.c
+++ b/engine/common/net_chan.c
@@ -273,8 +273,8 @@ void Netchan_ReportFlow( netchan_t *chan )
 
 	Assert( chan != NULL );
 
-	Q_strcpy( incoming, Q_pretifymem((float)chan->flow[FLOW_INCOMING].totalbytes, 3 ));
-	Q_strcpy( outgoing, Q_pretifymem((float)chan->flow[FLOW_OUTGOING].totalbytes, 3 ));
+	Q_strncpy( incoming, Q_pretifymem((float)chan->flow[FLOW_INCOMING].totalbytes, 3 ), sizeof( incoming ));
+	Q_strncpy( outgoing, Q_pretifymem((float)chan->flow[FLOW_OUTGOING].totalbytes, 3 ), sizeof( outgoing ));
 
 	Con_DPrintf( "Signon network traffic:  %s from server, %s to server\n", incoming, outgoing );
 }

--- a/engine/common/net_encode.c
+++ b/engine/common/net_encode.c
@@ -793,7 +793,7 @@ static void Delta_InitFields( void )
 		pfile = COM_ParseFile( pfile, encodeDll, sizeof( encodeDll ));
 
 		if( !Q_stricmp( encodeDll, "none" ))
-			Q_strcpy( encodeFunc, "null" );
+			Q_strncpy( encodeFunc, "null", sizeof( encodeFunc ));
 		else pfile = COM_ParseFile( pfile, encodeFunc, sizeof( encodeFunc ));
 
 		// jump to '{'

--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -732,7 +732,8 @@ const char *NET_AdrToString( const netadr_t a )
 		return s;
 	}
 
-	Q_sprintf( s, "%i.%i.%i.%i:%i", a.ip[0], a.ip[1], a.ip[2], a.ip[3], ntohs( a.port ));
+	Q_snprintf( s, sizeof( s ),
+		"%i.%i.%i.%i:%i", a.ip[0], a.ip[1], a.ip[2], a.ip[3], ntohs( a.port ));
 
 	return s;
 }
@@ -758,7 +759,8 @@ const char *NET_BaseAdrToString( const netadr_t a )
 		return s;
 	}
 
-	Q_sprintf( s, "%i.%i.%i.%i", a.ip[0], a.ip[1], a.ip[2], a.ip[3] );
+	Q_snprintf( s, sizeof( s ),
+		"%i.%i.%i.%i", a.ip[0], a.ip[1], a.ip[2], a.ip[3] );
 
 	return s;
 }

--- a/engine/common/sequence.c
+++ b/engine/common/sequence.c
@@ -1556,7 +1556,7 @@ static void Sequence_ParseFile( const char *fileName, qboolean isGlobal )
 	byte *buffer;
 	fs_offset_t bufSize = 0;
 
-	Q_strcpy( g_sequenceParseFileName, fileName );
+	Q_strncpy( g_sequenceParseFileName, fileName, sizeof( g_sequenceParseFileName ));
 	g_sequenceParseFileIsGlobal = isGlobal;
 
 	buffer = FS_LoadFile( va("sequences/%s.seq", fileName ), &bufSize, true );

--- a/engine/common/soundlib/snd_main.c
+++ b/engine/common/soundlib/snd_main.c
@@ -90,7 +90,9 @@ wavdata_t *FS_LoadSound( const char *filename, const byte *buffer, size_t size )
 	{
 		if( anyformat || !Q_stricmp( ext, format->ext ))
 		{
-			Q_sprintf( path, format->formatstring, loadname, "", format->ext );
+			Q_snprintf( path, sizeof( path ),
+				format->formatstring, loadname, "", format->ext );
+
 			f = FS_LoadFile( path, &filesize, false );
 			if( f && filesize > 0 )
 			{
@@ -175,7 +177,9 @@ stream_t *FS_OpenStream( const char *filename )
 	{
 		if( anyformat || !Q_stricmp( ext, format->ext ))
 		{
-			Q_sprintf( path, format->formatstring, loadname, "", format->ext );
+			Q_snprintf( path, sizeof( path ),
+				format->formatstring, loadname, "", format->ext );
+
 			if(( stream = format->openfunc( path )) != NULL )
 			{
 				stream->format = format;

--- a/engine/platform/posix/sys_posix.c
+++ b/engine/platform/posix/sys_posix.c
@@ -50,11 +50,12 @@ static qboolean Sys_FindExecutable( const char *baseName, char *buf, size_t size
 			needTrailingSlash = ( envPath[length - 1] == '/' ) ? 0 : 1;
 			if( length + baseNameLength + needTrailingSlash < size )
 			{
-				Q_strncpy( buf, envPath, length + 1 );
-				if( needTrailingSlash )
-					Q_strcpy( buf + length, "/" );
-				Q_strcpy( buf + length + needTrailingSlash, baseName );
-				buf[length + needTrailingSlash + baseNameLength] = '\0';
+				string temp;
+
+				Q_strncpy( temp, envPath, length + 1 );
+				Q_snprintf( buf, size, "%s%s%s",
+					temp, needTrailingSlash ? "/" : "", baseName );
+
 				if( access( buf, X_OK ) == 0 )
 					return true;
 			}

--- a/engine/platform/sdl/vid_sdl.c
+++ b/engine/platform/sdl/vid_sdl.c
@@ -736,9 +736,8 @@ qboolean VID_CreateWindow( int width, int height, qboolean fullscreen )
 
 	if( !iconLoaded )
 	{
-		Q_strcpy( iconpath, GI->iconpath );
-		COM_StripExtension( iconpath );
-		COM_DefaultExtension( iconpath, ".tga" );
+		Q_strncpy( iconpath, GI->iconpath, sizeof( iconpath ));
+		COM_ReplaceExtension( iconpath, ".tga", sizeof( iconpath ));
 
 		icon = FS_LoadImage( iconpath, NULL, 0 );
 

--- a/engine/platform/win32/lib_custom_win.c
+++ b/engine/platform/win32/lib_custom_win.c
@@ -373,21 +373,21 @@ void *MemoryLoadLibrary( const char *name )
 
 	if( !data )
 	{
-		Q_sprintf( errorstring, "couldn't load %s", name );
+		Q_snprintf( errorstring, sizeof( errorstring ), "couldn't load %s", name );
 		goto library_error;
 	}
 
 	dos_header = (PIMAGE_DOS_HEADER)data;
 	if( dos_header->e_magic != IMAGE_DOS_SIGNATURE )
 	{
-		Q_sprintf( errorstring, "%s it's not a valid executable file", name );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s it's not a valid executable file", name );
 		goto library_error;
 	}
 
 	old_header = (PIMAGE_NT_HEADERS)&((const byte *)(data))[dos_header->e_lfanew];
 	if( old_header->Signature != IMAGE_NT_SIGNATURE )
 	{
-		Q_sprintf( errorstring, "%s missing PE header", name );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s missing PE header", name );
 		goto library_error;
 	}
 
@@ -402,7 +402,7 @@ void *MemoryLoadLibrary( const char *name )
 
 	if( code == NULL )
 	{
-		Q_sprintf( errorstring, "%s can't reserve memory", name );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s can't reserve memory", name );
 		goto library_error;
 	}
 
@@ -436,7 +436,7 @@ void *MemoryLoadLibrary( const char *name )
 	// load required dlls and adjust function table of imports
 	if( !BuildImportTable( result ))
 	{
-		Q_sprintf( errorstring, "%s failed to build import table", name );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s failed to build import table", name );
 		goto library_error;
 	}
 
@@ -450,7 +450,7 @@ void *MemoryLoadLibrary( const char *name )
 		DllEntry = (DllEntryProc)CALCULATE_ADDRESS( code, result->headers->OptionalHeader.AddressOfEntryPoint );
 		if( DllEntry == 0 )
 		{
-			Q_sprintf( errorstring, "%s has no entry point", name );
+			Q_snprintf( errorstring, sizeof( errorstring ), "%s has no entry point", name );
 			goto library_error;
 		}
 
@@ -458,7 +458,7 @@ void *MemoryLoadLibrary( const char *name )
 		successfull = (*DllEntry)((HINSTANCE)code, DLL_PROCESS_ATTACH, 0 );
 		if( !successfull )
 		{
-			Q_sprintf( errorstring, "can't attach library %s", name );
+			Q_snprintf( errorstring, sizeof( errorstring ), "can't attach library %s", name );
 			goto library_error;
 		}
 		result->initialized = 1;

--- a/engine/platform/win32/lib_win.c
+++ b/engine/platform/win32/lib_win.c
@@ -101,55 +101,55 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 	f = FS_Open( hInst->shortPath, "rb", false );
 	if( !f )
 	{
-		Q_sprintf( errorstring, "couldn't load %s", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "couldn't load %s", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( FS_Read( f, &dos_header, sizeof( dos_header )) != sizeof( dos_header ))
 	{
-		Q_sprintf( errorstring, "%s has corrupted EXE header", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s has corrupted EXE header", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( dos_header.e_magic != IMAGE_DOS_SIGNATURE )
 	{
-		Q_sprintf( errorstring, "%s does not have a valid dll signature", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid dll signature", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( FS_Seek( f, dos_header.e_lfanew, SEEK_SET ) == -1 )
 	{
-		Q_sprintf( errorstring, "%s error seeking for new exe header", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s error seeking for new exe header", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( FS_Read( f, &nt_signature, sizeof( nt_signature )) != sizeof( nt_signature ))
 	{
-		Q_sprintf( errorstring, "%s has corrupted NT header", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s has corrupted NT header", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( nt_signature != IMAGE_NT_SIGNATURE )
 	{
-		Q_sprintf( errorstring, "%s does not have a valid NT signature", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid NT signature", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( FS_Read( f, &pe_header, sizeof( pe_header )) != sizeof( pe_header ))
 	{
-		Q_sprintf( errorstring, "%s does not have a valid PE header", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid PE header", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( !pe_header.SizeOfOptionalHeader )
 	{
-		Q_sprintf( errorstring, "%s does not have an optional header", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have an optional header", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( FS_Read( f, &optional_header, sizeof( optional_header )) != sizeof( optional_header ))
 	{
-		Q_sprintf( errorstring, "%s optional header probably corrupted", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s optional header probably corrupted", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -159,7 +159,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 	{
 		if( FS_Read( f, &section_header, sizeof( section_header )) != sizeof( section_header ))
 		{
-			Q_sprintf( errorstring, "%s error during reading section header", hInst->shortPath );
+			Q_snprintf( errorstring, sizeof( errorstring ), "%s error during reading section header", hInst->shortPath );
 			goto table_error;
 		}
 
@@ -180,13 +180,13 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Seek( f, exports_offset, SEEK_SET ) == -1 )
 	{
-		Q_sprintf( errorstring, "%s does not have a valid exports section", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid exports section", hInst->shortPath );
 		goto table_error;
 	}
 
 	if( FS_Read( f, &export_directory, sizeof( export_directory )) != sizeof( export_directory ))
 	{
-		Q_sprintf( errorstring, "%s does not have a valid optional header", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid optional header", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -194,7 +194,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( hInst->num_ordinals > MAX_LIBRARY_EXPORTS )
 	{
-		Q_sprintf( errorstring, "%s too many exports %i", hInst->shortPath, hInst->num_ordinals );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s too many exports %i", hInst->shortPath, hInst->num_ordinals );
 		hInst->num_ordinals = 0;
 		goto table_error;
 	}
@@ -203,7 +203,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Seek( f, ordinal_offset, SEEK_SET ) == -1 )
 	{
-		Q_sprintf( errorstring, "%s does not have a valid ordinals section", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid ordinals section", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -211,7 +211,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Read( f, hInst->ordinals, hInst->num_ordinals * sizeof( word )) != (hInst->num_ordinals * sizeof( word )))
 	{
-		Q_sprintf( errorstring, "%s error during reading ordinals table", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s error during reading ordinals table", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -219,7 +219,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Seek( f, function_offset, SEEK_SET ) == -1 )
 	{
-		Q_sprintf( errorstring, "%s does not have a valid export address section", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s does not have a valid export address section", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -227,7 +227,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Read( f, hInst->funcs, hInst->num_ordinals * sizeof( dword )) != (hInst->num_ordinals * sizeof( dword )))
 	{
-		Q_sprintf( errorstring, "%s error during reading export address section", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s error during reading export address section", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -235,7 +235,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Seek( f, name_offset, SEEK_SET ) == -1 )
 	{
-		Q_sprintf( errorstring, "%s file does not have a valid names section", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s file does not have a valid names section", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -243,7 +243,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( FS_Read( f, p_Names, hInst->num_ordinals * sizeof( dword )) != (hInst->num_ordinals * sizeof( dword )))
 	{
-		Q_sprintf( errorstring, "%s error during reading names table", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s error during reading names table", hInst->shortPath );
 		goto table_error;
 	}
 
@@ -264,7 +264,7 @@ qboolean LibraryLoadSymbols( dll_user_t *hInst )
 
 	if( i != hInst->num_ordinals )
 	{
-		Q_sprintf( errorstring, "%s error during loading names section", hInst->shortPath );
+		Q_snprintf( errorstring, sizeof( errorstring ), "%s error during loading names section", hInst->shortPath );
 		goto table_error;
 	}
 	FS_Close( f );

--- a/engine/server/sv_client.c
+++ b/engine/server/sv_client.c
@@ -1050,8 +1050,8 @@ void SV_RemoteCommand( netadr_t from, sizebuf_t *msg )
 		remaining[0] = 0;
 		for( i = 2; i < Cmd_Argc(); i++ )
 		{
-			Q_strcat( remaining, Cmd_Argv( i ));
-			Q_strcat( remaining, " " );
+			Q_strncat( remaining, Cmd_Argv( i ), sizeof( remaining ));
+			Q_strncat( remaining, " ", sizeof( remaining ));
 		}
 		Cmd_ExecuteString( remaining );
 	}
@@ -3384,8 +3384,8 @@ void SV_ParseCvarValue2( sv_client_t *cl, sizebuf_t *msg )
 	string	name, value;
 	int	requestID = MSG_ReadLong( msg );
 
-	Q_strcpy( name, MSG_ReadString( msg ));
-	Q_strcpy( value, MSG_ReadString( msg ));
+	Q_strncpy( name, MSG_ReadString( msg ), sizeof( name ));
+	Q_strncpy( value, MSG_ReadString( msg ), sizeof( value ));
 
 	if( svgame.dllFuncs2.pfnCvarValue2 != NULL )
 		svgame.dllFuncs2.pfnCvarValue2( cl->edict, requestID, name, value );

--- a/engine/server/sv_cmds.c
+++ b/engine/server/sv_cmds.c
@@ -337,12 +337,12 @@ void SV_NextMap_f( void )
 		if( Q_stricmp( ext, "bsp" ))
 			continue;
 
-		COM_FileBase( t->filenames[i], nextmap );
+		COM_FileBase( t->filenames[i], nextmap, sizeof( nextmap ));
 		if( Q_stricmp( sv_hostmap->string, nextmap ))
 			continue;
 
 		next = ( i + 1 ) % t->numfilenames;
-		COM_FileBase( t->filenames[next], nextmap );
+		COM_FileBase( t->filenames[next], nextmap, sizeof( nextmap ));
 		Cvar_DirectSet( sv_hostmap, nextmap );
 
 		// found current point, check for valid

--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -340,7 +340,7 @@ void SV_CreateGenericResources( void )
 	string	filename;
 
 	Q_strncpy( filename, sv.model_precache[1], sizeof( filename ));
-	COM_ReplaceExtension( filename, ".res" );
+	COM_ReplaceExtension( filename, ".res", sizeof( filename ));
 	COM_FixSlashes( filename );
 
 	SV_ReadResourceList( filename );

--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -997,7 +997,7 @@ qboolean SV_SpawnServer( const char *mapname, const char *startspot, qboolean ba
 
 	for( i = WORLD_INDEX; i < sv.worldmodel->numsubmodels; i++ )
 	{
-		Q_sprintf( sv.model_precache[i+1], "*%i", i );
+		Q_snprintf( sv.model_precache[i+1], sizeof( sv.model_precache[i+1] ), "*%i", i );
 		sv.models[i+1] = Mod_ForName( sv.model_precache[i+1], false, false );
 		SetBits( sv.model_precache_flags[i+1], RES_FATALIFMISSING );
 	}

--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -973,7 +973,7 @@ qboolean SV_SpawnServer( const char *mapname, const char *startspot, qboolean ba
 	if( svs.maxclients == 1 ) Cvar_SetValue( "sv_clienttrace", 1 );
 
 	// make sure what server name doesn't contain path and extension
-	COM_FileBase( mapname, sv.name );
+	COM_FileBase( mapname, sv.name, sizeof( sv.name ));
 
 	// precache and static commands can be issued during map initialization
 	Host_SetServerState( ss_loading );

--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -655,7 +655,7 @@ void FS_ParseGenericGameInfo( gameinfo_t *GameInfo, const char *buf, const qbool
 		{
 			pfile = COM_ParseFile( pfile, GameInfo->iconpath, sizeof( GameInfo->iconpath ));
 			COM_FixSlashes( GameInfo->iconpath );
-			COM_DefaultExtension( GameInfo->iconpath, ".ico" );
+			COM_DefaultExtension( GameInfo->iconpath, ".ico", sizeof( GameInfo->iconpath ));
 		}
 		else if( !Q_stricmp( token, "type" ))
 		{
@@ -1229,7 +1229,7 @@ static qboolean FS_FindLibrary( const char *dllname, qboolean directpath, fs_dll
 	}
 	dllInfo->shortPath[i] = '\0';
 
-	COM_DefaultExtension( dllInfo->shortPath, "."OS_LIB_EXT );	// apply ext if forget
+	COM_DefaultExtension( dllInfo->shortPath, "."OS_LIB_EXT, sizeof( dllInfo->shortPath ));	// apply ext if forget
 
 	search = FS_FindFile( dllInfo->shortPath, &index, NULL, 0, false );
 

--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -1150,7 +1150,7 @@ void FS_LoadGameInfo( const char *rootfolder )
 	// lock uplevel of gamedir for read\write
 	fs_ext_path = false;
 
-	if( rootfolder ) Q_strcpy( fs_gamedir, rootfolder );
+	if( rootfolder ) Q_strncpy( fs_gamedir, rootfolder, sizeof( fs_gamedir ));
 	Con_Reportf( "FS_LoadGameInfo( %s )\n", fs_gamedir );
 
 	// clear any old pathes

--- a/filesystem/wad.c
+++ b/filesystem/wad.c
@@ -467,13 +467,12 @@ static int FS_FindFile_WAD( searchpath_t *search, const char *path, char *fixedn
 
 		Q_strncpy( wadfolder, wadbasename, sizeof( wadfolder ));
 		Q_snprintf( wadname, sizeof( wadname ), "%s.wad", wadbasename );
-
 		anywadname = false;
 	}
 
 	// make wadname from wad fullpath
 	COM_FileBase( search->filename, shortname, sizeof( shortname ));
-	COM_DefaultExtension( shortname, ".wad" );
+	COM_DefaultExtension( shortname, ".wad", sizeof( shortname ));
 
 	// quick reject by wadname
 	if( !anywadname && Q_stricmp( wadname, shortname ))
@@ -532,7 +531,7 @@ static void FS_Search_WAD( searchpath_t *search, stringlist_t *list, const char 
 
 	// make wadname from wad fullpath
 	COM_FileBase( search->filename, temp2, sizeof( temp2 ));
-	COM_DefaultExtension( temp2, ".wad" );
+	COM_DefaultExtension( temp2, ".wad", sizeof( temp2 ));
 
 	// quick reject by wadname
 	if( !anywadname && Q_stricmp( wadname, temp2 ))
@@ -562,7 +561,7 @@ static void FS_Search_WAD( searchpath_t *search, stringlist_t *list, const char 
 					// build path: wadname/lumpname.ext
 					Q_snprintf( temp2, sizeof( temp2 ), "%s/%s", wadfolder, temp );
 					Q_snprintf( buf, sizeof( buf ), ".%s", W_ExtFromType( search->wad->lumps[i].type ));
-					COM_DefaultExtension( temp2, buf );
+					COM_DefaultExtension( temp2, buf, sizeof( temp2 ));
 					stringlistappend( list, temp2 );
 				}
 			}

--- a/filesystem/wad.c
+++ b/filesystem/wad.c
@@ -459,16 +459,20 @@ static int FS_FindFile_WAD( searchpath_t *search, const char *path, char *fixedn
 	COM_ExtractFilePath( path, wadname );
 	wadfolder[0] = '\0';
 
-	if( COM_CheckStringEmpty( wadname ) )
+	if( COM_CheckStringEmpty( wadname ))
 	{
-		COM_FileBase( wadname, wadname );
-		Q_strncpy( wadfolder, wadname, sizeof( wadfolder ));
-		COM_DefaultExtension( wadname, ".wad" );
+		string wadbasename;
+
+		COM_FileBase( wadname, wadbasename, sizeof( wadbasename ));
+
+		Q_strncpy( wadfolder, wadbasename, sizeof( wadfolder ));
+		Q_snprintf( wadname, sizeof( wadname ), "%s.wad", wadbasename );
+
 		anywadname = false;
 	}
 
 	// make wadname from wad fullpath
-	COM_FileBase( search->filename, shortname );
+	COM_FileBase( search->filename, shortname, sizeof( shortname ));
 	COM_DefaultExtension( shortname, ".wad" );
 
 	// quick reject by wadname
@@ -477,7 +481,7 @@ static int FS_FindFile_WAD( searchpath_t *search, const char *path, char *fixedn
 
 	// NOTE: we can't using long names for wad,
 	// because we using original wad names[16];
-	COM_FileBase( path, shortname );
+	COM_FileBase( path, shortname, sizeof( shortname ));
 
 	lump = W_FindLump( search->wad, shortname, type );
 
@@ -512,19 +516,22 @@ static void FS_Search_WAD( searchpath_t *search, stringlist_t *list, const char 
 		return;
 
 	COM_ExtractFilePath( pattern, wadname );
-	COM_FileBase( pattern, wadpattern );
+	COM_FileBase( pattern, wadpattern, sizeof( wadpattern ));
 	wadfolder[0] = '\0';
 
 	if( COM_CheckStringEmpty( wadname ))
 	{
-		COM_FileBase( wadname, wadname );
-		Q_strncpy( wadfolder, wadname, sizeof( wadfolder ));
-		COM_DefaultExtension( wadname, ".wad" );
+		string wadbasename;
+
+		COM_FileBase( wadname, wadbasename, sizeof( wadbasename ));
+
+		Q_strncpy( wadfolder, wadbasename, sizeof( wadfolder ));
+		Q_snprintf( wadname, sizeof( wadname ), "%s.wad", wadbasename );
 		anywadname = false;
 	}
 
 	// make wadname from wad fullpath
-	COM_FileBase( search->filename, temp2 );
+	COM_FileBase( search->filename, temp2, sizeof( temp2 ));
 	COM_DefaultExtension( temp2, ".wad" );
 
 	// quick reject by wadname

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -803,7 +803,10 @@ void COM_PathSlashFix( char *path )
 	len = Q_strlen( path );
 
 	if( path[len - 1] != '\\' && path[len - 1] != '/' )
-		Q_strcpy( &path[len], "/" );
+	{
+		path[len] = '/';
+		path[len + 1] = '\0';
+	}
 }
 
 /*

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -1,6 +1,7 @@
 /*
 crtlib.c - internal stdlib
 Copyright (C) 2011 Uncle Mike
+Copyright (c) QuakeSpasm contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -578,40 +579,37 @@ char *Q_pretifymem( float value, int digitsafterdecimal )
 COM_FileBase
 
 Extracts the base name of a file (no path, no extension, assumes '/' as path separator)
+a1ba: adapted and simplified version from QuakeSpasm
 ============
 */
-void COM_FileBase( const char *in, char *out )
+void COM_FileBase( const char *in, char *out, size_t size )
 {
-	int	len, start, end;
+	const char *dot, *slash, *s;
+	size_t len;
 
-	len = Q_strlen( in );
-	if( !len ) return;
+	if( unlikely( !COM_CheckString( in ) || size <= 1 ))
+	{
+		out[0] = 0;
+		return;
+	}
 
-	// scan backward for '.'
-	end = len - 1;
+	slash = in;
+	dot = NULL;
+	for( s = in; *s; s++ )
+	{
+		if( *s == '/' || *s == '\\' )
+			slash = s + 1;
 
-	while( end && in[end] != '.' && in[end] != '/' && in[end] != '\\' )
-		end--;
+		if( *s == '.' )
+			dot = s;
+	}
 
-	if( in[end] != '.' )
-		end = len-1; // no '.', copy to end
-	else end--; // found ',', copy to left of '.'
+	if( dot == NULL || dot < slash )
+		dot = s;
 
-	// scan backward for '/'
-	start = len - 1;
+	len = Q_min( size - 1, dot - slash );
 
-	while( start >= 0 && in[start] != '/' && in[start] != '\\' )
-		start--;
-
-	if( start < 0 || ( in[start] != '/' && in[start] != '\\' ))
-		start = 0;
-	else start++;
-
-	// length of new sting
-	len = end - start + 1;
-
-	// Copy partial string
-	Q_strncpy( out, &in[start], len + 1 );
+	memcpy( out, slash, len );
 	out[len] = 0;
 }
 

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -714,7 +714,7 @@ void COM_StripExtension( char *path )
 COM_DefaultExtension
 ==================
 */
-void COM_DefaultExtension( char *path, const char *extension )
+void COM_DefaultExtension( char *path, const char *extension, size_t size )
 {
 	const char	*src;
 	size_t		 len;
@@ -731,7 +731,7 @@ void COM_DefaultExtension( char *path, const char *extension )
 		src--;
 	}
 
-	Q_strcpy( &path[len], extension );
+	Q_strncpy( &path[len], extension, size - len );
 }
 
 /*
@@ -739,10 +739,10 @@ void COM_DefaultExtension( char *path, const char *extension )
 COM_ReplaceExtension
 ==================
 */
-void COM_ReplaceExtension( char *path, const char *extension )
+void COM_ReplaceExtension( char *path, const char *extension, size_t size )
 {
 	COM_StripExtension( path );
-	COM_DefaultExtension( path, extension );
+	COM_DefaultExtension( path, extension, size );
 }
 
 /*

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -490,18 +490,6 @@ int Q_snprintf( char *buffer, size_t buffersize, const char *format, ... )
 	return result;
 }
 
-int Q_sprintf( char *buffer, const char *format, ... )
-{
-	va_list	args;
-	int	result;
-
-	va_start( args, format );
-	result = Q_vsnprintf( buffer, 99999, format, args );
-	va_end( args );
-
-	return result;
-}
-
 void COM_StripColors( const char *in, char *out )
 {
 	while ( *in )
@@ -530,14 +518,14 @@ char *Q_pretifymem( float value, int digitsafterdecimal )
 	if( value > onemb )
 	{
 		value /= onemb;
-		Q_strcpy( suffix, " Mb" );
+		Q_strncpy( suffix, " Mb", sizeof( suffix ));
 	}
 	else if( value > onekb )
 	{
 		value /= onekb;
-		Q_strcpy( suffix, " Kb" );
+		Q_strncpy( suffix, " Kb", sizeof( suffix ));
 	}
-	else Q_strcpy( suffix, " bytes" );
+	else Q_strncpy( suffix, " bytes", sizeof( suffix ));
 
 	// clamp to >= 0
 	digitsafterdecimal = Q_max( digitsafterdecimal, 0 );
@@ -545,15 +533,15 @@ char *Q_pretifymem( float value, int digitsafterdecimal )
 	// if it's basically integral, don't do any decimals
 	if( fabs( value - (int)value ) < 0.00001f )
 	{
-		Q_sprintf( val, "%i%s", (int)value, suffix );
+		Q_snprintf( val, sizeof( val ), "%i%s", (int)value, suffix );
 	}
 	else
 	{
 		char fmt[32];
 
 		// otherwise, create a format string for the decimals
-		Q_sprintf( fmt, "%%.%if%s", digitsafterdecimal, suffix );
-		Q_sprintf( val, fmt, (double)value );
+		Q_snprintf( fmt, sizeof( fmt ), "%%.%if%s", digitsafterdecimal, suffix );
+		Q_snprintf( val, sizeof( val ), fmt, (double)value );
 	}
 
 	// copy from in to out

--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -64,9 +64,7 @@ void Q_strnlwr( const char *in, char *out, size_t size_out );
 size_t Q_colorstr( const char *string );
 char Q_toupper( const char in );
 char Q_tolower( const char in );
-#define Q_strcat( dst, src ) Q_strncat( dst, src, 99999 )
 size_t Q_strncat( char *dst, const char *src, size_t siz );
-#define Q_strcpy( dst, src ) Q_strncpy( dst, src, 99999 )
 size_t Q_strncpy( char *dst, const char *src, size_t siz );
 qboolean Q_isdigit( const char *str );
 qboolean Q_isspace( const char *str );

--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -84,7 +84,7 @@ int Q_sprintf( char *buffer, const char *format, ... ) _format( 2 );
 void COM_StripColors( const char *in, char *out );
 #define Q_memprint( val ) Q_pretifymem( val, 2 )
 char *Q_pretifymem( float value, int digitsafterdecimal );
-void COM_FileBase( const char *in, char *out );
+void COM_FileBase( const char *in, char *out, size_t size );
 const char *COM_FileExtension( const char *in );
 void COM_DefaultExtension( char *path, const char *extension );
 void COM_ReplaceExtension( char *path, const char *extension );

--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -79,15 +79,14 @@ const byte *Q_memmem( const byte *haystack, size_t haystacklen, const byte *need
 const char *Q_timestamp( int format );
 int Q_vsnprintf( char *buffer, size_t buffersize, const char *format, va_list args );
 int Q_snprintf( char *buffer, size_t buffersize, const char *format, ... ) _format( 3 );
-int Q_sprintf( char *buffer, const char *format, ... ) _format( 2 );
 #define Q_strpbrk strpbrk
 void COM_StripColors( const char *in, char *out );
 #define Q_memprint( val ) Q_pretifymem( val, 2 )
 char *Q_pretifymem( float value, int digitsafterdecimal );
 void COM_FileBase( const char *in, char *out, size_t size );
 const char *COM_FileExtension( const char *in );
-void COM_DefaultExtension( char *path, const char *extension );
-void COM_ReplaceExtension( char *path, const char *extension );
+void COM_DefaultExtension( char *path, const char *extension, size_t size );
+void COM_ReplaceExtension( char *path, const char *extension, size_t size );
 void COM_ExtractFilePath( const char *path, char *dest );
 const char *COM_FileWithoutPath( const char *in );
 void COM_StripExtension( char *path );

--- a/public/tests/test_filebase.c
+++ b/public/tests/test_filebase.c
@@ -1,0 +1,112 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "xash3d_mathlib.h"
+#include "crtlib.h"
+
+static void COM_FileBase_old( const char *in, char *out, size_t size )
+{
+	int	len, start, end;
+
+	len = Q_strlen( in );
+	if( !len || !size ) return;
+
+	// scan backward for '.'
+	end = len - 1;
+
+	while( end && in[end] != '.' && in[end] != '/' && in[end] != '\\' )
+		end--;
+
+	if( in[end] != '.' )
+		end = len-1; // no '.', copy to end
+	else end--; // found ',', copy to left of '.'
+
+	// scan backward for '/'
+	start = len - 1;
+
+	while( start >= 0 && in[start] != '/' && in[start] != '\\' )
+		start--;
+
+	if( start < 0 || ( in[start] != '/' && in[start] != '\\' ))
+		start = 0;
+	else start++;
+
+	// length of new sting
+	len = end - start + 1;
+
+	if( size > len ) // patched to somewhat support size limit
+	{
+		// Copy partial string
+		Q_strncpy( out, &in[start], len + 1 );
+		out[len] = 0;
+	}
+	else
+	{
+		Q_strncpy( out, &in[start], size );
+	}
+}
+
+#define COM_FILEBASE_CHECK( in, out, size, expected ) \
+	COM_FileBase( in, out, size );     \
+	if( Q_strcmp( out, expected ))     \
+	{                                  \
+		printf( "%d: fail with libpublic impl, got: %s, expected: %s\n", __LINE__, out, expected ); \
+		return 1;                      \
+	}                                  \
+	COM_FileBase_old( in, out, size ); \
+	if( Q_strcmp( out, expected ))     \
+	{                                  \
+		printf( "%d: fail with old impl, got: %s, expected: %s\n", __LINE__, out, expected ); \
+		return 2;                      \
+	}
+
+static int Test_FileBase( void )
+{
+	string s;
+
+	// test slashless case
+	COM_FILEBASE_CHECK( "asdf", s, sizeof( s ), "asdf" );
+
+	// test slashless case with extension
+	COM_FILEBASE_CHECK( "sdf.wad", s, sizeof( s ), "sdf" );
+
+	// test case with one slash
+	COM_FILEBASE_CHECK( "zxcv/asdfqwer", s, sizeof( s ), "asdfqwer" );
+
+	// test case with multiple slashes
+	COM_FILEBASE_CHECK( "zxc/asd/qwert", s, sizeof( s ), "qwert" );
+
+	// test case with full path
+	COM_FILEBASE_CHECK( "zxc/asd/qvert.lkjefgkljh", s, sizeof( s ), "qvert" );
+
+	// test case where dot placed before last slash
+	COM_FILEBASE_CHECK( "pak0.pk3/texture", s, sizeof( s ), "texture" );
+
+	// test case of directory path
+	COM_FILEBASE_CHECK( "pak0.pk3/", s, sizeof( s ), "" );
+
+	// test case of file with no name
+	COM_FILEBASE_CHECK( "blep/.nomedia", s, sizeof( s ), "" );
+
+	// test idiot cases
+	COM_FILEBASE_CHECK( NULL, s, sizeof( s ), "" );
+	COM_FILEBASE_CHECK( "", s, sizeof( s ), "" );
+	COM_FILEBASE_CHECK( "jhnwrgkujihrgwfikouj", s, 0, "" );
+
+	// test length limit
+	COM_FILEBASE_CHECK( "qwertyuiop", s, 3, "qw" );
+	COM_FILEBASE_CHECK( "qwertyuiop", s, 1, "" );
+
+	return 0;
+}
+
+int main( void )
+{
+	int ret;
+
+	ret = Test_FileBase();
+
+	if( ret )
+		return EXIT_FAILURE;
+
+	return EXIT_SUCCESS;
+}

--- a/public/tests/test_strings.c
+++ b/public/tests/test_strings.c
@@ -12,9 +12,6 @@ int Test_Strcpycatcmp( void )
 	if( Q_strcmp( dst, buf ))
 		return 2;
 
-	if( Q_strcpy( dst, buf ) != sizeof( buf ) - 1 )
-		return 3;
-
 	if( Q_strcmp( dst, buf ))
 		return 4;
 

--- a/public/wscript
+++ b/public/wscript
@@ -27,6 +27,7 @@ def build(bld):
 		tests = {
 			'strings': 'tests/test_strings.c',
 			'build': 'tests/test_build.c',
+			'filebase': 'tests/test_filebase.c',
 		}
 
 		for i in tests:

--- a/ref/gl/gl_alias.c
+++ b/ref/gl/gl_alias.c
@@ -443,7 +443,7 @@ rgbdata_t *Mod_CreateSkinData( model_t *mod, byte *data, int width, int height )
 		}
 	}
 
-	COM_FileBase( loadmodel->name, name );
+	COM_FileBase( loadmodel->name, name, sizeof( name ));
 
 	// for alias models only player can have remap textures
 	if( mod != NULL && !Q_stricmp( name, "player" ))

--- a/ref/gl/gl_backend.c
+++ b/ref/gl/gl_backend.c
@@ -689,7 +689,7 @@ rebuild_page:
 		if( FBitSet( image->flags, TF_DEPTHMAP ) && !FBitSet( image->flags, TF_NOCOMPARE ))
 			pglTexParameteri( image->target, GL_TEXTURE_COMPARE_MODE_ARB, GL_COMPARE_R_TO_TEXTURE_ARB );
 
-		COM_FileBase( image->name, shortname );
+		COM_FileBase( image->name, shortname, sizeof( shortname ));
 		if( Q_strlen( shortname ) > 18 )
 		{
 			// cutoff too long names, it looks ugly

--- a/ref/gl/gl_backend.c
+++ b/ref/gl/gl_backend.c
@@ -578,9 +578,8 @@ qboolean VID_CubemapShot( const char *base, uint size, const float *vieworg, qbo
 	r_shot->buffer = buffer;
 
 	// make sure what we have right extension
-	Q_strncpy( basename, base, MAX_STRING );
-	COM_StripExtension( basename );
-	COM_DefaultExtension( basename, ".tga" );
+	Q_strncpy( basename, base, sizeof( basename ));
+	COM_ReplaceExtension( basename, ".tga", sizeof( basename ));
 
 	// write image as 6 sides
 	result = gEngfuncs.FS_SaveImage( basename, r_shot );

--- a/ref/gl/gl_decals.c
+++ b/ref/gl/gl_decals.c
@@ -1188,7 +1188,7 @@ int R_CreateDecalList( decallist_t *pList )
 			pList[total].scale = decal->scale;
 
 			R_DecalUnProject( decal, &pList[total] );
-			COM_FileBase( R_GetTexture( decal->texture )->name, pList[total].name );
+			COM_FileBase( R_GetTexture( decal->texture )->name, pList[total].name, sizeof( pList[total].name ));
 
 			// check to see if the decal should be added
 			total = DecalListAdd( pList, total );

--- a/ref/gl/gl_image.c
+++ b/ref/gl/gl_image.c
@@ -1587,7 +1587,7 @@ int GL_LoadTextureArray( const char **names, int flags )
 	// create complexname from layer names
 	for( i = 0; i < numLayers - 1; i++ )
 	{
-		COM_FileBase( names[i], basename );
+		COM_FileBase( names[i], basename, sizeof( basename ));
 		ret = Q_snprintf( &name[len], sizeof( name ) - len, "%s|", basename );
 
 		if( ret == -1 )
@@ -1596,7 +1596,7 @@ int GL_LoadTextureArray( const char **names, int flags )
 		len += ret;
 	}
 	
-	COM_FileBase( names[i], basename );
+	COM_FileBase( names[i], basename, sizeof( basename ));
 	ret = Q_snprintf( &name[len], sizeof( name ) - len, "%s[%i]", basename, numLayers );
 
 	if( ret == -1 )

--- a/ref/gl/gl_rmisc.c
+++ b/ref/gl/gl_rmisc.c
@@ -119,7 +119,7 @@ void R_NewMap( void )
 
 		Q_strncpy( mapname, WORLDMODEL->name, sizeof( mapname ));
 		COM_StripExtension( mapname );
-		Q_sprintf( filepath, "%s_detail.txt", mapname );
+		Q_snprintf( filepath, sizeof( filepath ), "%s_detail.txt", mapname );
 
 		R_ParseDetailTextures( filepath );
 	}

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -3757,7 +3757,7 @@ static void R_StudioLoadTexture( model_t *mod, studiohdr_t *phdr, mstudiotexture
 	}
 
 	Q_strncpy( mdlname, mod->name, sizeof( mdlname ));
-	COM_FileBase( ptexture->name, name );
+	COM_FileBase( ptexture->name, name, sizeof( name ));
 	COM_StripExtension( mdlname );
 
 	if( FBitSet( ptexture->flags, STUDIO_NF_NOMIPS ))

--- a/ref/soft/r_decals.c
+++ b/ref/soft/r_decals.c
@@ -1200,7 +1200,7 @@ int GAME_EXPORT R_CreateDecalList( decallist_t *pList )
 			pList[total].scale = decal->scale;
 
 			R_DecalUnProject( decal, &pList[total] );
-			COM_FileBase( R_GetTexture( decal->texture )->name, pList[total].name );
+			COM_FileBase( R_GetTexture( decal->texture )->name, pList[total].name, sizeof( pList[total].name ));
 
 			// check to see if the decal should be added
 			total = DecalListAdd( pList, total );

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -3537,7 +3537,7 @@ static void R_StudioLoadTexture( model_t *mod, studiohdr_t *phdr, mstudiotexture
 	}
 
 	Q_strncpy( mdlname, mod->name, sizeof( mdlname ));
-	COM_FileBase( ptexture->name, name );
+	COM_FileBase( ptexture->name, name, sizeof( name ));
 	COM_StripExtension( mdlname );
 
 	if( FBitSet( ptexture->flags, STUDIO_NF_NOMIPS ))

--- a/utils/mdldec/mdldec.c
+++ b/utils/mdldec/mdldec.c
@@ -244,7 +244,7 @@ static qboolean LoadMDL( const char *modelname )
 		}
 	}
 
-	COM_FileBase( modelname, modelfile );
+	COM_FileBase( modelname, modelfile, sizeof( modelfile ));
 
 	SequenceNameFix();
 

--- a/utils/mdldec/qc.c
+++ b/utils/mdldec/qc.c
@@ -329,7 +329,7 @@ static void WriteBodyGroupInfo( FILE *fp )
 		{
 			model = (mstudiomodel_t *)( (byte *)model_hdr + bodypart->modelindex );
 
-			COM_FileBase( model->name, modelname );
+			COM_FileBase( model->name, modelname, sizeof( modelname ));
 
 			fprintf( fp, "$body \"%s\" \"%s\"\n\n", bodypart->name, modelname );
 			continue;
@@ -349,7 +349,7 @@ static void WriteBodyGroupInfo( FILE *fp )
 				continue;
 			}
 
-			COM_FileBase( model->name, modelname );
+			COM_FileBase( model->name, modelname, sizeof( modelname ));
 
 			fprintf( fp, "studio \"%s\"\n", modelname );
 		}

--- a/utils/mdldec/smd.c
+++ b/utils/mdldec/smd.c
@@ -465,7 +465,7 @@ static void WriteReferences( void )
 			if( !Q_strncmp( model->name, "blank", 5 ) )
 				continue;
 
-			COM_FileBase( model->name, name );
+			COM_FileBase( model->name, name, sizeof( name ));
 
 			len = Q_snprintf( filename, MAX_SYSPATH, "%s%s.smd", destdir, name );
 

--- a/utils/mdldec/texture.c
+++ b/utils/mdldec/texture.c
@@ -39,7 +39,7 @@ static void WriteBMP( mstudiotexture_t *texture )
 	bmp_t		 bmp_hdr = {0,};
 	size_t		 texture_size;
 
-	COM_FileBase( texture->name, texturename );
+	COM_FileBase( texture->name, texturename, sizeof( texturename ));
 	len = Q_snprintf( filename, MAX_SYSPATH, "%s%s.bmp", destdir, texturename );
 
 	if( len == -1 )


### PR DESCRIPTION
This PR removes usage of:
* Q_strcat
* Q_strcpy
* Q_sprintf
* Q_vsprintf (as important fix, merged to master already)

Adds size limit to:
* COM_Default/ReplaceExtensions
* COM_FileBase