### PR TITLE
Refapi 5

### DIFF
--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -1109,12 +1109,12 @@ void CL_InitEdicts( int maxclients )
 		clgame.remap_info = (remap_info_t **)Mem_Calloc( clgame.mempool, sizeof( remap_info_t* ) * clgame.maxRemapInfos );
 	}
 
-	ref.dllFuncs.R_ProcessEntData( true );
+	ref.dllFuncs.R_ProcessEntData( true, clgame.entities, clgame.maxEntities );
 }
 
 void CL_FreeEdicts( void )
 {
-	ref.dllFuncs.R_ProcessEntData( false );
+	ref.dllFuncs.R_ProcessEntData( false, NULL, 0 );
 
 	if( clgame.entities )
 		Mem_Free( clgame.entities );

--- a/engine/client/client.h
+++ b/engine/client/client.h
@@ -996,9 +996,7 @@ void CL_EmitEntities( void );
 // cl_remap.c
 //
 remap_info_t *CL_GetRemapInfoForEntity( cl_entity_t *e );
-void CL_AllocRemapInfo( cl_entity_t *entity, model_t *model, int topcolor, int bottomcolor );
-void CL_FreeRemapInfo( remap_info_t *info );
-void CL_UpdateRemapInfo( cl_entity_t *ent, int topcolor, int bottomcolor );
+qboolean CL_EntitySetRemapColors( cl_entity_t *e, model_t *mod, int top, int bottom );
 void CL_ClearAllRemaps( void );
 
 //

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -425,7 +425,7 @@ static qboolean R_LoadProgs( const char *name )
 	// make local copy of engfuncs to prevent overwrite it with user dll
 	memcpy( &gpEngfuncs, &gEngfuncs, sizeof( gpEngfuncs ));
 
-	if( !GetRefAPI( REF_API_VERSION, &ref.dllFuncs, &gpEngfuncs, &refState ))
+	if( GetRefAPI( REF_API_VERSION, &ref.dllFuncs, &gpEngfuncs, &refState ) != REF_API_VERSION )
 	{
 		COM_FreeLibrary( ref.hInstance );
 		Con_Reportf( "R_LoadProgs: can't init renderer API: wrong version\n" );

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -272,10 +272,8 @@ static ref_api_t gEngfuncs =
 	pfnMod_Extradata,
 	pfnGetModels,
 
+	CL_EntitySetRemapColors,
 	CL_GetRemapInfoForEntity,
-	CL_AllocRemapInfo,
-	CL_FreeRemapInfo,
-	CL_UpdateRemapInfo,
 
 	CL_ExtraUpdate,
 	Host_Error,

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -212,6 +212,11 @@ static qboolean R_Init_Video_( const int type )
 	return R_Init_Video( type );
 }
 
+static model_t **pfnGetModels( void )
+{
+	return cl.models;
+}
+
 static ref_api_t gEngfuncs =
 {
 	pfnEngineGetParm,
@@ -248,7 +253,6 @@ static ref_api_t gEngfuncs =
 
 	CL_GetLocalPlayer,
 	CL_GetViewModel,
-	CL_GetEntityByIndex,
 	R_BeamGetEntity,
 	CL_GetWaterEntity,
 	CL_AddVisibleEntity,
@@ -272,7 +276,7 @@ static ref_api_t gEngfuncs =
 
 	Mod_ForName,
 	pfnMod_Extradata,
-	CL_ModelHandle,
+	pfnGetModels,
 
 	CL_GetRemapInfoForEntity,
 	CL_AllocRemapInfo,

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -104,9 +104,9 @@ static void pfnGetPredictedOrigin( vec3_t v )
 	VectorCopy( cl.simorg, v );
 }
 
-static color24 *pfnCL_GetPaletteColor( int color ) // clgame.palette[color]
+static color24 *pfnCL_GetPaletteColor( void ) // clgame.palette[color]
 {
-	return &clgame.palette[color];
+	return clgame.palette;
 }
 
 static void pfnCL_GetScreenInfo( int *width, int *height ) // clgame.scrInfo, ptrs may be NULL
@@ -156,11 +156,6 @@ static int pfnGetStudioModelInterface( int version, struct r_studio_interface_s 
 	return clgame.dllFuncs.pfnGetStudioModelInterface ?
 		clgame.dllFuncs.pfnGetStudioModelInterface( version, ppinterface, pstudio ) :
 		0;
-}
-
-static poolhandle_t pfnImage_GetPool( void )
-{
-	return host.imagepool;
 }
 
 static const bpc_desc_t *pfnImage_GetPFDesc( int idx )
@@ -251,7 +246,6 @@ static ref_api_t gEngfuncs =
 	Con_DrawString,
 	CL_DrawCenterPrint,
 
-	CL_GetLocalPlayer,
 	CL_GetViewModel,
 	R_BeamGetEntity,
 	CL_GetWaterEntity,
@@ -289,7 +283,6 @@ static ref_api_t gEngfuncs =
 	COM_RandomFloat,
 	COM_RandomLong,
 	pfnRefGetScreenFade,
-	CL_TextMessageGet,
 	pfnGetPredictedOrigin,
 	pfnCL_GetPaletteColor,
 	pfnCL_GetScreenInfo,
@@ -353,7 +346,6 @@ static ref_api_t gEngfuncs =
 	FS_CopyImage,
 	FS_FreeImage,
 	Image_SetMDLPointer,
-	pfnImage_GetPool,
 	pfnImage_GetPFDesc,
 
 	pfnDrawNormalTriangles,

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -34,8 +34,9 @@ GNU General Public License for more details.
 // 2. FS functions are removed, instead we have full fs_api_t
 // 3. SlerpBones, CalcBonePosition/Quaternion calls were moved to libpublic/mathlib
 // 4. R_StudioEstimateFrame now has time argument
-// 5. Removed GetSomethingByIndex calls, renderers are supposed to cache pointer values.
+// 5. Removed GetSomethingByIndex calls, renderers are supposed to cache pointer values
 //    Removed previously unused calls
+//    Simplified remapping calls
 #define REF_API_VERSION 5
 
 
@@ -332,10 +333,8 @@ typedef struct ref_api_s
 	struct model_s **(*pfnGetModels)( void );
 
 	// remap
+	qboolean (*CL_EntitySetRemapColors)( cl_entity_t *e, model_t *mod, int top, int bottom );
 	struct remap_info_s *(*CL_GetRemapInfoForEntity)( cl_entity_t *e );
-	void (*CL_AllocRemapInfo)( cl_entity_t *entity, model_t *model, int topcolor, int bottomcolor );
-	void (*CL_FreeRemapInfo)( struct remap_info_s *info );
-	void (*CL_UpdateRemapInfo)( cl_entity_t *entity, int topcolor, int bottomcolor );
 
 	// utils
 	void  (*CL_ExtraUpdate)( void );

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -447,6 +447,7 @@ typedef struct ref_interface_s
 	void (*GL_InitExtensions)( void );
 	void (*GL_ClearExtensions)( void );
 
+	// scene rendering
 	void (*R_BeginFrame)( qboolean clearScene );
 	void (*R_RenderScene)( void );
 	void (*R_EndFrame)( void );
@@ -461,7 +462,8 @@ typedef struct ref_interface_s
 
 	qboolean (*R_AddEntity)( struct cl_entity_s *clent, int type );
 	void (*CL_AddCustomBeam)( cl_entity_t *pEnvBeam );
-	void		(*R_ProcessEntData)( qboolean allocate, cl_entity_t *entities, unsigned int max_entities );
+	void (*R_ProcessEntData)( qboolean allocate, cl_entity_t *entities, unsigned int max_entities );
+	void (*R_Flush)( unsigned int flush_flags );
 
 	// debug
 	void (*R_ShowTextures)( void );

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -301,7 +301,6 @@ typedef struct ref_api_s
 	// entity management
 	struct cl_entity_s *(*GetLocalPlayer)( void );
 	struct cl_entity_s *(*GetViewModel)( void );
-	struct cl_entity_s *(*GetEntityByIndex)( int idx );
 	struct cl_entity_s *(*R_BeamGetEntity)( int index );
 	struct cl_entity_s *(*CL_GetWaterEntity)( const vec3_t p );
 	qboolean (*CL_AddVisibleEntity)( cl_entity_t *ent, int entityType );
@@ -329,7 +328,7 @@ typedef struct ref_api_s
 	// model management
 	model_t *(*Mod_ForName)( const char *name, qboolean crash, qboolean trackCRC );
 	void *(*Mod_Extradata)( int type, model_t *model );
-	struct model_s *(*pfnGetModelByIndex)( int index ); // CL_ModelHandle
+	struct model_s **(*pfnGetModels)( void );
 
 	// remap
 	struct remap_info_s *(*CL_GetRemapInfoForEntity)( cl_entity_t *e );
@@ -463,7 +462,7 @@ typedef struct ref_interface_s
 
 	qboolean (*R_AddEntity)( struct cl_entity_s *clent, int type );
 	void (*CL_AddCustomBeam)( cl_entity_t *pEnvBeam );
-	void		(*R_ProcessEntData)( qboolean allocate );
+	void		(*R_ProcessEntData)( qboolean allocate, cl_entity_t *entities, unsigned int max_entities );
 
 	// debug
 	void (*R_ShowTextures)( void );

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -37,6 +37,7 @@ GNU General Public License for more details.
 // 5. Removed GetSomethingByIndex calls, renderers are supposed to cache pointer values
 //    Removed previously unused calls
 //    Simplified remapping calls
+//    GetRefAPI is now expected to return REF_API_VERSION
 #define REF_API_VERSION 5
 
 

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -34,7 +34,9 @@ GNU General Public License for more details.
 // 2. FS functions are removed, instead we have full fs_api_t
 // 3. SlerpBones, CalcBonePosition/Quaternion calls were moved to libpublic/mathlib
 // 4. R_StudioEstimateFrame now has time argument
-#define REF_API_VERSION 4
+// 5. Removed GetSomethingByIndex calls, renderers are supposed to cache pointer values.
+//    Removed previously unused calls
+#define REF_API_VERSION 5
 
 
 #define TF_SKY		(TF_SKYSIDE|TF_NOMIPMAP)
@@ -299,7 +301,6 @@ typedef struct ref_api_s
 	void	(*CL_DrawCenterPrint)( void );
 
 	// entity management
-	struct cl_entity_s *(*GetLocalPlayer)( void );
 	struct cl_entity_s *(*GetViewModel)( void );
 	struct cl_entity_s *(*R_BeamGetEntity)( int index );
 	struct cl_entity_s *(*CL_GetWaterEntity)( const vec3_t p );
@@ -343,9 +344,8 @@ typedef struct ref_api_s
 	float (*COM_RandomFloat)( float rmin, float rmax );
 	int   (*COM_RandomLong)( int rmin, int rmax );
 	struct screenfade_s *(*GetScreenFade)( void );
-	struct client_textmessage_s *(*pfnTextMessageGet)( const char *pName );
 	void (*GetPredictedOrigin)( vec3_t v );
-	color24 *(*CL_GetPaletteColor)(int color); // clgame.palette[color]
+	color24 *(*CL_GetPaletteColor)( void ); // clgame.palette[color]
 	void (*CL_GetScreenInfo)( int *width, int *height ); // clgame.scrInfo, ptrs may be NULL
 	void (*SetLocalLightLevel)( int level ); // cl.local.light_level
 	int (*Sys_CheckParm)( const char *flag );
@@ -419,7 +419,6 @@ typedef struct ref_api_s
 	rgbdata_t *(*FS_CopyImage)( rgbdata_t *in );
 	void (*FS_FreeImage)( rgbdata_t *pack );
 	void (*Image_SetMDLPointer)( byte *p );
-	poolhandle_t (*Image_GetPool)( void );
 	const struct bpc_desc_s *(*Image_GetPFDesc)( int idx );
 
 	// client exports

--- a/ref/gl/gl_alias.c
+++ b/ref/gl/gl_alias.c
@@ -1002,15 +1002,10 @@ R_AliasSetRemapColors
 
 ===============
 */
-void R_AliasSetRemapColors( int newTop, int newBottom )
+static void R_AliasSetRemapColors( int newTop, int newBottom )
 {
-	gEngfuncs.CL_AllocRemapInfo( RI.currententity, RI.currentmodel, newTop, newBottom );
-
-	if( gEngfuncs.CL_GetRemapInfoForEntity( RI.currententity ))
-	{
-		gEngfuncs.CL_UpdateRemapInfo( RI.currententity, newTop, newBottom );
+	if( gEngfuncs.CL_EntitySetRemapColors( RI.currententity, RI.currentmodel, newTop, newBottom ))
 		m_fDoRemap = true;
-	}
 }
 
 /*

--- a/ref/gl/gl_alias.c
+++ b/ref/gl/gl_alias.c
@@ -427,7 +427,7 @@ rgbdata_t *Mod_CreateSkinData( model_t *mod, byte *data, int width, int height )
 	skin.encode = DXT_ENCODE_DEFAULT;
 	skin.numMips = 1;
 	skin.buffer = data;
-	skin.palette = (byte *)gEngfuncs.CL_GetPaletteColor( 0 );
+	skin.palette = (byte *)tr.palette;
 	skin.size = width * height;
 
 	if( !gEngfuncs.Image_CustomPalette() )
@@ -1261,7 +1261,7 @@ static void R_AliasDrawAbsBBox( cl_entity_t *e, const vec3_t absmin, const vec3_
 	int	i;
 
 	// looks ugly, skip
-	if( r_drawentities->value != 5 || e == gEngfuncs.GetViewModel() )
+	if( r_drawentities->value != 5 || e == tr.viewent )
 		return;
 
 	// compute a full bounding box

--- a/ref/gl/gl_beams.c
+++ b/ref/gl/gl_beams.c
@@ -943,7 +943,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 	model_t	*model;
 	vec3_t	delta;
 
-	model = gEngfuncs.pfnGetModelByIndex( pbeam->modelIndex );
+	model = CL_ModelHandle( pbeam->modelIndex );
 	SetBits( pbeam->flags, FBEAM_ISACTIVE );
 
 	if( !model || model->type != mod_sprite )
@@ -1146,7 +1146,7 @@ passed through this
 */
 static void R_BeamSetup( BEAM *pbeam, vec3_t start, vec3_t end, int modelIndex, float life, float width, float amplitude, float brightness, float speed )
 {
-	model_t	*sprite = gEngfuncs.pfnGetModelByIndex( modelIndex );
+	model_t	*sprite = CL_ModelHandle( modelIndex );
 
 	if( !sprite ) return;
 

--- a/ref/gl/gl_context.c
+++ b/ref/gl/gl_context.c
@@ -295,13 +295,21 @@ const byte *GL_TextureData( unsigned int texnum )
 	return NULL;
 }
 
-void R_ProcessEntData( qboolean allocate )
+void R_ProcessEntData( qboolean allocate, cl_entity_t *entities, unsigned int max_entities )
 {
 	if( !allocate )
 	{
 		tr.draw_list->num_solid_entities = 0;
 		tr.draw_list->num_trans_entities = 0;
 		tr.draw_list->num_beam_entities = 0;
+
+		tr.max_entities = 0;
+		tr.entities = NULL;
+	}
+	else
+	{
+		tr.max_entities = max_entities;
+		tr.entities = entities;
 	}
 
 	if( gEngfuncs.drawFuncs->R_ProcessEntData )

--- a/ref/gl/gl_context.c
+++ b/ref/gl/gl_context.c
@@ -316,6 +316,11 @@ void R_ProcessEntData( qboolean allocate, cl_entity_t *entities, unsigned int ma
 		gEngfuncs.drawFuncs->R_ProcessEntData( allocate );
 }
 
+static void GAME_EXPORT R_Flush( unsigned int flags )
+{
+	// stub
+}
+
 qboolean R_SetDisplayTransform( ref_screen_rotation_t rotate, int offset_x, int offset_y, float scale_x, float scale_y )
 {
 	qboolean ret = true;
@@ -380,6 +385,7 @@ ref_interface_t gReffuncs =
 	R_AddEntity,
 	CL_AddCustomBeam,
 	R_ProcessEntData,
+	R_Flush,
 
 	R_ShowTextures,
 

--- a/ref/gl/gl_cull.c
+++ b/ref/gl/gl_cull.c
@@ -42,7 +42,7 @@ R_CullModel
 */
 int R_CullModel( cl_entity_t *e, const vec3_t absmin, const vec3_t absmax )
 {
-	if( e == gEngfuncs.GetViewModel() )
+	if( e == tr.viewent )
 	{
 		if( ENGINE_GET_PARM( PARM_DEV_OVERVIEW ))
 			return 1;

--- a/ref/gl/gl_cull.c
+++ b/ref/gl/gl_cull.c
@@ -77,7 +77,7 @@ int R_CullSurface( msurface_t *surf, gl_frustum_t *frustum, uint clipflags )
 		return CULL_VISIBLE;
 
 	// world surfaces can be culled by vis frame too
-	if( RI.currententity == gEngfuncs.GetEntityByIndex( 0 ) && surf->visframe != tr.framecount )
+	if( RI.currententity == CL_GetEntityByIndex( 0 ) && surf->visframe != tr.framecount )
 		return CULL_VISFRAME;
 
 	// only static ents can be culled by frustum
@@ -92,7 +92,7 @@ int R_CullSurface( msurface_t *surf, gl_frustum_t *frustum, uint clipflags )
 		{
 			vec3_t	orthonormal;
 
-			if( e == gEngfuncs.GetEntityByIndex( 0 ) ) orthonormal[2] = surf->plane->normal[2];
+			if( e == CL_GetEntityByIndex( 0 )) orthonormal[2] = surf->plane->normal[2];
 			else Matrix4x4_VectorRotate( RI.objectMatrix, surf->plane->normal, orthonormal );
 			dist = orthonormal[2];
 		}

--- a/ref/gl/gl_dbghulls.c
+++ b/ref/gl/gl_dbghulls.c
@@ -28,7 +28,7 @@ GNU General Public License for more details.
 // REFTODO: rewrite in triapi
 void R_DrawWorldHull( void )
 {
-	hull_model_t	*hull = &WORLD->hull_models[0];
+	hull_model_t	*hull = &tr.world->hull_models[0];
 	winding_t		*poly;
 	int		i;
 
@@ -69,10 +69,10 @@ void R_DrawModelHull( void )
 		return;
 
 	i = atoi( RI.currentmodel->name + 1 );
-	if( i < 1 || i >= WORLD->num_hull_models )
+	if( i < 1 || i >= tr.world->num_hull_models )
 		return;
 
-	hull = &WORLD->hull_models[i];
+	hull = &tr.world->hull_models[i];
 
 	pglPolygonOffset( 1.0f, 2.0 );
 	pglEnable( GL_POLYGON_OFFSET_FILL );

--- a/ref/gl/gl_decals.c
+++ b/ref/gl/gl_decals.c
@@ -750,15 +750,15 @@ void R_DecalShoot( int textureIndex, int entityIndex, int modelIndex, vec3_t pos
 
 	if( entityIndex > 0 )
 	{
-		ent = gEngfuncs.GetEntityByIndex( entityIndex );
+		ent = CL_GetEntityByIndex( entityIndex );
 
-		if( modelIndex > 0 ) model = gEngfuncs.pfnGetModelByIndex( modelIndex );
-		else if( ent != NULL ) model = gEngfuncs.pfnGetModelByIndex( ent->curstate.modelindex );
+		if( modelIndex > 0 ) model = CL_ModelHandle( modelIndex );
+		else if( ent != NULL ) model = CL_ModelHandle( ent->curstate.modelindex );
 		else return;
 	}
 	else if( modelIndex > 0 )
-		model = gEngfuncs.pfnGetModelByIndex( modelIndex );
-	else model = WORLDMODEL;
+		model = CL_ModelHandle( modelIndex );
+	else model = CL_ModelHandle( 1 );
 
 	if( !model ) return;
 

--- a/ref/gl/gl_image.c
+++ b/ref/gl/gl_image.c
@@ -1668,11 +1668,11 @@ int GL_LoadTextureArray( const char **names, int flags )
 		else
 		{
 			// create new image
-			pic = Mem_Malloc( gEngfuncs.Image_GetPool(), sizeof( rgbdata_t ));
+			pic = Mem_Malloc( r_temppool, sizeof( rgbdata_t ));
 			memcpy( pic, src, sizeof( rgbdata_t ));
 
 			// expand pic buffer for all layers
-			pic->buffer = Mem_Malloc( gEngfuncs.Image_GetPool(), pic->size * numLayers );
+			pic->buffer = Mem_Malloc( r_temppool, pic->size * numLayers );
 			pic->depth = 0;
 		}
 

--- a/ref/gl/gl_local.h
+++ b/ref/gl/gl_local.h
@@ -259,6 +259,8 @@ typedef struct
 	cl_entity_t *entities;
 	movevars_t *movevars;
 	model_t **models;
+	color24 *palette;
+	cl_entity_t *viewent;
 
 	uint max_entities;
 } gl_globals_t;

--- a/ref/gl/gl_local.h
+++ b/ref/gl/gl_local.h
@@ -57,10 +57,6 @@ void VGL_ShimEndFrame( void );
 
 #include <stdio.h>
 
-#define WORLD (gEngfuncs.GetWorld())
-#define WORLDMODEL (gEngfuncs.pfnGetModelByIndex( 1 ))
-#define MOVEVARS (gEngfuncs.pfnGetMoveVars())
-
 // make mod_ref.h?
 #define LM_SAMPLE_SIZE             16
 
@@ -257,6 +253,14 @@ typedef struct
 	vec3_t		modelorg;		// relative to viewpoint
 
 	qboolean fCustomSkybox;
+
+	// get from engine
+	struct world_static_s *world;
+	cl_entity_t *entities;
+	movevars_t *movevars;
+	model_t **models;
+
+	uint max_entities;
 } gl_globals_t;
 
 typedef struct
@@ -707,7 +711,6 @@ typedef struct
 	qboolean		in2DMode;
 } glstate_t;
 
-
 typedef struct
 {
 	qboolean		initialized;	// OpenGL subsystem started
@@ -723,6 +726,21 @@ extern ref_globals_t *gpGlobals;
 
 #define ENGINE_GET_PARM_ (*gEngfuncs.EngineGetParm)
 #define ENGINE_GET_PARM( parm ) ENGINE_GET_PARM_( ( parm ), 0 )
+
+//
+// helper funcs
+//
+static inline cl_entity_t *CL_GetEntityByIndex( int index )
+{
+	return &tr.entities[index];
+}
+
+static inline model_t *CL_ModelHandle( int index )
+{
+	return tr.models[index];
+}
+
+#define WORLDMODEL (tr.models[1])
 
 //
 // renderer cvars

--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -1288,6 +1288,8 @@ qboolean R_Init( void )
 	tr.world = gEngfuncs.GetWorld();
 	tr.models = gEngfuncs.pfnGetModels();
 	tr.movevars = gEngfuncs.pfnGetMoveVars();
+	tr.palette = gEngfuncs.CL_GetPaletteColor();
+	tr.viewent = gEngfuncs.GetViewModel();
 
 	GL_SetDefaults();
 	R_CheckVBO();

--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -1284,6 +1284,11 @@ qboolean R_Init( void )
 		return false;
 	}
 
+	// see R_ProcessEntData for tr.entities initialization
+	tr.world = gEngfuncs.GetWorld();
+	tr.models = gEngfuncs.pfnGetModels();
+	tr.movevars = gEngfuncs.pfnGetMoveVars();
+
 	GL_SetDefaults();
 	R_CheckVBO();
 	R_InitImages();

--- a/ref/gl/gl_rlight.c
+++ b/ref/gl/gl_rlight.c
@@ -152,7 +152,7 @@ void R_PushDlights( void )
 
 	tr.dlightframecount = tr.framecount;
 
-	RI.currententity = gEngfuncs.GetEntityByIndex( 0 );
+	RI.currententity = CL_GetEntityByIndex( 0 );
 	if( RI.currententity )
 		RI.currentmodel = RI.currententity->model;
 

--- a/ref/gl/gl_rmain.c
+++ b/ref/gl/gl_rmain.c
@@ -324,7 +324,7 @@ R_GetFarClip
 static float R_GetFarClip( void )
 {
 	if( WORLDMODEL && RI.drawWorld )
-		return MOVEVARS->zmax * 1.73f;
+		return tr.movevars->zmax * 1.73f;
 	return 2048.0f;
 }
 
@@ -429,7 +429,7 @@ void R_RotateForEntity( cl_entity_t *e )
 {
 	float	scale = 1.0f;
 
-	if( e == gEngfuncs.GetEntityByIndex( 0 ) )
+	if( e == CL_GetEntityByIndex( 0 ))
 	{
 		R_LoadIdentity();
 		return;
@@ -455,7 +455,7 @@ void R_TranslateForEntity( cl_entity_t *e )
 {
 	float	scale = 1.0f;
 
-	if( e == gEngfuncs.GetEntityByIndex( 0 ) )
+	if( e == CL_GetEntityByIndex( 0 ))
 	{
 		R_LoadIdentity();
 		return;
@@ -669,7 +669,7 @@ static void R_CheckFog( void )
 	// quake global fog
 	if( ENGINE_GET_PARM( PARM_QUAKE_COMPATIBLE ))
 	{
-		if( !MOVEVARS->fog_settings )
+		if( !tr.movevars->fog_settings )
 		{
 			if( pglIsEnabled( GL_FOG ))
 				pglDisable( GL_FOG );
@@ -678,10 +678,10 @@ static void R_CheckFog( void )
 		}
 
 		// quake-style global fog
-		RI.fogColor[0] = ((MOVEVARS->fog_settings & 0xFF000000) >> 24) / 255.0f;
-		RI.fogColor[1] = ((MOVEVARS->fog_settings & 0xFF0000) >> 16) / 255.0f;
-		RI.fogColor[2] = ((MOVEVARS->fog_settings & 0xFF00) >> 8) / 255.0f;
-		RI.fogDensity = ((MOVEVARS->fog_settings & 0xFF) / 255.0f) * 0.01f;
+		RI.fogColor[0] = ((tr.movevars->fog_settings & 0xFF000000) >> 24) / 255.0f;
+		RI.fogColor[1] = ((tr.movevars->fog_settings & 0xFF0000) >> 16) / 255.0f;
+		RI.fogColor[2] = ((tr.movevars->fog_settings & 0xFF00) >> 8) / 255.0f;
+		RI.fogDensity = ((tr.movevars->fog_settings & 0xFF) / 255.0f) * 0.01f;
 		RI.fogStart = RI.fogEnd = 0.0f;
 		RI.fogColor[3] = 1.0f;
 		RI.fogCustom = false;

--- a/ref/gl/gl_rmisc.c
+++ b/ref/gl/gl_rmisc.c
@@ -146,7 +146,7 @@ void R_NewMap( void )
  		tx->texturechain = NULL;
 	}
 
-	R_SetupSky( MOVEVARS->skyName );
+	R_SetupSky( tr.movevars->skyName );
 
 	GL_BuildLightmaps ();
 	R_GenerateVBO();

--- a/ref/gl/gl_rpart.c
+++ b/ref/gl/gl_rpart.c
@@ -49,7 +49,7 @@ void CL_DrawParticles( double frametime, particle_t *cl_active_particles, float 
 {
 	particle_t	*p;
 	vec3_t		right, up;
-	color24		*pColor;
+	color24		сolor;
 	int		alpha;
 	float		size;
 
@@ -85,15 +85,15 @@ void CL_DrawParticles( double frametime, particle_t *cl_active_particles, float 
 			VectorScale( RI.cull_vup, size, up );
 
 			p->color = bound( 0, p->color, 255 );
-			pColor = gEngfuncs.CL_GetPaletteColor( p->color );
+			сolor = tr.palette[p->color];
 
 			alpha = 255 * (p->die - gpGlobals->time) * 16.0f;
 			if( alpha > 255 || p->type == pt_static )
 				alpha = 255;
 
-			pglColor4ub( gEngfuncs.LightToTexGamma( pColor->r ),
-				gEngfuncs.LightToTexGamma( pColor->g ),
-				gEngfuncs.LightToTexGamma( pColor->b ), alpha );
+			pglColor4ub( gEngfuncs.LightToTexGamma( сolor.r ),
+				gEngfuncs.LightToTexGamma( сolor.g ),
+				gEngfuncs.LightToTexGamma( сolor.b ), alpha );
 
 			pglTexCoord2f( 0.0f, 1.0f );
 			pglVertex3f( p->org[0] - right[0] + up[0], p->org[1] - right[1] + up[1], p->org[2] - right[2] + up[2] );
@@ -205,7 +205,7 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 		{
 			vec3_t	verts[4], tmp2;
 			vec3_t	tmp, normal;
-			color24	*pColor;
+			color24	color;
 
 			// Transform point into screen space
 			TriWorldToScreen( start, screen );
@@ -235,8 +235,8 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 				p->color = 0;
 			}
 
-			pColor = &gTracerColors[p->color];
-			pglColor4ub( pColor->r, pColor->g, pColor->b, p->packedColor );
+			color = gTracerColors[p->color];
+			pglColor4ub( color.r, color.g, color.b, p->packedColor );
 
 			pglBegin( GL_QUADS );
 				pglTexCoord2f( 0.0f, 0.8f );

--- a/ref/gl/gl_rpart.c
+++ b/ref/gl/gl_rpart.c
@@ -188,7 +188,7 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 	pglDisable( GL_ALPHA_TEST );
 	pglDepthMask( GL_FALSE );
 
-	gravity = frametime * MOVEVARS->gravity;
+	gravity = frametime * tr.movevars->gravity;
 	scale = 1.0 - (frametime * 0.9);
 	if( scale < 0.0f ) scale = 0.0f;
 

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -758,7 +758,7 @@ void DrawGLPoly( glpoly_t *p, float xScale, float yScale )
 		float		flRate, flAngle;
 		gl_texture_t	*texture;
 
-		if( ENGINE_GET_PARM( PARM_QUAKE_COMPATIBLE ) && RI.currententity == gEngfuncs.GetEntityByIndex( 0 ) )
+		if( ENGINE_GET_PARM( PARM_QUAKE_COMPATIBLE ) && RI.currententity == CL_GetEntityByIndex( 0 ))
 		{
 			// same as doom speed
 			flConveyorSpeed = -35.0f;
@@ -1235,7 +1235,7 @@ void R_DrawTextureChains( void )
 	GL_SetupFogColorForSurfaces();
 
 	// restore worldmodel
-	RI.currententity = gEngfuncs.GetEntityByIndex( 0 );
+	RI.currententity = CL_GetEntityByIndex( 0 );
 	RI.currentmodel = RI.currententity->model;
 
 	if( ENGINE_GET_PARM( PARM_SKY_SPHERE ) )
@@ -1266,7 +1266,7 @@ void R_DrawTextureChains( void )
 		if( !s || ( i == tr.skytexturenum ))
 			continue;
 
-		if(( s->flags & SURF_DRAWTURB ) && MOVEVARS->wateralpha < 1.0f )
+		if(( s->flags & SURF_DRAWTURB ) && tr.movevars->wateralpha < 1.0f )
 			continue;	// draw translucent water later
 
 		if( ENGINE_GET_PARM( PARM_QUAKE_COMPATIBLE ) && FBitSet( s->flags, SURF_TRANSPARENT ))
@@ -1309,7 +1309,7 @@ void R_DrawAlphaTextureChains( void )
 	GL_SetupFogColorForSurfaces();
 
 	// restore worldmodel
-	RI.currententity = gEngfuncs.GetEntityByIndex( 0 );
+	RI.currententity = CL_GetEntityByIndex( 0 );
 	RI.currentmodel = RI.currententity->model;
 	RI.currententity->curstate.rendermode = kRenderTransAlpha;
 	draw_alpha_surfaces = false;
@@ -1350,11 +1350,11 @@ void R_DrawWaterSurfaces( void )
 		return;
 
 	// non-transparent water is already drawed
-	if( MOVEVARS->wateralpha >= 1.0f )
+	if( tr.movevars->wateralpha >= 1.0f )
 		return;
 
 	// restore worldmodel
-	RI.currententity = gEngfuncs.GetEntityByIndex( 0 );
+	RI.currententity = CL_GetEntityByIndex( 0 );
 	RI.currentmodel = RI.currententity->model;
 
 	// go back to the world matrix
@@ -1365,7 +1365,7 @@ void R_DrawWaterSurfaces( void )
 	pglDisable( GL_ALPHA_TEST );
 	pglBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 	pglTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
-	pglColor4f( 1.0f, 1.0f, 1.0f, MOVEVARS->wateralpha );
+	pglColor4f( 1.0f, 1.0f, 1.0f, tr.movevars->wateralpha );
 
 	for( i = 0; i < WORLDMODEL->numtextures; i++ )
 	{
@@ -3280,7 +3280,7 @@ void R_DrawWorld( void )
 
 	// paranoia issues: when gl_renderer is "0" we need have something valid for currententity
 	// to prevent crashing until HeadShield drawing.
-	RI.currententity = gEngfuncs.GetEntityByIndex( 0 );
+	RI.currententity = CL_GetEntityByIndex( 0 );
 	if( !RI.currententity )
 		return;
 
@@ -3490,7 +3490,7 @@ void GL_RebuildLightmaps( void )
 
 	for( i = 0; i < ENGINE_GET_PARM( PARM_NUMMODELS ); i++ )
 	{
-		if(( m = gEngfuncs.pfnGetModelByIndex( i + 1 )) == NULL )
+		if(( m = CL_ModelHandle( i + 1 )) == NULL )
 			continue;
 
 		if( m->name[0] == '*' || m->type != mod_brush )
@@ -3554,7 +3554,7 @@ void GL_BuildLightmaps( void )
 
 	for( i = 0; i < ENGINE_GET_PARM( PARM_NUMMODELS ); i++ )
 	{
-		if(( m = gEngfuncs.pfnGetModelByIndex( i + 1 )) == NULL )
+		if(( m = CL_ModelHandle( i + 1 )) == NULL )
 			continue;
 
 		if( m->name[0] == '*' || m->type != mod_brush )

--- a/ref/gl/gl_sprite.c
+++ b/ref/gl/gl_sprite.c
@@ -826,7 +826,7 @@ void R_DrawSpriteModel( cl_entity_t *e )
 	{
 		cl_entity_t	*parent;
 
-		parent = gEngfuncs.GetEntityByIndex( e->curstate.aiment );
+		parent = CL_GetEntityByIndex( e->curstate.aiment );
 
 		if( parent && parent->model )
 		{

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -1851,7 +1851,7 @@ void R_StudioRenderShadow( int iSprite, float *p1, float *p2, float *p3, float *
 	if( !p1 || !p2 || !p3 || !p4 )
 		return;
 
-	if( TriSpriteTexture( gEngfuncs.pfnGetModelByIndex( iSprite ), 0 ))
+	if( TriSpriteTexture( CL_ModelHandle( iSprite ), 0 ))
 	{
 		TriRenderMode( kRenderTransAlpha );
 		TriColor4f( 0.0f, 0.0f, 0.0f, 1.0f );
@@ -3371,7 +3371,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 		// copy attachments into global entity array
 		if( RI.currententity->index > 0 )
 		{
-			cl_entity_t *ent = gEngfuncs.GetEntityByIndex( RI.currententity->index );
+			cl_entity_t *ent = CL_GetEntityByIndex( RI.currententity->index );
 			memcpy( ent->attachment, RI.currententity->attachment, sizeof( vec3_t ) * 4 );
 		}
 	}
@@ -3414,7 +3414,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 		if( pplayer->weaponmodel )
 		{
 			cl_entity_t	saveent = *RI.currententity;
-			model_t		*pweaponmodel = gEngfuncs.pfnGetModelByIndex( pplayer->weaponmodel );
+			model_t		*pweaponmodel = CL_ModelHandle( pplayer->weaponmodel );
 
 			m_pStudioHeader = (studiohdr_t *)gEngfuncs.Mod_Extradata( mod_studio, pweaponmodel );
 
@@ -3500,7 +3500,7 @@ static int R_StudioDrawModel( int flags )
 		// copy attachments into global entity array
 		if( RI.currententity->index > 0 )
 		{
-			cl_entity_t *ent = gEngfuncs.GetEntityByIndex( RI.currententity->index );
+			cl_entity_t *ent = CL_GetEntityByIndex( RI.currententity->index );
 			memcpy( ent->attachment, RI.currententity->attachment, sizeof( vec3_t ) * 4 );
 		}
 	}
@@ -3569,7 +3569,7 @@ void R_DrawStudioModel( cl_entity_t *e )
 	{
 		if( e->curstate.movetype == MOVETYPE_FOLLOW && e->curstate.aiment > 0 )
 		{
-			cl_entity_t *parent = gEngfuncs.GetEntityByIndex( e->curstate.aiment );
+			cl_entity_t *parent = CL_GetEntityByIndex( e->curstate.aiment );
 
 			if( parent && parent->model && parent->model->type == mod_studio )
 			{
@@ -3828,7 +3828,9 @@ void Mod_StudioUnloadTextures( void *data )
 
 static model_t *pfnModelHandle( int modelindex )
 {
-	return gEngfuncs.pfnGetModelByIndex( modelindex );
+	if( modelindex < 0 || modelindex >= MAX_MODELS )
+		return NULL;
+	return CL_ModelHandle( modelindex );
 }
 
 static void *pfnMod_CacheCheck( struct cache_user_s *c )

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -196,7 +196,7 @@ static qboolean R_AllowFlipViewModel( cl_entity_t *e )
 {
 	if( cl_righthand && cl_righthand->value > 0 )
 	{
-		if( e == gEngfuncs.GetViewModel() )
+		if( e == tr.viewent )
 			return true;
 	}
 
@@ -412,7 +412,7 @@ pfnGetViewEntity
 */
 static cl_entity_t *pfnGetViewEntity( void )
 {
-	return gEngfuncs.GetViewModel();
+	return tr.viewent;
 }
 
 /*
@@ -2488,7 +2488,7 @@ static void R_StudioDrawAbsBBox( void )
 	int	i;
 
 	// looks ugly, skip
-	if( RI.currententity == gEngfuncs.GetViewModel() )
+	if( RI.currententity == tr.viewent )
 		return;
 
 	if( !R_StudioComputeBBox( p ))
@@ -3605,7 +3605,7 @@ void R_RunViewmodelEvents( void )
 	if( !RP_NORMALPASS() || ENGINE_GET_PARM( PARM_LOCAL_HEALTH ) <= 0 || !CL_IsViewEntityLocalPlayer())
 		return;
 
-	RI.currententity = gEngfuncs.GetViewModel();
+	RI.currententity = tr.viewent;
 
 	if( !RI.currententity->model || RI.currententity->model->type != mod_studio )
 		return;
@@ -3627,7 +3627,7 @@ R_GatherPlayerLight
 */
 void R_GatherPlayerLight( void )
 {
-	cl_entity_t	*view = gEngfuncs.GetViewModel();
+	cl_entity_t	*view = tr.viewent;
 	colorVec		c;
 
 	tr.ignore_lightgamma = true;
@@ -3643,7 +3643,7 @@ R_DrawViewModel
 */
 void R_DrawViewModel( void )
 {
-	cl_entity_t	*view = gEngfuncs.GetViewModel();
+	cl_entity_t	*view = tr.viewent;
 
 	R_GatherPlayerLight();
 

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -2624,13 +2624,8 @@ R_StudioSetRemapColors
 */
 static void R_StudioSetRemapColors( int newTop, int newBottom )
 {
-	gEngfuncs.CL_AllocRemapInfo( RI.currententity, RI.currentmodel, newTop, newBottom );
-
-	if( gEngfuncs.CL_GetRemapInfoForEntity( RI.currententity ))
-	{
-		gEngfuncs.CL_UpdateRemapInfo( RI.currententity, newTop, newBottom );
+	if( gEngfuncs.CL_EntitySetRemapColors( RI.currententity, RI.currentmodel, newTop, newBottom ))
 		m_fDoRemap = true;
-	}
 }
 
 void R_StudioResetPlayerModels( void )

--- a/ref/soft/r_beams.c
+++ b/ref/soft/r_beams.c
@@ -956,7 +956,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 	model_t	*model;
 	vec3_t	delta;
 
-	model = gEngfuncs.pfnGetModelByIndex( pbeam->modelIndex );
+	model = CL_ModelHandle( pbeam->modelIndex );
 	SetBits( pbeam->flags, FBEAM_ISACTIVE );
 
 	if( !model || model->type != mod_sprite )
@@ -1159,7 +1159,7 @@ passed through this
 */
 static void R_BeamSetup( BEAM *pbeam, vec3_t start, vec3_t end, int modelIndex, float life, float width, float amplitude, float brightness, float speed )
 {
-	model_t	*sprite = gEngfuncs.pfnGetModelByIndex( modelIndex );
+	model_t	*sprite = CL_ModelHandle( modelIndex );
 
 	if( !sprite ) return;
 

--- a/ref/soft/r_bsp.c
+++ b/ref/soft/r_bsp.c
@@ -949,7 +949,7 @@ void R_RenderWorld (void)
 	c_drawnode=0;
 
 	// auto cycle the world frame for texture animation
-	RI.currententity = gEngfuncs.GetEntityByIndex(0);
+	RI.currententity = CL_GetEntityByIndex(0);
 	//RI.currententity->frame = (int)(gpGlobals->time*2);
 
 	VectorCopy (RI.vieworg, tr.modelorg);

--- a/ref/soft/r_context.c
+++ b/ref/soft/r_context.c
@@ -279,6 +279,11 @@ void GAME_EXPORT R_ProcessEntData( qboolean allocate, cl_entity_t *entities, uns
 	tr.max_entities = max_entities;
 }
 
+static void GAME_EXPORT R_Flush( unsigned int flags )
+{
+	// stub
+}
+
 // stubs
 
 void GAME_EXPORT GL_SetTexCoordArrayMode( uint mode )
@@ -426,6 +431,7 @@ ref_interface_t gReffuncs =
 	R_AddEntity,
 	CL_AddCustomBeam,
 	R_ProcessEntData,
+	R_Flush,
 
 	R_ShowTextures,
 

--- a/ref/soft/r_context.c
+++ b/ref/soft/r_context.c
@@ -273,9 +273,10 @@ void Mod_UnloadTextures( model_t *mod )
 	}
 }
 
-void GAME_EXPORT R_ProcessEntData( qboolean allocate )
+void GAME_EXPORT R_ProcessEntData( qboolean allocate, cl_entity_t *entities, unsigned int max_entities )
 {
-
+	tr.entities = entities;
+	tr.max_entities = max_entities;
 }
 
 // stubs

--- a/ref/soft/r_decals.c
+++ b/ref/soft/r_decals.c
@@ -774,14 +774,14 @@ void GAME_EXPORT R_DecalShoot( int textureIndex, int entityIndex, int modelIndex
 
 	if( entityIndex > 0 )
 	{
-		ent = gEngfuncs.GetEntityByIndex( entityIndex );
+		ent = CL_GetEntityByIndex( entityIndex );
 
-		if( modelIndex > 0 ) model = gEngfuncs.pfnGetModelByIndex( modelIndex );
-		else if( ent != NULL ) model = gEngfuncs.pfnGetModelByIndex( ent->curstate.modelindex );
+		if( modelIndex > 0 ) model = CL_ModelHandle( modelIndex );
+		else if( ent != NULL ) model = CL_ModelHandle( ent->curstate.modelindex );
 		else return;
 	}
 	else if( modelIndex > 0 )
-		model = gEngfuncs.pfnGetModelByIndex( modelIndex );
+		model = CL_ModelHandle( modelIndex );
 	else model = WORLDMODEL;
 
 	if( !model ) return;

--- a/ref/soft/r_edge.c
+++ b/ref/soft/r_edge.c
@@ -1118,7 +1118,7 @@ void D_SolidSurf (surf_t *s)
 	{
 		if( alphaspans )
 			return;
-		RI.currententity = gEngfuncs.GetEntityByIndex(0); //r_worldentity;
+		RI.currententity = CL_GetEntityByIndex(0); //r_worldentity;
 		tr.modelviewIdentity = true;
 	}
 

--- a/ref/soft/r_light.c
+++ b/ref/soft/r_light.c
@@ -155,7 +155,7 @@ void R_PushDlights( void )
 
 	tr.dlightframecount = tr.framecount;
 
-	RI.currententity = gEngfuncs.GetEntityByIndex( 0 );
+	RI.currententity = CL_GetEntityByIndex( 0 );
 	if( RI.currententity )
 		RI.currentmodel = RI.currententity->model;
 

--- a/ref/soft/r_local.h
+++ b/ref/soft/r_local.h
@@ -41,13 +41,8 @@ typedef	int	fixed16_t;
 
 #include <stdio.h>
 
-#define WORLD (gEngfuncs.GetWorld())
-#define WORLDMODEL (gEngfuncs.pfnGetModelByIndex( 1 ))
-#define MOVEVARS (gEngfuncs.pfnGetMoveVars())
-
 // make mod_ref.h?
 #define LM_SAMPLE_SIZE             16
-
 
 extern poolhandle_t r_temppool;
 
@@ -298,6 +293,13 @@ typedef struct
 	int sample_size;
 	uint sample_bits;
 	qboolean map_unload;
+
+	// get from engine
+	cl_entity_t *entities;
+	movevars_t *movevars;
+	model_t **models;
+
+	uint max_entities;
 } gl_globals_t;
 
 typedef struct
@@ -671,6 +673,21 @@ void TriBrightness( float brightness );
 
 #define ENGINE_GET_PARM_ (*gEngfuncs.EngineGetParm)
 #define ENGINE_GET_PARM( parm ) ENGINE_GET_PARM_( (parm), 0 )
+
+//
+// helper funcs
+//
+static inline cl_entity_t *CL_GetEntityByIndex( int index )
+{
+	return &tr.entities[index];
+}
+
+static inline model_t *CL_ModelHandle( int index )
+{
+	return tr.models[index];
+}
+
+#define WORLDMODEL (tr.models[1])
 
 extern ref_api_t      gEngfuncs;
 extern ref_globals_t *gpGlobals;

--- a/ref/soft/r_local.h
+++ b/ref/soft/r_local.h
@@ -298,6 +298,8 @@ typedef struct
 	cl_entity_t *entities;
 	movevars_t *movevars;
 	model_t **models;
+	color24 *palette;
+	cl_entity_t *viewent;
 
 	uint max_entities;
 } gl_globals_t;

--- a/ref/soft/r_main.c
+++ b/ref/soft/r_main.c
@@ -1941,6 +1941,8 @@ qboolean GAME_EXPORT R_Init( void )
 	// see R_ProcessEntData for tr.entities initialization
 	tr.models = gEngfuncs.pfnGetModels();
 	tr.movevars = gEngfuncs.pfnGetMoveVars();
+	tr.palette = gEngfuncs.CL_GetPaletteColor();
+	tr.viewent = gEngfuncs.GetViewModel();
 
 	R_InitBlit( glblit );
 

--- a/ref/soft/r_main.c
+++ b/ref/soft/r_main.c
@@ -425,7 +425,7 @@ R_GetFarClip
 static float R_GetFarClip( void )
 {
 	if( WORLDMODEL && RI.drawWorld )
-		return MOVEVARS->zmax * 1.73f;
+		return tr.movevars->zmax * 1.73f;
 	return 2048.0f;
 }
 
@@ -539,7 +539,7 @@ void R_RotateForEntity( cl_entity_t *e )
 #if 0
 	float	scale = 1.0f;
 
-	if( e == gEngfuncs.GetEntityByIndex( 0 ) )
+	if( e == CL_GetEntityByIndex( 0 ) )
 	{
 		R_LoadIdentity();
 		return;
@@ -567,7 +567,7 @@ void R_TranslateForEntity( cl_entity_t *e )
 #if 0
 	float	scale = 1.0f;
 
-	if( e == gEngfuncs.GetEntityByIndex( 0 ) )
+	if( e == CL_GetEntityByIndex( 0 ) )
 	{
 		R_LoadIdentity();
 		return;
@@ -784,7 +784,7 @@ void R_DrawEntitiesOnList( void )
 	//d_aflatcolor = 0;
 	tr.blend = 1.0f;
 //	GL_CheckForErrors();
-	//RI.currententity = gEngfuncs.GetEntityByIndex(0);
+	//RI.currententity = CL_GetEntityByIndex(0);
 	d_pdrawspans = R_PolysetFillSpans8;
 	GL_SetRenderMode(kRenderNormal);
 	// first draw solid entities
@@ -815,7 +815,7 @@ void R_DrawEntitiesOnList( void )
 			extern void	(*d_pdrawspans)(void *);
 			extern void R_PolysetFillSpans8 ( void * );
 			d_pdrawspans = R_PolysetFillSpans8;
-			//RI.currententity = gEngfuncs.GetEntityByIndex(0);
+			//RI.currententity = CL_GetEntityByIndex(0);
 			R_AliasSetUpTransform();
 			image_t *image = R_GetTexture(GL_LoadTexture("gfx/env/desertbk", NULL, 0, 0));
 			r_affinetridesc.pskin = image->pixels[0];
@@ -1937,6 +1937,10 @@ qboolean GAME_EXPORT R_Init( void )
 		gEngfuncs.R_Free_Video();
 		return false;
 	}
+
+	// see R_ProcessEntData for tr.entities initialization
+	tr.models = gEngfuncs.pfnGetModels();
+	tr.movevars = gEngfuncs.pfnGetMoveVars();
 
 	R_InitBlit( glblit );
 

--- a/ref/soft/r_part.c
+++ b/ref/soft/r_part.c
@@ -49,7 +49,7 @@ void GAME_EXPORT CL_DrawParticles( double frametime, particle_t *cl_active_parti
 {
 	particle_t	*p;
 	vec3_t		right, up;
-	color24		*pColor;
+	color24		color;
 	int		alpha;
 	float		size;
 
@@ -84,17 +84,17 @@ void GAME_EXPORT CL_DrawParticles( double frametime, particle_t *cl_active_parti
 			VectorScale( RI.cull_vup, size, up );
 
 			p->color = bound( 0, p->color, 255 );
-			pColor = gEngfuncs.CL_GetPaletteColor( p->color );
+			color = tr.palette[p->color];
 
 			alpha = 255 * (p->die - gpGlobals->time) * 16.0f;
 			if( alpha > 255 || p->type == pt_static )
 				alpha = 255;
 
-			//TriColor4ub( gEngfuncs.LightToTexGamma( pColor->r ),
-			//	gEngfuncs.LightToTexGamma( pColor->g ),
-		//		gEngfuncs.LightToTexGamma( pColor->b ), alpha );
+			//TriColor4ub( gEngfuncs.LightToTexGamma( color.r ),
+			//	gEngfuncs.LightToTexGamma( color.g ),
+		//		gEngfuncs.LightToTexGamma( color.b ), alpha );
 			//TriBrightness( alpha / 255.0f );
-			_TriColor4f(1.0f*alpha/255/255*pColor->r,1.0f*alpha/255/255*pColor->g,1.0f*alpha/255/255* pColor->b,1.0f );
+			_TriColor4f(1.0f*alpha/255/255*color.r,1.0f*alpha/255/255*color.g,1.0f*alpha/255/255* color.b,1.0f );
 
 			TriBegin( TRI_QUADS );
 			TriTexCoord2f( 0.0f, 1.0f );
@@ -211,7 +211,7 @@ void GAME_EXPORT CL_DrawTracers( double frametime, particle_t *cl_active_tracers
 		{
 			vec3_t	verts[4], tmp2;
 			vec3_t	tmp, normal;
-			color24	*pColor;
+			color24	color;
 			short alpha = p->packedColor;
 
 			// Transform point into screen space
@@ -242,9 +242,9 @@ void GAME_EXPORT CL_DrawTracers( double frametime, particle_t *cl_active_tracers
 				p->color = 0;
 			}
 
-			pColor = &gTracerColors[p->color];
-			//TriColor4ub( pColor->r, pColor->g, pColor->b, p->packedColor );
-			_TriColor4f(1.0f*alpha/255/255*pColor->r,1.0f*alpha/255/255*pColor->g,1.0f*alpha/255/255* pColor->b,1.0f );
+			color = gTracerColors[p->color];
+			//TriColor4ub( color.r, color.g, color.b, p->packedColor );
+			_TriColor4f(1.0f*alpha/255/255*color.r,1.0f*alpha/255/255*color.g,1.0f*alpha/255/255* color.b,1.0f );
 
 
 			TriBegin( TRI_QUADS );

--- a/ref/soft/r_part.c
+++ b/ref/soft/r_part.c
@@ -194,7 +194,7 @@ void GAME_EXPORT CL_DrawTracers( double frametime, particle_t *cl_active_tracers
 	//pglDisable( GL_ALPHA_TEST );
 	//pglDepthMask( GL_FALSE );
 
-	gravity = frametime * MOVEVARS->gravity;
+	gravity = frametime * tr.movevars->gravity;
 	scale = 1.0 - (frametime * 0.9);
 	if( scale < 0.0f ) scale = 0.0f;
 

--- a/ref/soft/r_sprite.c
+++ b/ref/soft/r_sprite.c
@@ -895,7 +895,7 @@ void R_DrawSpriteModel( cl_entity_t *e )
 	{
 		cl_entity_t	*parent;
 
-		parent = gEngfuncs.GetEntityByIndex( e->curstate.aiment );
+		parent = CL_GetEntityByIndex( e->curstate.aiment );
 
 		if( parent && parent->model )
 		{

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -1846,7 +1846,7 @@ void R_StudioRenderShadow( int iSprite, float *p1, float *p2, float *p3, float *
 	if( !p1 || !p2 || !p3 || !p4 )
 		return;
 
-	if( TriSpriteTexture( gEngfuncs.pfnGetModelByIndex( iSprite ), 0 ))
+	if( TriSpriteTexture( CL_ModelHandle( iSprite ), 0 ))
 	{
 		TriRenderMode( kRenderTransAlpha );
 		_TriColor4f( 0.0f, 0.0f, 0.0f, 1.0f );
@@ -3137,7 +3137,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 		// copy attachments into global entity array
 		if( RI.currententity->index > 0 )
 		{
-			cl_entity_t *ent = gEngfuncs.GetEntityByIndex( RI.currententity->index );
+			cl_entity_t *ent = CL_GetEntityByIndex( RI.currententity->index );
 			memcpy( ent->attachment, RI.currententity->attachment, sizeof( vec3_t ) * 4 );
 		}
 	}
@@ -3180,7 +3180,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 		if( pplayer->weaponmodel )
 		{
 			cl_entity_t	saveent = *RI.currententity;
-			model_t		*pweaponmodel = gEngfuncs.pfnGetModelByIndex( pplayer->weaponmodel );
+			model_t		*pweaponmodel = CL_ModelHandle( pplayer->weaponmodel );
 
 			m_pStudioHeader = (studiohdr_t *)gEngfuncs.Mod_Extradata( mod_studio, pweaponmodel );
 
@@ -3266,7 +3266,7 @@ static int R_StudioDrawModel( int flags )
 		// copy attachments into global entity array
 		if( RI.currententity->index > 0 )
 		{
-			cl_entity_t *ent = gEngfuncs.GetEntityByIndex( RI.currententity->index );
+			cl_entity_t *ent = CL_GetEntityByIndex( RI.currententity->index );
 			memcpy( ent->attachment, RI.currententity->attachment, sizeof( vec3_t ) * 4 );
 		}
 	}
@@ -3335,7 +3335,7 @@ void R_DrawStudioModel( cl_entity_t *e )
 	{
 		if( e->curstate.movetype == MOVETYPE_FOLLOW && e->curstate.aiment > 0 )
 		{
-			cl_entity_t *parent = gEngfuncs.GetEntityByIndex( e->curstate.aiment );
+			cl_entity_t *parent = CL_GetEntityByIndex( e->curstate.aiment );
 
 			if( parent && parent->model && parent->model->type == mod_studio )
 			{
@@ -3610,7 +3610,7 @@ void Mod_StudioUnloadTextures( void *data )
 
 static model_t *pfnModelHandle( int modelindex )
 {
-	return gEngfuncs.pfnGetModelByIndex( modelindex );
+	return CL_ModelHandle( modelindex );
 }
 
 static void *pfnMod_CacheCheck( struct cache_user_s *c )

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -2384,13 +2384,8 @@ R_StudioSetRemapColors
 */
 static void R_StudioSetRemapColors( int newTop, int newBottom )
 {
-	gEngfuncs.CL_AllocRemapInfo( RI.currententity, RI.currentmodel, newTop, newBottom );
-
-	if( gEngfuncs.CL_GetRemapInfoForEntity( RI.currententity ))
-	{
-		gEngfuncs.CL_UpdateRemapInfo( RI.currententity, newTop, newBottom );
+	if( gEngfuncs.CL_EntitySetRemapColors( RI.currententity, RI.currentmodel, newTop, newBottom ))
 		m_fDoRemap = true;
-	}
 }
 
 void R_StudioResetPlayerModels( void )

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -185,7 +185,7 @@ static qboolean R_AllowFlipViewModel( cl_entity_t *e )
 {
 	if( cl_righthand && cl_righthand->value > 0 )
 	{
-		if( e == gEngfuncs.GetViewModel() )
+		if( e == tr.viewent )
 			return true;
 	}
 
@@ -401,7 +401,7 @@ pfnGetViewEntity
 */
 static cl_entity_t *pfnGetViewEntity( void )
 {
-	return gEngfuncs.GetViewModel();
+	return tr.viewent;
 }
 
 /*
@@ -2246,7 +2246,7 @@ static void R_StudioDrawAbsBBox( void )
 	int	i;
 
 	// looks ugly, skip
-	if( RI.currententity == gEngfuncs.GetViewModel() )
+	if( RI.currententity == tr.viewent )
 		return;
 
 	if( !R_StudioComputeBBox( p ))
@@ -3371,7 +3371,7 @@ void R_RunViewmodelEvents( void )
 	if( !RP_NORMALPASS() || ENGINE_GET_PARM( PARM_LOCAL_HEALTH ) <= 0 || !CL_IsViewEntityLocalPlayer())
 		return;
 
-	RI.currententity = gEngfuncs.GetViewModel();
+	RI.currententity = tr.viewent;
 
 	if( !RI.currententity->model || RI.currententity->model->type != mod_studio )
 		return;
@@ -3393,7 +3393,7 @@ R_GatherPlayerLight
 */
 void R_GatherPlayerLight( void )
 {
-	cl_entity_t	*view = gEngfuncs.GetViewModel();
+	cl_entity_t	*view = tr.viewent;
 	colorVec		c;
 
 	tr.ignore_lightgamma = true;
@@ -3409,7 +3409,7 @@ R_DrawViewModel
 */
 void R_DrawViewModel( void )
 {
-	cl_entity_t	*view = gEngfuncs.GetViewModel();
+	cl_entity_t	*view = tr.viewent;
 
 	R_GatherPlayerLight();
 


### PR DESCRIPTION
Main RefAPI changes:

- Removed GetSomethingByIndex calls, renderers are supposed to cache pointer values
- Removed previously unused calls
- Simplified remapping calls
- GetRefAPI now must return REF_API_VERSION

API simplification gave a small performance boost: from 1350 to 1450 FPS in a small timedemo test.

This is an old branch that I decided to continue on after having an idea about remap calls. It doesn't have vbo-fix changes yet but I expect to merge these after this branch will be merged.