### PR TITLE
Попытка починить levelshots

### DIFF
--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -993,9 +993,10 @@ void CL_ParseServerData( sizebuf_t *msg, qboolean legacy )
 	{
 		if( !FS_FileExists( va( "%s.bmp", cl_levelshot_name.string ), true ))
 			Cvar_Set( "cl_levelshot_name", "*black" ); // render a black screen
-		cls.scrshot_request = scrshot_plaque; // request levelshot even if exist (check filetime)
 	}
 
+	cls.scrshot_request = scrshot_plaque; // request levelshot even if exist (check filetime)
+	
 	for( i = 0; i < MAX_CLIENTS; i++ )
 		COM_ClearCustomizationList( &cl.players[i].customdata, true );
 	CL_CreateCustomizationList();


### PR DESCRIPTION
## Ситуация

При переходе между уровнями что `ref_gl`, что в `ref_vk` рисуется чёрный экран. В оригинале игры изображение "застывает", пока не прогрузится следующий уровень. Чёрный экран сильно давит на глаза во время игры.

На этот баг жаловались пару раз:

- https://github.com/FWGS/xash3d-fwgs/issues/798
- https://github.com/FWGS/xash3d-fwgs/issues/641

А так же было одно ишью в форке от @w23:

- https://github.com/w23/xash3d-fwgs/issues/250

## Причины проблемы

При смене уровня явно подразумевалась отрисовка скриншота уровня: для этого есть весь код. Но скриншота на момент смены локации не существует.

Поковыряв цепочку вызовов я выяснил, что для создания скриншотов происходит вызов [`SCR_MakeLevelShot`](https://github.com/FWGS/xash3d-fwgs/blob/4acd0e5304059a2e2dafbf98ec5644c22733319e/engine/client/cl_scrn.c#L239), которая дёргает команду `levelshot`. Команда проставляет переменные и активирует [`SCR_MakeScreenShot`](https://github.com/FWGS/xash3d-fwgs/blob/4acd0e5304059a2e2dafbf98ec5644c22733319e/engine/client/cl_scrn.c#L286), которая сделает скриншот сразу после отрисовки следующего кадра.

Но [`SCR_MakeLevelShot`](https://github.com/FWGS/xash3d-fwgs/blob/4acd0e5304059a2e2dafbf98ec5644c22733319e/engine/client/cl_scrn.c#L239) не отрабатывает, ибо в переменную `scrshot_request` не прописан `scrshot_plaque`, на который сделана проверка.

Судя по всему, скриншот должен создаваться после вызова [`CL_ParseServerData`](https://github.com/FWGS/xash3d-fwgs/blob/4acd0e5304059a2e2dafbf98ec5644c22733319e/engine/client/cl_parse.c#L849). При вызове этой функции прописываются пути до скриншота уровня, а так же происходит какая-то неочевидная проверка с установкой `scrshot_plaque`.

Больше никто не проставляет `scrshot_plaque` для создания скриншота уровня.

Не долго думая, я безусловно выставил `scrshot_plaque` в [`CL_ParseServerData`](https://github.com/FWGS/xash3d-fwgs/blob/4acd0e5304059a2e2dafbf98ec5644c22733319e/engine/client/cl_parse.c#L849).

## Последствия фикса

При повторном переходе между уровнями теперь отображаются скриншоты. Правда, только при повторном. При первом переходе скриншот не успевает создаться и отрисовывается чёрный экран. Так же скриншоты не удаляются при выходе из игры или смены карты, и при переходе туда-сюда рисуется старый скриншот. Но кажется это лучше, чем контрастно чёрный экран после светлой локации, бьющий по глазам.

## Дополнение

Я не думаю, что мой фикс правильный. У меня в голове нет понимания, *что хотел сказать автор своим кодом* и как лучше сделать "застывание" камеры при переключении уровней. Кажется, что скриншот для этого не очень подходит: копировать картинку с видеокарты, писать на диск и потом читать явно работает медленнее, чем сама смена уровня.