### PR TITLE
Getnativeobject

### DIFF
--- a/Documentation/extensions/native-object.md
+++ b/Documentation/extensions/native-object.md
@@ -1,0 +1,25 @@
+# GetNativeObject API
+
+To be able to use platform-specific features or get optional engine interfaces, we've added a simple call to MobilityAPI on client DLL and PhysicsAPI for server DLL and extended MenuAPI for menu DLL.
+
+It's defined like this:
+
+```
+void *pfnGetNativeObject( const char *name );
+```
+
+#### Cross-platform objects
+
+Only these objects are guaranteed to be available on all targets.
+
+| Object name | Interface |
+|-------------|-----------|
+| `VFileSystem009` | Provides C++ interface to filesystem, binary-compatible with Valve's VFileSystem009. |
+| `XashFileSystemXXX` | Provides C interface to filesystem. This interface is unstable and not recommended for generic use, outside of engine internals. For more info about current version look into `filesystem.h`. |
+
+#### Android-specific objects
+
+| Object name | Interface |
+|-------------|-----------|
+| `JNIEnv`    | Allows interfacing with Java Native Interface. |
+| `ActivityClass` | Returns JNI object for engine Android activity class. |

--- a/engine/client/cl_gameui.c
+++ b/engine/client/cl_gameui.c
@@ -1211,6 +1211,7 @@ static ui_extendedfuncs_t gExtendedfuncs =
 	pfnParseFileSafe,
 	NET_AdrToString,
 	NET_CompareAdrSort,
+	Sys_GetNativeObject,
 };
 
 void UI_UnloadProgs( void )

--- a/engine/menu_int.h
+++ b/engine/menu_int.h
@@ -215,6 +215,7 @@ typedef struct ui_extendedfuncs_s {
 	// network address funcs
 	const char *(*pfnAdrToString)( const struct netadr_s a );
 	int (*pfnCompareAdr)( const void *a, const void *b ); // netadr_t
+	void *(*pfnGetNativeObject)( const char *name );
 } ui_extendedfuncs_t;
 
 // deprecated export from old engine

--- a/engine/physint.h
+++ b/engine/physint.h
@@ -107,7 +107,10 @@ typedef struct server_physics_api_s
 	int		(*pfnSaveFile)( const char *filename, const void *data, int len );
 	const byte	*(*pfnLoadImagePixels)( const char *filename, int *width, int *height );
 
-	const char*	(*pfnGetModelName)( int modelindex );
+	const char *(*pfnGetModelName)( int modelindex );
+
+	// FWGS extension
+	void       *(*pfnGetNativeObject)( const char *object );
 } server_physics_api_t;
 
 // physic callbacks

--- a/engine/platform/android/android.c
+++ b/engine/platform/android/android.c
@@ -63,23 +63,16 @@ Android_GetNativeObject
 
 void *Android_GetNativeObject( const char *name )
 {
-	static const char *availObjects[] = { "JNIEnv", "ActivityClass", NULL };
-	void *object = NULL;
-
-	if( !name )
+	if( !strcasecmp( name, "JNIEnv" ) )
 	{
-		object = (void *)availObjects;
-	}
-	else if( !strcasecmp( name, "JNIEnv" ) )
-	{
-		object = (void *)jni.env;
+		return (void *)jni.env;
 	}
 	else if( !strcasecmp( name, "ActivityClass" ) )
 	{
-		object = (void *)jni.actcls;
+		return (void *)jni.actcls;
 	}
 
-	return object;
+	return NULL;
 }
 
 /*

--- a/engine/server/sv_phys.c
+++ b/engine/server/sv_phys.c
@@ -2116,6 +2116,7 @@ static server_physics_api_t gPhysicsAPI =
 	COM_SaveFile,
 	pfnLoadImagePixels,
 	pfnGetModelName,
+	Sys_GetNativeObject
 };
 
 /*


### PR DESCRIPTION
Add GetNativeObject to menu extended and server physics API.

Though I'm not sure about extending server physics API as it's not strictly unique to FWGS, and there could be a situation where we would have to support multiple API versions because of that decision (compatibility with other Xash3D fork or Unkle Mike suddenly updating the API).
