### PR TITLE
Disable server unload

### DIFF
--- a/engine/client/cl_gameui.c
+++ b/engine/client/cl_gameui.c
@@ -982,28 +982,21 @@ pfnCheckGameDll
 */
 int GAME_EXPORT pfnCheckGameDll( void )
 {
-	string dllpath;
-	void	*hInst;
-
-#if TARGET_OS_IPHONE
-	// loading server library drains too many ram
-	// so 512MB iPod Touch cannot even connect to
-	// to servers in cstrike
+#if XASH_INTERNAL_GAMELIBS
 	return true;
-#endif
+#else
+	string dllpath;
 
 	if( svgame.hInstance )
 		return true;
 
 	COM_GetCommonLibraryPath( LIBRARY_SERVER, dllpath, sizeof( dllpath ));
 
-	if(( hInst = COM_LoadLibrary( dllpath, true, false )) != NULL )
-	{
-		COM_FreeLibrary( hInst ); // don't increase linker's reference counter
+	if( FS_FileExists( dllpath, false ))
 		return true;
-	}
-	Con_Reportf( S_WARN "Could not load server library: %s\n", COM_GetLibraryError() );
+
 	return false;
+#endif
 }
 
 /*

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -747,8 +747,6 @@ void SV_ShutdownGame( void );
 void SV_ExecLoadLevel( void );
 void SV_ExecLoadGame( void );
 void SV_ExecChangeLevel( void );
-qboolean SV_InitGameProgs( void );
-void SV_FreeGameProgs( void );
 void CL_WriteMessageHistory( void );
 void CL_SendCmd( void );
 void CL_Disconnect( void );

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -1423,14 +1423,10 @@ save serverinfo variables into server.cfg (using for dedicated server too)
 */
 void GAME_EXPORT Host_WriteServerConfig( const char *name )
 {
-	qboolean already_loaded;
 	file_t	*f;
 	string newconfigfile;
 
 	Q_snprintf( newconfigfile, MAX_STRING, "%s.new", name );
-
-	// TODO: remove this mechanism, make it safer for now
-	already_loaded = SV_InitGameProgs();	// collect user variables
 
 	// FIXME: move this out until menu parser is done
 	CSCR_LoadDefaultCVars( "settings.scr" );
@@ -1448,10 +1444,6 @@ void GAME_EXPORT Host_WriteServerConfig( const char *name )
 		Host_FinalizeConfig( f, name );
 	}
 	else Con_DPrintf( S_ERROR "Couldn't write %s.\n", name );
-
-	// don't unload library that wasn't loaded by us
-	if( !already_loaded )
-		SV_FreeGameProgs();	// release progs with all variables
 }
 
 /*

--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -33,6 +33,7 @@ GNU General Public License for more details.
 #include "common.h"
 #include "base_cmd.h"
 #include "client.h"
+#include "server.h"
 #include "netchan.h"
 #include "protocol.h"
 #include "mod_local.h"
@@ -1308,6 +1309,7 @@ void EXPORT Host_Shutdown( void )
 #endif
 
 	SV_Shutdown( "Server shutdown\n" );
+	SV_UnloadProgs();
 	SV_ShutdownFilter();
 	CL_Shutdown();
 

--- a/engine/server/server.h
+++ b/engine/server/server.h
@@ -360,7 +360,6 @@ typedef struct
 typedef struct
 {
 	qboolean		initialized;		// sv_init has completed
-	qboolean	game_library_loaded;	// is game library loaded in SV_InitGame
 	double		timestart;		// just for profiling
 
 	int		maxclients;		// server max clients

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -5130,7 +5130,6 @@ void SV_UnloadProgs( void )
 
 	Mod_ResetStudioAPI ();
 
-	svs.game_library_loaded = false;
 	COM_FreeLibrary( svgame.hInstance );
 	Mem_FreePool( &svgame.mempool );
 	memset( &svgame, 0, sizeof( svgame ));

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -5148,7 +5148,13 @@ qboolean SV_LoadProgs( const char *name )
 	edict_t			*e;
 
 	if( svgame.hInstance )
+	{
+#if XASH_WIN32
+		SV_UnloadProgs();
+#else // XASH_WIN32
 		return true;
+#endif // XASH_WIN32
+	}
 
 	// fill it in
 	svgame.pmove = &gpMove;

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -5148,7 +5148,8 @@ qboolean SV_LoadProgs( const char *name )
 	static playermove_t		gpMove;
 	edict_t			*e;
 
-	if( svgame.hInstance ) SV_UnloadProgs();
+	if( svgame.hInstance )
+		return true;
 
 	// fill it in
 	svgame.pmove = &gpMove;

--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -1115,28 +1115,6 @@ int SV_GetMaxClients( void )
 	return svs.maxclients;
 }
 
-qboolean SV_InitGameProgs( void )
-{
-	string dllpath;
-
-	if( svgame.hInstance ) return true; // already loaded
-
-	COM_GetCommonLibraryPath( LIBRARY_SERVER, dllpath, sizeof( dllpath ));
-
-	// just try to initialize
-	SV_LoadProgs( dllpath );
-
-	return false;
-}
-
-void SV_FreeGameProgs( void )
-{
-	if( svs.initialized ) return;	// server is active
-
-	// unload progs (free cvars and commands)
-	SV_UnloadProgs();
-}
-
 /*
 ================
 SV_ExecLoadLevel

--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -706,7 +706,7 @@ qboolean SV_InitGame( void )
 {
 	string dllpath;
 
-	if( svs.game_library_loaded )
+	if( svgame.hInstance )
 		return true;
 
 	// first initialize?
@@ -721,7 +721,6 @@ qboolean SV_InitGame( void )
 	}
 
 	// client frames will be allocated in SV_ClientConnect
-	svs.game_library_loaded = true;
 	return true;
 }
 

--- a/engine/server/sv_main.c
+++ b/engine/server/sv_main.c
@@ -1090,8 +1090,6 @@ void SV_Shutdown( const char *finalmsg )
 		// drop the client if want to load a new map
 		if( CL_IsPlaybackDemo( ))
 			CL_Drop();
-
-		SV_UnloadProgs ();
 		return;
 	}
 
@@ -1108,7 +1106,7 @@ void SV_Shutdown( const char *finalmsg )
 		NET_MasterShutdown();
 
 	NET_Config( false, false );
-	SV_UnloadProgs ();
+	SV_DeactivateServer();
 	CL_Drop();
 
 	// free current level

--- a/engine/server/sv_main.c
+++ b/engine/server/sv_main.c
@@ -1090,6 +1090,10 @@ void SV_Shutdown( const char *finalmsg )
 		// drop the client if want to load a new map
 		if( CL_IsPlaybackDemo( ))
 			CL_Drop();
+
+#if XASH_WIN32
+		SV_UnloadProgs();
+#endif // XASH_WIN32
 		return;
 	}
 
@@ -1107,6 +1111,9 @@ void SV_Shutdown( const char *finalmsg )
 
 	NET_Config( false, false );
 	SV_DeactivateServer();
+#if XASH_WIN32
+	SV_UnloadProgs();
+#endif // XASH_WIN32
 	CL_Drop();
 
 	// free current level

--- a/public/crtlib.c
+++ b/public/crtlib.c
@@ -642,7 +642,14 @@ COM_ExtractFilePath
 */
 void COM_ExtractFilePath( const char *path, char *dest )
 {
-	const char *src = path + Q_strlen( path ) - 1;
+	size_t len = Q_strlen( path );
+	const char *src = path + len - 1;
+
+	if( len == 0 )
+	{
+		dest[0] = 0;
+		return;
+	}
 
 	// back up until a \ or the start
 	while( src != path && !(*(src - 1) == '\\' || *(src - 1) == '/' ))


### PR DESCRIPTION
cc @mittorn @SNMetamorph @nekonomicon @Vladislav4KZ 

Despite this in general might fix a lot of bugs on many platforms, this still needs to be tested against random oddities, especially in mods that were made for Xash3D.

I only had a random issue where entity didn't get correct state after map reload (load any map in HL1, then load Hazard Course, and you'll fall out of the elevator). But calling `SV_DeactivateServer()` in place of `SV_UnloadProgs()` in `SV_Shutdown()` seems to be helped, and it makes sense to clean up entities, and etc.