### PR TITLE
Software ripples for GL renderer

### DIFF
--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -16,6 +16,7 @@ CVAR_DEFINE_AUTO( gl_msaa_samples, "0", FCVAR_GLCONFIG, "samples number for mult
 CVAR_DEFINE_AUTO( gl_clear, "0", FCVAR_ARCHIVE, "clearing screen after each frame" );
 CVAR_DEFINE_AUTO( r_showtree, "0", FCVAR_ARCHIVE, "build the graph of visible BSP tree" );
 static CVAR_DEFINE_AUTO( r_refdll, "", FCVAR_RENDERINFO, "choose renderer implementation, if supported" );
+static CVAR_DEFINE_AUTO( r_refdll_loaded, "", FCVAR_READ_ONLY, "currently loaded renderer" );
 
 void R_GetTextureParms( int *w, int *h, int texnum )
 {
@@ -519,6 +520,7 @@ static qboolean R_LoadRenderer( const char *refopt )
 		return false;
 	}
 
+	Cvar_FullSet( "r_refdll_loaded", refopt, FCVAR_READ_ONLY );
 	Con_Reportf( "Renderer %s initialized\n", refdll );
 
 	return true;
@@ -610,6 +612,7 @@ qboolean R_Init( void )
 	Cvar_RegisterVariable( &gl_clear );
 	Cvar_RegisterVariable( &r_showtree );
 	Cvar_RegisterVariable( &r_refdll );
+	Cvar_RegisterVariable( &r_refdll_loaded );
 
 	// cvars that are expected to exist
 	Cvar_Get( "r_speeds", "0", FCVAR_ARCHIVE, "shows renderer speeds" );

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -2012,6 +2012,20 @@ static void Mod_LoadMarkSurfaces( model_t *mod, dbspmodel_t *bmod )
 	}
 }
 
+static qboolean Mod_LooksLikeWaterTexture( const char *name )
+{
+	if(( name[0] == '*' && Q_stricmp( name, REF_DEFAULT_TEXTURE )) || name[0] == '!' )
+		return true;
+
+	if( !Host_IsQuakeCompatible( ))
+	{
+		if( !Q_strncmp( name, "water", 5 ) || !Q_strnicmp( name, "laser", 5 ))
+			return true;
+	}
+
+	return false;
+}
+
 static void Mod_LoadTextureData( model_t *mod, dbspmodel_t *bmod, int textureIndex )
 {
 #if !XASH_DEDICATED
@@ -2031,6 +2045,10 @@ static void Mod_LoadTextureData( model_t *mod, dbspmodel_t *bmod, int textureInd
 
 	if( FBitSet( host.features, ENGINE_IMPROVED_LINETRACE ) && mipTex->name[0] == '{' )
 		SetBits( txFlags, TF_KEEP_SOURCE ); // Paranoia2 texture alpha-tracing
+
+	// check if this is water to keep the source texture and expand it to RGBA (so ripple effect works)
+	if( Mod_LooksLikeWaterTexture( mipTex->name ))
+		SetBits( txFlags, TF_KEEP_SOURCE | TF_EXPAND_SOURCE );
 
 	usesCustomPalette = Mod_CalcMipTexUsesCustomPalette( mod, bmod, textureIndex );
 
@@ -2449,14 +2467,8 @@ static void Mod_LoadSurfaces( model_t *mod, dbspmodel_t *bmod )
 		if( !Q_strncmp( tex->name, "sky", 3 ))
 			SetBits( out->flags, SURF_DRAWSKY );
 
-		if(( tex->name[0] == '*' && Q_stricmp( tex->name, REF_DEFAULT_TEXTURE )) || tex->name[0] == '!' )
+		if( Mod_LooksLikeWaterTexture( tex->name ))
 			SetBits( out->flags, SURF_DRAWTURB );
-
-		if( !Host_IsQuakeCompatible( ))
-		{
-			if( !Q_strncmp( tex->name, "water", 5 ) || !Q_strnicmp( tex->name, "laser", 5 ))
-				SetBits( out->flags, SURF_DRAWTURB );
-		}
 
 		if( !Q_strncmp( tex->name, "scroll", 6 ))
 			SetBits( out->flags, SURF_CONVEYOR );

--- a/ref/gl/gl_image.c
+++ b/ref/gl/gl_image.c
@@ -342,6 +342,8 @@ void R_SetTextureParameters( void )
 	// change all the existing mipmapped texture objects
 	for( i = 0; i < gl_numTextures; i++ )
 		GL_UpdateTextureParams( i );
+
+	R_UpdateRippleTexParams();
 }
 
 /*
@@ -2317,6 +2319,7 @@ void R_InitImages( void )
 	// validate cvars
 	R_SetTextureParameters();
 	GL_CreateInternalTextures();
+	R_InitRipples();
 
 	gEngfuncs.Cmd_AddCommand( "texturelist", R_TextureList_f, "display loaded textures list" );
 }

--- a/ref/gl/gl_local.h
+++ b/ref/gl/gl_local.h
@@ -489,6 +489,11 @@ void R_ClearSkyBox( void );
 void R_DrawSkyBox( void );
 void R_DrawClouds( void );
 void EmitWaterPolys( msurface_t *warp, qboolean reverse );
+void R_InitRipples( void );
+void R_ResetRipples( void );
+void R_AnimateRipples( void );
+void R_UpdateRippleTexParams( void );
+void R_UploadRipples( texture_t *image );
 
 //
 // gl_vgui.c
@@ -750,6 +755,9 @@ extern convar_t	r_vbo;
 extern convar_t	r_vbo_dlightmode;
 extern convar_t r_studio_sort_textures;
 extern convar_t r_studio_drawelements;
+extern convar_t r_ripple;
+extern convar_t r_ripple_updatetime;
+extern convar_t r_ripple_spawntime;
 
 //
 // engine shared convars

--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -30,6 +30,10 @@ CVAR_DEFINE_AUTO( r_traceglow, "0", FCVAR_GLCONFIG, "cull flares behind models" 
 CVAR_DEFINE_AUTO( gl_round_down, "2", FCVAR_GLCONFIG|FCVAR_READ_ONLY, "round texture sizes to nearest POT value" );
 CVAR_DEFINE( r_vbo, "gl_vbo", "0", FCVAR_ARCHIVE, "draw world using VBO (known to be glitchy)" );
 CVAR_DEFINE( r_vbo_dlightmode, "gl_vbo_dlightmode", "1", FCVAR_ARCHIVE, "vbo dlight rendering mode (0-1)" );
+CVAR_DEFINE_AUTO( r_ripple, "0", FCVAR_GLCONFIG, "enable software-like water texture ripple simulation" );
+CVAR_DEFINE_AUTO( r_ripple_updatetime, "0.05", FCVAR_GLCONFIG, "how fast ripple simulation is" );
+CVAR_DEFINE_AUTO( r_ripple_spawntime, "0.1", FCVAR_GLCONFIG, "how fast new ripples spawn" );
+
 
 DEFINE_ENGINE_SHARED_CVAR_LIST()
 
@@ -1186,6 +1190,9 @@ void GL_InitCommands( void )
 	gEngfuncs.Cvar_RegisterVariable( &r_traceglow );
 	gEngfuncs.Cvar_RegisterVariable( &r_studio_sort_textures );
 	gEngfuncs.Cvar_RegisterVariable( &r_studio_drawelements );
+	gEngfuncs.Cvar_RegisterVariable( &r_ripple );
+	gEngfuncs.Cvar_RegisterVariable( &r_ripple_updatetime );
+	gEngfuncs.Cvar_RegisterVariable( &r_ripple_spawntime );
 
 	gEngfuncs.Cvar_RegisterVariable( &gl_extensions );
 	gEngfuncs.Cvar_RegisterVariable( &gl_texture_nearest );

--- a/ref/gl/gl_rmain.c
+++ b/ref/gl/gl_rmain.c
@@ -969,6 +969,8 @@ void R_RenderScene( void )
 
 	R_MarkLeaves();
 	R_DrawFog ();
+	if( RI.drawWorld )
+		R_AnimateRipples();
 
 	R_CheckGLFog();
 	R_DrawWorld();

--- a/ref/gl/gl_rmisc.c
+++ b/ref/gl/gl_rmisc.c
@@ -150,6 +150,7 @@ void R_NewMap( void )
 
 	GL_BuildLightmaps ();
 	R_GenerateVBO();
+	R_ResetRipples();
 
 	if( gEngfuncs.drawFuncs->R_NewMap != NULL )
 		gEngfuncs.drawFuncs->R_NewMap();

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -204,7 +204,7 @@ void GL_SetupFogColorForSurfaces( void )
 	vec3_t	fogColor;
 	float	factor, div;
 
-	if( !glState.isFogEnabled)
+	if( !glState.isFogEnabled )
 		return;
 
 	if( RI.currententity && RI.currententity->curstate.rendermode == kRenderTransTexture )
@@ -1135,14 +1135,15 @@ void R_RenderBrushPoly( msurface_t *fa, int cull_type )
 
 	t = R_TextureAnimation( fa );
 
-	GL_Bind( XASH_TEXTURE0, t->gl_texturenum );
-
 	if( FBitSet( fa->flags, SURF_DRAWTURB ))
 	{
+		R_UploadRipples( t );
+
 		// warp texture, no lightmaps
 		EmitWaterPolys( fa, (cull_type == CULL_BACKSIDE));
 		return;
 	}
+	else GL_Bind( XASH_TEXTURE0, t->gl_texturenum );
 
 	if( t->fb_texturenum )
 	{
@@ -1411,7 +1412,7 @@ void R_DrawWaterSurfaces( void )
 			continue;
 
 		// set modulate mode explicitly
-		GL_Bind( XASH_TEXTURE0, t->gl_texturenum );
+		R_UploadRipples( t );
 
 		for( ; s; s = s->texturechain )
 			EmitWaterPolys( s, false );

--- a/ref/gl/gl_warp.c
+++ b/ref/gl/gl_warp.c
@@ -82,7 +82,7 @@ static struct
 	uint32_t texture[RIPPLES_TEXSIZE];
 	int gl_texturenum;
 	int rippletexturenum;
-	int texturescale; // not all textures are 128x128, scale the texcoords down
+	float texturescale; // not all textures are 128x128, scale the texcoords down
 } g_ripple;
 
 static qboolean CheckSkybox( const char *name, char out[6][MAX_STRING] )
@@ -1010,7 +1010,15 @@ void R_UploadRipples( texture_t *image )
 		return;
 
 	g_ripple.gl_texturenum = image->gl_texturenum;
-	g_ripple.texturescale = Q_max( 1, image->width / 64 );
+	if( r_ripple.value == 1.0f )
+	{
+		g_ripple.texturescale = Q_max( 1.0f, image->width / 64.0f );
+	}
+	else
+	{
+		g_ripple.texturescale = 1.0f;
+	}
+
 
 	pixels = (uint32_t *)glt->original->buffer;
 	wbits = MostSignificantBit( image->width );

--- a/ref/gl/gl_warp.c
+++ b/ref/gl/gl_warp.c
@@ -790,9 +790,7 @@ void EmitWaterPolys( msurface_t *warp, qboolean reverse )
 	if( !warp->polys ) return;
 
 	// set the current waveheight
-	if( r_ripple.value )
-		waveHeight = 0;
-	else if( warp->polys->verts[0][2] >= RI.vieworg[2] )
+	if( warp->polys->verts[0][2] >= RI.vieworg[2] )
 		waveHeight = -RI.currententity->curstate.scale;
 	else waveHeight = RI.currententity->curstate.scale;
 

--- a/ref/gl/gl_warp.c
+++ b/ref/gl/gl_warp.c
@@ -957,9 +957,9 @@ void R_AnimateRipples( void )
 
 		g_ripple.oldtime = g_ripple.time;
 
-		x = gEngfuncs.COM_RandomLong( 0, 0x7fff );
-		y = gEngfuncs.COM_RandomLong( 0, 0x7fff );
-		val = gEngfuncs.COM_RandomLong( 0, 0x3ff );
+		x = rand() & 0x7fff;
+		y = rand() & 0x7fff;
+		val = rand() & 0x3ff;
 
 		R_SpawnNewRipple( x, y, val );
 	}

--- a/ref/gl/gl_warp.c
+++ b/ref/gl/gl_warp.c
@@ -1012,7 +1012,9 @@ void R_UploadRipples( texture_t *image )
 		return;
 
 	g_ripple.gl_texturenum = image->gl_texturenum;
-	g_ripple.texturescale = RIPPLES_CACHEWIDTH / image->width;
+
+	// TODO: original sw.dll always draws at 64x64
+	g_ripple.texturescale = Q_max( 2, RIPPLES_CACHEWIDTH / image->width );
 
 	pixels = (uint32_t *)glt->original->buffer;
 	v = MostSignificantBit( image->width );


### PR DESCRIPTION
We just update textures here.

This version differs from my older version I did for Yamagi Quake 2, just to be sure, I rechecked it with decompile and compared it against original `sw.dll`, that's why it uses only 64x64 despite drawing texture at 128x128.

I want this merged with the current CPU-based solution, as I believe someone smart will later make a GPU-based solution, and we would be able to compare if it will be any better.

