### PR TITLE
Add gameinfo.txt key to make engine use larger lightmaps without modifying the DLL

### DIFF
--- a/Documentation/gameinfo.md
+++ b/Documentation/gameinfo.md
@@ -76,6 +76,7 @@ These strings are specific to Xash3D FWGS.
 | `internal_vgui_support` | boolean    | 0                        | Only for programmers! Required to be set as 1 for PrimeXT!<br>When set to 1, the engine will not load vgui_support DLL, as VGUI support is done (or intentionally ignored) on the game side. |
 | `render_picbutton_text` | boolean    | 0                        | When set to 1, the UI will not use prerendered `btns_main.bmp` and dynamically render them instead |
 | `quicksave_aged_count`  | integer    | 2                        | Quick saves limit used in saves rotation |
+| `use_large_lightmaps`   | boolean    | 0                        | Enables ENGINE_LARGE_LIGHTMAPS feature. DLL still overrides this key through PhysicAPI. |
 
 ## Note on GoldSrc liblist.gam support
 

--- a/engine/server/sv_phys.c
+++ b/engine/server/sv_phys.c
@@ -2129,6 +2129,9 @@ qboolean SV_InitPhysicsAPI( void )
 {
 	static PHYSICAPI	pPhysIface;
 
+	if( GI->use_large_lightmaps )
+		SetBits( host.features, ENGINE_LARGE_LIGHTMAPS );
+
 	pPhysIface = (PHYSICAPI)COM_GetProcAddress( svgame.hInstance, "Server_GetPhysicsInterface" );
 	if( pPhysIface )
 	{
@@ -2140,7 +2143,6 @@ qboolean SV_InitPhysicsAPI( void )
 			{
 				// grab common engine features (it will be shared across the network)
 				host.features = svgame.physFuncs.SV_CheckFeatures();
-				Host_PrintEngineFeatures ();
 			}
 			return true;
 		}
@@ -2150,6 +2152,8 @@ qboolean SV_InitPhysicsAPI( void )
 
 		return false; // just tell user about problems
 	}
+
+	Host_PrintEngineFeatures();
 
 	// physic interface is missed
 	return true;

--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -609,6 +609,7 @@ static void FS_WriteGameInfo( const char *filepath, gameinfo_t *GameInfo )
 	// always expose our extensions :)
 	FS_Printf( f, "internal_vgui_support\t\t%s\n", GameInfo->internal_vgui_support ? "1" : "0" );
 	FS_Printf( f, "render_picbutton_text\t\t%s\n", GameInfo->render_picbutton_text ? "1" : "0" );
+	FS_Printf( f, "use_large_lightmaps\t\t%s\n", GameInfo->use_large_lightmaps ? "1" : "0" );
 
 	FS_Close( f );	// all done
 }
@@ -865,6 +866,11 @@ void FS_ParseGenericGameInfo( gameinfo_t *GameInfo, const char *buf, const qbool
 			{
 				pfile = COM_ParseFile( pfile, token, sizeof( token ));
 				GameInfo->autosave_aged_count = bound( 2, Q_atoi( token ), 99 );
+			}
+			else if( !Q_stricmp( token, "use_large_lightmaps" ))
+			{
+				pfile = COM_ParseFile( pfile, token, sizeof( token ));
+				GameInfo->use_large_lightmaps = Q_atoi( token ) ? true : false;
 			}
 		}
 	}

--- a/filesystem/filesystem.h
+++ b/filesystem/filesystem.h
@@ -105,6 +105,8 @@ typedef struct gameinfo_s
 
 	int		quicksave_aged_count; // min is 1, max is 99
 	int		autosave_aged_count; // min is 1, max is 99
+
+	qboolean	use_large_lightmaps; // enables engine feature ENGINE_LARGE_LIGHTMAPS without the need of patching the DLL
 } gameinfo_t;
 
 typedef enum


### PR DESCRIPTION
The DLL requested features still takes precedence over this key. 

Should we warn if gameinfo.txt has use_large_lightmaps 1 but DLL doesn't request it?