### PR TITLE
PSVita: disable NPOT textures, use newer vitaGL

### DIFF
--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -744,8 +744,6 @@ void GL_InitExtensionsBigGL( void )
 #if XASH_PSVITA
 	// not all GL1.1 functions are implemented in vitaGL, but there's enough
 	GL_SetExtension( GL_OPENGL_110, true );
-	// NPOT textures are actually supported, but the extension is not listed in GL_EXTENSIONS
-	GL_SetExtension( GL_ARB_TEXTURE_NPOT_EXT, true );
 	// init our immediate mode override
 	VGL_ShimInit();
 #endif

--- a/scripts/gha/build_psvita.sh
+++ b/scripts/gha/build_psvita.sh
@@ -24,7 +24,7 @@ mkdir -p artifacts/ || die
 
 echo "Building vitaGL..."
 
-make -C vitaGL NO_TEX_COMBINER=1 HAVE_UNFLIPPED_FBOS=1 HAVE_PTHREAD=1 MATH_SPEEDHACK=1 DRAW_SPEEDHACK=1 HAVE_CUSTOM_HEAP=1 -j2 install || die
+make -C vitaGL NO_TEX_COMBINER=1 HAVE_UNFLIPPED_FBOS=1 HAVE_PTHREAD=1 MATH_SPEEDHACK=1 DRAW_SPEEDHACK=1 -j2 install || die
 
 echo "Building vrtld..."
 

--- a/scripts/gha/deps_psvita.sh
+++ b/scripts/gha/deps_psvita.sh
@@ -6,7 +6,7 @@ echo "Downloading vitasdk..."
 
 export VITASDK=/usr/local/vitasdk
 
-VITAGL_SRCREV="c52391378c2bf1a00a0194c4fd88c35492d104b8" # lock vitaGL version to avoid compilation errors
+VITAGL_SRCREV="064db9efb15833e18777a3e768b8b1fb2abee78f" # lock vitaGL version to avoid compilation errors
 
 install_package()
 {


### PR DESCRIPTION
No clue why NPOT texture mipmaps stopped working, but they did and that is the cause of the visual glitches mentioned in the Discord.
This breaks the menu buttons though since they don't render correctly with NPOT textures disabled for some reason.

This also bumps vitaGL to a newer commit, though still not the latest one because the latest one has major issues with the texture loader.