### PR TITLE
Fix engine/renderer timings synchronization. Bump to RefAPI 6

### DIFF
--- a/engine/client/cl_parse.c
+++ b/engine/client/cl_parse.c
@@ -1642,9 +1642,6 @@ void CL_RegisterResources( sizebuf_t *msg )
 
 			CL_ClearWorld ();
 
-			// update the ref state.
-			R_UpdateRefState ();
-
 			// tell rendering system we have a new set of models.
 			ref.dllFuncs.R_NewMap ();
 

--- a/engine/client/cl_parse_48.c
+++ b/engine/client/cl_parse_48.c
@@ -660,9 +660,6 @@ void CL_LegacyPrecache_f( void )
 	if( clgame.entities )
 		clgame.entities->model = cl.worldmodel;
 
-	// update the ref state.
-	R_UpdateRefState ();
-
 	// tell rendering system we have a new set of models.
 	ref.dllFuncs.R_NewMap ();
 

--- a/engine/client/cl_render.c
+++ b/engine/client/cl_render.c
@@ -187,28 +187,18 @@ intptr_t CL_RenderGetParm( const int parm, const int arg, const qboolean checkRe
 			return CL_IsThirdPerson();
 		case PARM_QUAKE_COMPATIBLE:
 			return Host_IsQuakeCompatible();
-		case PARM_PLAYER_INDEX:
-			return cl.playernum + 1;
-		case PARM_VIEWENT_INDEX:
-			return cl.viewentity;
 		case PARM_CONNSTATE:
 			return (int)cls.state;
 		case PARM_PLAYING_DEMO:
 			return cls.demoplayback;
 		case PARM_WATER_LEVEL:
 			return cl.local.waterlevel;
-		case PARM_MAX_CLIENTS:
-			return cl.maxclients;
 		case PARM_LOCAL_HEALTH:
 			return cl.local.health;
 		case PARM_LOCAL_GAME:
 			return Host_IsLocalGame();
 		case PARM_NUMENTITIES:
 			return pfnNumberOfEntities();
-		case PARM_NUMMODELS:
-			return cl.nummodels;
-		case PARM_WORLD_VERSION:
-			return world.version;
 		case PARM_GET_CLIENT_PTR:
 			return (intptr_t)&cl.time; // with the offset
 		case PARM_GET_HOST_PTR:

--- a/engine/client/cl_render.c
+++ b/engine/client/cl_render.c
@@ -209,6 +209,18 @@ intptr_t CL_RenderGetParm( const int parm, const int arg, const qboolean checkRe
 			return cl.nummodels;
 		case PARM_WORLD_VERSION:
 			return world.version;
+		case PARM_GET_CLIENT_PTR:
+			return (intptr_t)&cl.time; // with the offset
+		case PARM_GET_HOST_PTR:
+			return (intptr_t)&host.realtime; // with the offset
+		case PARM_GET_WORLD_PTR:
+			return (intptr_t)&world;
+		case PARM_GET_MOVEVARS_PTR:
+			return (intptr_t)&clgame.movevars;
+		case PARM_GET_PALETTE_PTR:
+			return (intptr_t)&clgame.palette;
+		case PARM_GET_VIEWENT_PTR:
+			return (intptr_t)&clgame.viewent;
 		}
 	}
 	return 0;

--- a/engine/client/client.h
+++ b/engine/client/client.h
@@ -174,6 +174,26 @@ typedef struct
 // at every server map change
 typedef struct
 {
+	// ==== shared through RefAPI's ref_client_t ====
+	double		time;			// this is the time value that the client
+						// is rendering at.  always <= cls.realtime
+						// a lerp point for other data
+	double		oldtime;			// previous cl.time, time-oldtime is used
+						// to decay light values and smooth step ups
+	int		viewentity;
+
+	// server state information
+	int		playernum;
+	int		maxclients;
+
+	int		nummodels;
+	model_t		*models[MAX_MODELS+1];		// precached models (plus sentinel slot)
+
+	qboolean	paused;
+
+	vec3_t		simorg;			// predicted origin
+	// ==== shared through RefAPI's ref_client_t ===
+
 	int		servercount;		// server identification for prespawns
 	int		validsequence;		// this is the sequence number of the last good
 						// world snapshot/update we got.  If this is 0, we can't
@@ -183,7 +203,6 @@ typedef struct
 
 	qboolean		video_prepped;		// false if on new level or new ref dll
 	qboolean		audio_prepped;		// false if on new level or new snd dll
-	qboolean		paused;
 
 	int		delta_sequence;		// acknowledged sequence number
 
@@ -205,11 +224,6 @@ typedef struct
 	runcmd_t		commands[MULTIPLAYER_BACKUP];		// each mesage will send several old cmds
 	local_state_t	predicted_frames[MULTIPLAYER_BACKUP];	// local client state
 
-	double		time;			// this is the time value that the client
-						// is rendering at.  always <= cls.realtime
-						// a lerp point for other data
-	double		oldtime;			// previous cl.time, time-oldtime is used
-						// to decay light values and smooth step ups
 	double		timedelta;		// floating delta between two updates
 
 	char		serverinfo[MAX_SERVERINFO_STRING];
@@ -223,7 +237,6 @@ typedef struct
 
 	// player final info
 	usercmd_t		*cmd;			// cl.commands[outgoing_sequence].cmd
-	int		viewentity;
 	vec3_t		viewangles;
 	vec3_t		viewheight;
 	vec3_t		punchangle;
@@ -236,13 +249,8 @@ typedef struct
 	float		addangletotal;
 	float		prevaddangletotal;
 
-	// predicted origin and velocity
-	vec3_t		simorg;
+	// predicted velocity
 	vec3_t		simvel;
-
-	// server state information
-	int		playernum;
-	int		maxclients;
 
 	entity_state_t	instanced_baseline[MAX_CUSTOM_BASELINES];
 	int		instanced_baseline_count;
@@ -251,8 +259,6 @@ typedef struct
 	char		event_precache[MAX_EVENTS][MAX_QPATH];
 	char		files_precache[MAX_CUSTOM][MAX_QPATH];
 	lightstyle_t	lightstyles[MAX_LIGHTSTYLES];
-	model_t		*models[MAX_MODELS+1];		// precached models (plus sentinel slot)
-	int		nummodels;
 	int		numfiles;
 
 	consistency_t	consistency_list[MAX_MODELS];

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -67,18 +67,8 @@ void GAME_EXPORT GL_FreeImage( const char *name )
 		 ref.dllFuncs.GL_FreeTexture( texnum );
 }
 
-void R_UpdateRefState( void )
-{
-	refState.time      = cl.time;
-	refState.oldtime   = cl.oldtime;
-	refState.realtime  = host.realtime;
-	refState.frametime = host.frametime;
-}
-
 void GL_RenderFrame( const ref_viewpass_t *rvp )
 {
-	R_UpdateRefState();
-
 	VectorCopy( rvp->vieworigin, refState.vieworg );
 	VectorCopy( rvp->viewangles, refState.viewangles );
 
@@ -88,11 +78,6 @@ void GL_RenderFrame( const ref_viewpass_t *rvp )
 static intptr_t pfnEngineGetParm( int parm, int arg )
 {
 	return CL_RenderGetParm( parm, arg, false ); // prevent recursion
-}
-
-static world_static_t *pfnGetWorld( void )
-{
-	return &world;
 }
 
 static void pfnStudioEvent( const mstudioevent_t *event, const cl_entity_t *e )
@@ -122,16 +107,6 @@ static void *pfnMod_Extradata( int type, model_t *m )
 	default: Host_Error( "Mod_Extradata: unknown type %d\n", type );
 	}
 	return NULL;
-}
-
-static void pfnGetPredictedOrigin( vec3_t v )
-{
-	VectorCopy( cl.simorg, v );
-}
-
-static color24 *pfnCL_GetPaletteColor( void ) // clgame.palette[color]
-{
-	return clgame.palette;
 }
 
 static void pfnCL_GetScreenInfo( int *width, int *height ) // clgame.scrInfo, ptrs may be NULL
@@ -232,11 +207,6 @@ static qboolean R_Init_Video_( const int type )
 	return R_Init_Video( type );
 }
 
-static model_t **pfnGetModels( void )
-{
-	return cl.models;
-}
-
 static ref_api_t gEngfuncs =
 {
 	pfnEngineGetParm,
@@ -271,14 +241,12 @@ static ref_api_t gEngfuncs =
 	Con_DrawString,
 	CL_DrawCenterPrint,
 
-	CL_GetViewModel,
 	R_BeamGetEntity,
 	CL_GetWaterEntity,
 	CL_AddVisibleEntity,
 
 	Mod_SampleSizeForFace,
 	Mod_BoxVisible,
-	pfnGetWorld,
 	Mod_PointInLeaf,
 	Mod_CreatePolygonsForHull,
 
@@ -295,7 +263,6 @@ static ref_api_t gEngfuncs =
 
 	Mod_ForName,
 	pfnMod_Extradata,
-	pfnGetModels,
 
 	CL_EntitySetRemapColors,
 	CL_GetRemapInfoForEntity,
@@ -306,8 +273,6 @@ static ref_api_t gEngfuncs =
 	COM_RandomFloat,
 	COM_RandomLong,
 	pfnRefGetScreenFade,
-	pfnGetPredictedOrigin,
-	pfnCL_GetPaletteColor,
 	pfnCL_GetScreenInfo,
 	pfnSetLocalLightLevel,
 	Sys_CheckParm,
@@ -357,7 +322,6 @@ static ref_api_t gEngfuncs =
 	PM_CL_TraceLine,
 	CL_VisTraceLine,
 	CL_TraceLine,
-	pfnGetMoveVars,
 
 	Image_AddCmdFlags,
 	Image_SetForceFlags,

--- a/engine/client/ref_common.h
+++ b/engine/client/ref_common.h
@@ -52,7 +52,6 @@ extern convar_t gl_clear;
 
 qboolean R_Init( void );
 void R_Shutdown( void );
-void R_UpdateRefState( void );
 
 extern triangleapi_t gTriApi;
 

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -302,8 +302,12 @@ typedef struct host_parm_s
 	int		argc;
 	char	**argv;
 
+	// ==== shared through RefAPI's ref_host_t
 	double		realtime;		// host.curtime
 	double		frametime;	// time between engine frames
+	uint		features;		// custom features that enables by mod-maker request
+	// ==== shared through RefAPI's ref_host_t
+
 	double		realframetime;	// for some system events, e.g. console animations
 
 	uint		framecount;	// global framecount
@@ -343,8 +347,6 @@ typedef struct host_parm_s
 	char		gamefolder[MAX_QPATH];	// it's a default gamefolder
 	poolhandle_t imagepool;	// imagelib mempool
 	poolhandle_t soundpool;	// soundlib mempool
-
-	uint		features;		// custom features that enables by mod-maker request
 
 	// for IN_MouseMove() easy access
 	int		window_center_x;

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -28,6 +28,7 @@ GNU General Public License for more details.
 #include "r_efx.h"
 #include "com_image.h"
 #include "filesystem.h"
+#include "common/protocol.h"
 
 // RefAPI changelog:
 // 1. Initial release
@@ -119,6 +120,26 @@ typedef struct ref_globals_s
 
 	int desktopBitsPixel;
 } ref_globals_t;
+
+typedef struct ref_client_s
+{
+	double   time;
+	double   oldtime;
+	int      viewentity;
+	int      playernum;
+	int      maxclients;
+	int      nummodels;
+	model_t *models[MAX_MODELS+1];
+	qboolean paused;
+	vec3_t   simorg;
+} ref_client_t;
+
+typedef struct ref_host_s
+{
+	double realtime;
+	double frametime;
+	int    features;
+} ref_host_t;
 
 enum
 {
@@ -262,6 +283,12 @@ typedef enum
 	PARM_NUMENTITIES       = -12, // local game only
 	PARM_NUMMODELS         = -13, // cl.nummodels
 	PARM_WORLD_VERSION     = -14,
+	PARM_GET_CLIENT_PTR    = -15, // ref_client_t
+	PARM_GET_HOST_PTR      = -16, // ref_host_t
+	PARM_GET_WORLD_PTR     = -17, // world
+	PARM_GET_MOVEVARS_PTR  = -18, // clgame.movevars
+	PARM_GET_PALETTE_PTR   = -19, // clgame.palette
+	PARM_GET_VIEWENT_PTR   = -20, // clgame.viewent
 } ref_parm_e;
 
 typedef struct ref_api_s

--- a/ref/gl/gl_alias.c
+++ b/ref/gl/gl_alias.c
@@ -765,7 +765,7 @@ similar to R_StudioDynamicLight
 */
 void R_AliasDynamicLight( cl_entity_t *ent, alight_t *plight )
 {
-	movevars_t	*mv = gEngfuncs.pfnGetMoveVars();
+	movevars_t	*mv = tr.movevars;
 	vec3_t		lightDir, vecSrc, vecEnd;
 	vec3_t		origin, dist, finalLight;
 	float		add, radius, total;

--- a/ref/gl/gl_alias.c
+++ b/ref/gl/gl_alias.c
@@ -1337,7 +1337,7 @@ static void R_AliasSetupTimings( void )
 	else
 	{
 		// menu stuff
-		g_alias.time = gpGlobals->realtime;
+		g_alias.time = gp_host->realtime;
 	}
 
 	m_fDoRemap = false;

--- a/ref/gl/gl_alias.c
+++ b/ref/gl/gl_alias.c
@@ -1332,7 +1332,7 @@ static void R_AliasSetupTimings( void )
 	if( RI.drawWorld )
 	{
 		// synchronize with server time
-		g_alias.time = gpGlobals->time;
+		g_alias.time = gp_cl->time;
 	}
 	else
 	{

--- a/ref/gl/gl_beams.c
+++ b/ref/gl/gl_beams.c
@@ -868,11 +868,7 @@ static qboolean R_BeamComputePoint( int beamEnt, vec3_t pt )
 	if( attach > 0 )
 		VectorCopy( ent->attachment[attach - 1], pt );
 	else if( ent->index == ( gp_cl->playernum + 1 ))
-	{
-		vec3_t simorg;
-		gEngfuncs.GetPredictedOrigin( simorg );
-		VectorCopy( simorg, pt );
-	}
+		VectorCopy( gp_cl->simorg, pt );
 	else VectorCopy( ent->origin, pt );
 
 	return true;

--- a/ref/gl/gl_beams.c
+++ b/ref/gl/gl_beams.c
@@ -608,7 +608,7 @@ void R_DrawBeamFollow( BEAM *pbeam, float frametime )
 	if( pnew )
 	{
 		VectorCopy( pbeam->source, pnew->org );
-		pnew->die = gpGlobals->time + pbeam->amplitude;
+		pnew->die = gp_cl->time + pbeam->amplitude;
 		VectorClear( pnew->vel );
 
 		pnew->next = particles;
@@ -655,7 +655,7 @@ void R_DrawBeamFollow( BEAM *pbeam, float frametime )
 	VectorMA( delta, -pbeam->width, normal, last2 );
 
 	div = 1.0f / pbeam->amplitude;
-	fraction = ( pbeam->die - gpGlobals->time ) * div;
+	fraction = ( pbeam->die - gp_cl->time ) * div;
 
 	vLast = 0.0f;
 	vStep = 1.0f;
@@ -688,7 +688,7 @@ void R_DrawBeamFollow( BEAM *pbeam, float frametime )
 
 		if( particles->next != NULL )
 		{
-			fraction = (particles->die - gpGlobals->time) * div;
+			fraction = (particles->die - gp_cl->time) * div;
 		}
 		else
 		{
@@ -916,7 +916,7 @@ qboolean R_BeamRecomputeEndpoints( BEAM *pbeam )
 		else if( !FBitSet( pbeam->flags, FBEAM_FOREVER ))
 		{
 			ClearBits( pbeam->flags, FBEAM_ENDENTITY );
-			pbeam->die = gpGlobals->time;
+			pbeam->die = gp_cl->time;
 			return false;
 		}
 		else
@@ -949,7 +949,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 	if( !model || model->type != mod_sprite )
 	{
 		pbeam->flags &= ~FBEAM_ISACTIVE; // force to ignore
-		pbeam->die = gpGlobals->time;
+		pbeam->die = gp_cl->time;
 		return;
 	}
 
@@ -1007,7 +1007,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 	if( pbeam->flags & ( FBEAM_FADEIN|FBEAM_FADEOUT ))
 	{
 		// update life cycle
-		pbeam->t = pbeam->freq + ( pbeam->die - gpGlobals->time );
+		pbeam->t = pbeam->freq + ( pbeam->die - gp_cl->time );
 		if( pbeam->t != 0.0f ) pbeam->t = 1.0f - pbeam->freq / pbeam->t;
 	}
 
@@ -1055,7 +1055,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 
 	TriRenderMode( FBitSet( pbeam->flags, FBEAM_SOLID ) ? kRenderNormal : kRenderTransAdd );
 
-	if( !TriSpriteTexture( model, (int)(pbeam->frame + pbeam->frameRate * gpGlobals->time) % pbeam->frameCount ))
+	if( !TriSpriteTexture( model, (int)(pbeam->frame + pbeam->frameRate * gp_cl->time) % pbeam->frameCount ))
 	{
 		ClearBits( pbeam->flags, FBEAM_ISACTIVE );
 		return;
@@ -1160,8 +1160,8 @@ static void R_BeamSetup( BEAM *pbeam, vec3_t start, vec3_t end, int modelIndex, 
 	VectorCopy( end, pbeam->target );
 	VectorSubtract( end, start, pbeam->delta );
 
-	pbeam->freq = speed * gpGlobals->time;
-	pbeam->die = life + gpGlobals->time;
+	pbeam->freq = speed * gp_cl->time;
+	pbeam->die = life + gp_cl->time;
 	pbeam->amplitude = amplitude;
 	pbeam->brightness = brightness;
 	pbeam->width = width;
@@ -1291,7 +1291,7 @@ void CL_DrawBeams( int fTrans, BEAM *active_beams )
 		if( !fTrans && !FBitSet( pBeam->flags, FBEAM_SOLID ))
 			continue;
 
-		R_BeamDraw( pBeam, gpGlobals->time -   gpGlobals->oldtime );
+		R_BeamDraw( pBeam, gp_cl->time -   gp_cl->oldtime );
 	}
 
 	pglShadeModel( GL_FLAT );

--- a/ref/gl/gl_beams.c
+++ b/ref/gl/gl_beams.c
@@ -867,7 +867,7 @@ static qboolean R_BeamComputePoint( int beamEnt, vec3_t pt )
 	// get attachment
 	if( attach > 0 )
 		VectorCopy( ent->attachment[attach - 1], pt );
-	else if( ent->index == ENGINE_GET_PARM( PARM_PLAYER_INDEX ) )
+	else if( ent->index == ( gp_cl->playernum + 1 ))
 	{
 		vec3_t simorg;
 		gEngfuncs.GetPredictedOrigin( simorg );

--- a/ref/gl/gl_context.c
+++ b/ref/gl/gl_context.c
@@ -24,6 +24,8 @@ GNU General Public License for more details.
 
 ref_api_t      gEngfuncs;
 ref_globals_t *gpGlobals;
+ref_client_t  *gp_cl;
+ref_host_t    *gp_host;
 
 static void R_ClearScreen( void )
 {
@@ -517,6 +519,9 @@ int EXPORT GetRefAPI( int version, ref_interface_t *funcs, ref_api_t *engfuncs, 
 	memcpy( funcs, &gReffuncs, sizeof( ref_interface_t ));
 	memcpy( &gEngfuncs, engfuncs, sizeof( ref_api_t ));
 	gpGlobals = globals;
+
+	gp_cl = (ref_client_t *)ENGINE_GET_PARM( PARM_GET_CLIENT_PTR );
+	gp_host = (ref_host_t *)ENGINE_GET_PARM( PARM_GET_HOST_PTR );
 
 	return REF_API_VERSION;
 }

--- a/ref/gl/gl_local.h
+++ b/ref/gl/gl_local.h
@@ -258,7 +258,6 @@ typedef struct
 	struct world_static_s *world;
 	cl_entity_t *entities;
 	movevars_t *movevars;
-	model_t **models;
 	color24 *palette;
 	cl_entity_t *viewent;
 
@@ -725,6 +724,8 @@ extern glstate_t		glState;
 extern glwstate_t		glw_state;
 extern ref_api_t      gEngfuncs;
 extern ref_globals_t *gpGlobals;
+extern ref_client_t  *gp_cl;
+extern ref_host_t    *gp_host;
 
 #define ENGINE_GET_PARM_ (*gEngfuncs.EngineGetParm)
 #define ENGINE_GET_PARM( parm ) ENGINE_GET_PARM_( ( parm ), 0 )
@@ -739,10 +740,10 @@ static inline cl_entity_t *CL_GetEntityByIndex( int index )
 
 static inline model_t *CL_ModelHandle( int index )
 {
-	return tr.models[index];
+	return gp_cl->models[index];
 }
 
-#define WORLDMODEL (tr.models[1])
+#define WORLDMODEL (gp_cl->models[1])
 
 //
 // renderer cvars

--- a/ref/gl/gl_local.h
+++ b/ref/gl/gl_local.h
@@ -87,10 +87,10 @@ extern poolhandle_t r_temppool;
 #define RP_NONVIEWERREF	(RP_ENVVIEW)
 #define R_ModelOpaque( rm )	( rm == kRenderNormal )
 #define R_StaticEntity( ent )	( VectorIsNull( ent->origin ) && VectorIsNull( ent->angles ))
-#define RP_LOCALCLIENT( e )	((e) != NULL && (e)->index == ENGINE_GET_PARM( PARM_PLAYER_INDEX ) && e->player )
+#define RP_LOCALCLIENT( e )	((e) != NULL && (e)->index == ( gp_cl->playernum + 1 ) && e->player )
 #define RP_NORMALPASS()	( FBitSet( RI.params, RP_NONVIEWERREF ) == 0 )
 
-#define CL_IsViewEntityLocalPlayer() ( ENGINE_GET_PARM( PARM_VIEWENT_INDEX ) == ENGINE_GET_PARM( PARM_PLAYER_INDEX ) )
+#define CL_IsViewEntityLocalPlayer() ( gp_cl->viewentity == ( gp_cl->playernum + 1 ))
 
 #define CULL_VISIBLE	0		// not culled
 #define CULL_BACKSIDE	1		// backside of transparent wall

--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -1287,11 +1287,10 @@ qboolean R_Init( void )
 	}
 
 	// see R_ProcessEntData for tr.entities initialization
-	tr.world = gEngfuncs.GetWorld();
-	tr.models = gEngfuncs.pfnGetModels();
-	tr.movevars = gEngfuncs.pfnGetMoveVars();
-	tr.palette = gEngfuncs.CL_GetPaletteColor();
-	tr.viewent = gEngfuncs.GetViewModel();
+	tr.world = (struct world_static_s *)ENGINE_GET_PARM( PARM_GET_WORLD_PTR );
+	tr.movevars = (movevars_t *)ENGINE_GET_PARM( PARM_GET_MOVEVARS_PTR );
+	tr.palette = (color24 *)ENGINE_GET_PARM( PARM_GET_PALETTE_PTR );
+	tr.viewent = (cl_entity_t *)ENGINE_GET_PARM( PARM_GET_VIEWENT_PTR );
 
 	GL_SetDefaults();
 	R_CheckVBO();

--- a/ref/gl/gl_rlight.c
+++ b/ref/gl/gl_rlight.c
@@ -36,7 +36,7 @@ void CL_RunLightStyles( void )
 {
 	int		i, k, flight, clight;
 	float		l, lerpfrac, backlerp;
-	float		frametime = (gpGlobals->time -   gpGlobals->oldtime);
+	float		frametime = (gp_cl->time -   gp_cl->oldtime);
 	float		scale;
 	lightstyle_t	*ls;
 
@@ -160,7 +160,7 @@ void R_PushDlights( void )
 	{
 		l = gEngfuncs.GetDynamicLight( i );
 
-		if( l->die < gpGlobals->time || !l->radius )
+		if( l->die < gp_cl->time || !l->radius )
 			continue;
 
 		if( GL_FrustumCullSphere( &RI.frustum, l->origin, l->radius, 15 ))

--- a/ref/gl/gl_rmain.c
+++ b/ref/gl/gl_rmain.c
@@ -339,8 +339,8 @@ void R_SetupFrustum( void )
 
 	if( RP_NORMALPASS() && ( ENGINE_GET_PARM( PARM_WATER_LEVEL ) >= 3 ) && ENGINE_GET_PARM( PARM_QUAKE_COMPATIBLE ))
 	{
-		RI.fov_x = atan( tan( DEG2RAD( RI.fov_x ) / 2 ) * ( 0.97f + sin( gpGlobals->time * 1.5f ) * 0.03f )) * 2 / (M_PI_F / 180.0f);
-		RI.fov_y = atan( tan( DEG2RAD( RI.fov_y ) / 2 ) * ( 1.03f - sin( gpGlobals->time * 1.5f ) * 0.03f )) * 2 / (M_PI_F / 180.0f);
+		RI.fov_x = atan( tan( DEG2RAD( RI.fov_x ) / 2 ) * ( 0.97f + sin( gp_cl->time * 1.5f ) * 0.03f )) * 2 / (M_PI_F / 180.0f);
+		RI.fov_y = atan( tan( DEG2RAD( RI.fov_y ) / 2 ) * ( 1.03f - sin( gp_cl->time * 1.5f ) * 0.03f )) * 2 / (M_PI_F / 180.0f);
 	}
 
 	// build the transformation matrix for the given view angles
@@ -954,7 +954,7 @@ void R_RenderScene( void )
 
 	// frametime is valid only for normal pass
 	if( RP_NORMALPASS( ))
-		tr.frametime = gpGlobals->time -   gpGlobals->oldtime;
+		tr.frametime = gp_cl->time -   gp_cl->oldtime;
 	else tr.frametime = 0.0;
 
 	// begin a new frame
@@ -1181,16 +1181,16 @@ int CL_FxBlend( cl_entity_t *e )
 	switch( e->curstate.renderfx )
 	{
 	case kRenderFxPulseSlowWide:
-		blend = e->curstate.renderamt + 0x40 * sin( gpGlobals->time * 2 + offset );
+		blend = e->curstate.renderamt + 0x40 * sin( gp_cl->time * 2 + offset );
 		break;
 	case kRenderFxPulseFastWide:
-		blend = e->curstate.renderamt + 0x40 * sin( gpGlobals->time * 8 + offset );
+		blend = e->curstate.renderamt + 0x40 * sin( gp_cl->time * 8 + offset );
 		break;
 	case kRenderFxPulseSlow:
-		blend = e->curstate.renderamt + 0x10 * sin( gpGlobals->time * 2 + offset );
+		blend = e->curstate.renderamt + 0x10 * sin( gp_cl->time * 2 + offset );
 		break;
 	case kRenderFxPulseFast:
-		blend = e->curstate.renderamt + 0x10 * sin( gpGlobals->time * 8 + offset );
+		blend = e->curstate.renderamt + 0x10 * sin( gp_cl->time * 8 + offset );
 		break;
 	case kRenderFxFadeSlow:
 		if( RP_NORMALPASS( ))
@@ -1229,27 +1229,27 @@ int CL_FxBlend( cl_entity_t *e )
 		blend = e->curstate.renderamt;
 		break;
 	case kRenderFxStrobeSlow:
-		blend = 20 * sin( gpGlobals->time * 4 + offset );
+		blend = 20 * sin( gp_cl->time * 4 + offset );
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxStrobeFast:
-		blend = 20 * sin( gpGlobals->time * 16 + offset );
+		blend = 20 * sin( gp_cl->time * 16 + offset );
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxStrobeFaster:
-		blend = 20 * sin( gpGlobals->time * 36 + offset );
+		blend = 20 * sin( gp_cl->time * 36 + offset );
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxFlickerSlow:
-		blend = 20 * (sin( gpGlobals->time * 2 ) + sin( gpGlobals->time * 17 + offset ));
+		blend = 20 * (sin( gp_cl->time * 2 ) + sin( gp_cl->time * 17 + offset ));
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxFlickerFast:
-		blend = 20 * (sin( gpGlobals->time * 16 ) + sin( gpGlobals->time * 23 + offset ));
+		blend = 20 * (sin( gp_cl->time * 16 ) + sin( gp_cl->time * 23 + offset ));
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;

--- a/ref/gl/gl_rpart.c
+++ b/ref/gl/gl_rpart.c
@@ -87,7 +87,7 @@ void CL_DrawParticles( double frametime, particle_t *cl_active_particles, float 
 			p->color = bound( 0, p->color, 255 );
 			color = tr.palette[p->color];
 
-			alpha = 255 * (p->die - gpGlobals->time) * 16.0f;
+			alpha = 255 * (p->die - gp_cl->time) * 16.0f;
 			if( alpha > 255 || p->type == pt_static )
 				alpha = 255;
 
@@ -194,7 +194,7 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 
 	for( p = cl_active_tracers; p; p = p->next )
 	{
-		atten = (p->die - gpGlobals->time);
+		atten = (p->die - gp_cl->time);
 		if( atten > 0.1f ) atten = 0.1f;
 
 		VectorScale( p->vel, ( p->ramp * atten ), delta );
@@ -259,7 +259,7 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 			p->vel[1] *= scale;
 			p->vel[2] -= gravity;
 
-			p->packedColor = 255 * (p->die - gpGlobals->time) * 2;
+			p->packedColor = 255 * (p->die - gp_cl->time) * 2;
 			if( p->packedColor > 255 ) p->packedColor = 255;
 		}
 		else if( p->type == pt_slowgrav )

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -3774,7 +3774,7 @@ void GL_RebuildLightmaps( void )
 
 	LM_InitBlock();
 
-	for( i = 0; i < ENGINE_GET_PARM( PARM_NUMMODELS ); i++ )
+	for( i = 0; i < gp_cl->nummodels; i++ )
 	{
 		if(( m = CL_ModelHandle( i + 1 )) == NULL )
 			continue;
@@ -3839,7 +3839,7 @@ void GL_BuildLightmaps( void )
 
 	LM_InitBlock();
 
-	for( i = 0; i < ENGINE_GET_PARM( PARM_NUMMODELS ); i++ )
+	for( i = 0; i < gp_cl->nummodels; i++ )
 	{
 		if(( m = CL_ModelHandle( i + 1 )) == NULL )
 			continue;

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -408,7 +408,7 @@ texture_t *R_TextureAnim( texture_t *b )
 			speed = 10;
 		else speed = 20;
 
-		reletive = (int)(gpGlobals->time * speed) % base->anim_total;
+		reletive = (int)(gp_cl->time * speed) % base->anim_total;
 	}
 
 
@@ -500,7 +500,7 @@ texture_t *R_TextureAnimation( msurface_t *s )
 			speed = 10;
 		else speed = 20;
 
-		reletive = (int)(gpGlobals->time * speed) % base->anim_total;
+		reletive = (int)(gp_cl->time * speed) % base->anim_total;
 	}
 
 	count = 0;
@@ -828,8 +828,8 @@ void DrawGLPoly( glpoly_t *p, float xScale, float yScale )
 		flAngle = ( flConveyorSpeed >= 0 ) ? 180 : 0;
 
 		SinCos( flAngle * ( M_PI_F / 180.0f ), &sy, &cy );
-		sOffset = gpGlobals->time * cy * flRate;
-		tOffset = gpGlobals->time * sy * flRate;
+		sOffset = gp_cl->time * cy * flRate;
+		tOffset = gp_cl->time * sy * flRate;
 
 		// make sure that we are positive
 		if( sOffset < 0.0f ) sOffset += 1.0f + -(int)sOffset;
@@ -1601,7 +1601,7 @@ void R_DrawBrushModel( cl_entity_t *e )
 	{
 		l = gEngfuncs.GetDynamicLight( k );
 
-		if( l->die < gpGlobals->time || !l->radius )
+		if( l->die < gp_cl->time || !l->radius )
 			continue;
 
 		VectorCopy( l->origin, oldorigin ); // save lightorigin

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -3819,7 +3819,7 @@ void GL_BuildLightmaps( void )
 
 	// update the lightmap blocksize
 	if( FBitSet( ENGINE_GET_PARM( PARM_FEATURES ), ENGINE_LARGE_LIGHTMAPS )
-		|| ENGINE_GET_PARM( PARM_WORLD_VERSION ) == QBSP2_VERSION )
+		|| tr.world->version == QBSP2_VERSION )
 		tr.block_size = BLOCK_SIZE_MAX;
 	else tr.block_size = BLOCK_SIZE_DEFAULT;
 

--- a/ref/gl/gl_sprite.c
+++ b/ref/gl/gl_sprite.c
@@ -430,7 +430,7 @@ mspriteframe_t *R_GetSpriteFrame( const model_t *pModel, int frame, float yaw )
 
 		// when loading in Mod_LoadSpriteGroup, we guaranteed all interval values
 		// are positive, so we don't have to worry about division by zero
-		targettime = gpGlobals->time - ((int)( gpGlobals->time / fullinterval )) * fullinterval;
+		targettime = gp_cl->time - ((int)( gp_cl->time / fullinterval )) * fullinterval;
 
 		for( i = 0; i < (numframes - 1); i++ )
 		{
@@ -494,25 +494,25 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 				// this can be happens when rendering switched between single and angled frames
 				// or change model on replace delta-entity
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 1.0f;
 			}
 
-			if( ent->latched.sequencetime < gpGlobals->time )
+			if( ent->latched.sequencetime < gp_cl->time )
 			{
 				if( frame != ent->latched.prevblending[1] )
 				{
 					ent->latched.prevblending[0] = ent->latched.prevblending[1];
 					ent->latched.prevblending[1] = frame;
-					ent->latched.sequencetime = gpGlobals->time;
+					ent->latched.sequencetime = gp_cl->time;
 					lerpFrac = 0.0f;
 				}
-				else lerpFrac = (gpGlobals->time - ent->latched.sequencetime) * 11.0f;
+				else lerpFrac = (gp_cl->time - ent->latched.sequencetime) * 11.0f;
 			}
 			else
 			{
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 0.0f;
 			}
 		}
@@ -526,7 +526,7 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 		{
 			// reset interpolation on change model
 			ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-			ent->latched.sequencetime = gpGlobals->time;
+			ent->latched.sequencetime = gp_cl->time;
 			lerpFrac = 0.0f;
 		}
 
@@ -541,7 +541,7 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 		numframes = pspritegroup->numframes;
 		fullinterval = pintervals[numframes-1];
 		jinterval = pintervals[1] - pintervals[0];
-		time = gpGlobals->time;
+		time = gp_cl->time;
 		jtime = 0.0f;
 
 		// when loading in Mod_LoadSpriteGroup, we guaranteed all interval values
@@ -580,25 +580,25 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 				// this can be happens when rendering switched between single and angled frames
 				// or change model on replace delta-entity
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 1.0f;
 			}
 
-			if( ent->latched.sequencetime < gpGlobals->time )
+			if( ent->latched.sequencetime < gp_cl->time )
 			{
 				if( frame != ent->latched.prevblending[1] )
 				{
 					ent->latched.prevblending[0] = ent->latched.prevblending[1];
 					ent->latched.prevblending[1] = frame;
-					ent->latched.sequencetime = gpGlobals->time;
+					ent->latched.sequencetime = gp_cl->time;
 					lerpFrac = 0.0f;
 				}
-				else lerpFrac = (gpGlobals->time - ent->latched.sequencetime) * ent->curstate.framerate;
+				else lerpFrac = (gp_cl->time - ent->latched.sequencetime) * ent->curstate.framerate;
 			}
 			else
 			{
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 0.0f;
 			}
 		}

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -1324,7 +1324,7 @@ R_StudioDynamicLight
 */
 void R_StudioDynamicLight( cl_entity_t *ent, alight_t *plight )
 {
-	movevars_t	*mv = gEngfuncs.pfnGetMoveVars();
+	movevars_t	*mv = tr.movevars;
 	vec3_t		lightDir, vecSrc, vecEnd;
 	vec3_t		origin, dist, finalLight;
 	float		add, radius, total;

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -174,8 +174,8 @@ static void R_StudioSetupTimings( void )
 	if( RI.drawWorld )
 	{
 		// synchronize with server time
-		g_studio.time = gpGlobals->time;
-		g_studio.frametime = gpGlobals->time - gpGlobals->oldtime;
+		g_studio.time = gp_cl->time;
+		g_studio.frametime = gp_cl->time - gp_cl->oldtime;
 	}
 	else
 	{
@@ -424,8 +424,8 @@ pfnGetEngineTimes
 static void pfnGetEngineTimes( int *framecount, double *current, double *old )
 {
 	if( framecount ) *framecount = tr.realframecount;
-	if( current ) *current = gpGlobals->time;
-	if( old ) *old =   gpGlobals->oldtime;
+	if( current ) *current = gp_cl->time;
+	if( old ) *old =   gp_cl->oldtime;
 }
 
 /*
@@ -2756,7 +2756,7 @@ static void R_StudioClientEvents( void )
 
 		ClearBits( e->curstate.effects, EF_MUZZLEFLASH );
 		VectorCopy( e->attachment[0], el->origin );
-		el->die = gpGlobals->time + 0.05f;
+		el->die = gp_cl->time + 0.05f;
 		el->color.r = 255;
 		el->color.g = 192;
 		el->color.b = 64;

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -180,8 +180,8 @@ static void R_StudioSetupTimings( void )
 	else
 	{
 		// menu stuff
-		g_studio.time = gpGlobals->realtime;
-		g_studio.frametime = gpGlobals->frametime;
+		g_studio.time = gp_host->realtime;
+		g_studio.frametime = gp_host->frametime;
 	}
 }
 
@@ -2772,7 +2772,7 @@ static void R_StudioClientEvents( void )
 		return;
 
 	end = R_StudioEstimateFrame( e, pseqdesc, g_studio.time );
-	start = end - e->curstate.framerate * gpGlobals->frametime * pseqdesc->fps;
+	start = end - e->curstate.framerate * gp_host->frametime * pseqdesc->fps;
 	pevent = (mstudioevent_t *)((byte *)m_pStudioHeader + pseqdesc->eventindex);
 
 	if( e->latched.sequencetime == e->curstate.animtime )

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -3607,7 +3607,7 @@ void R_RunViewmodelEvents( void )
 
 	R_StudioSetupTimings();
 
-	gEngfuncs.GetPredictedOrigin( simorg );
+	VectorCopy( gp_cl->simorg, simorg );
 	for( i = 0; i < 4; i++ )
 		VectorCopy( simorg, RI.currententity->attachment[i] );
 	RI.currentmodel = RI.currententity->model;

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -3297,7 +3297,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 
 	m_nPlayerIndex = pplayer->number - 1;
 
-	if( m_nPlayerIndex < 0 || m_nPlayerIndex >= ENGINE_GET_PARM( PARM_MAX_CLIENTS ) )
+	if( m_nPlayerIndex < 0 || m_nPlayerIndex >= gp_cl->maxclients )
 		return 0;
 
 	RI.currentmodel = R_StudioSetupPlayerModel( m_nPlayerIndex );
@@ -3379,7 +3379,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 			RI.currententity->curstate.body = 255;
 		}
 
-		if( !( !gpGlobals->developer && ENGINE_GET_PARM( PARM_MAX_CLIENTS ) == 1 ) && ( RI.currentmodel == RI.currententity->model ))
+		if( !( !gpGlobals->developer && gp_cl->maxclients == 1 ) && ( RI.currentmodel == RI.currententity->model ))
 			RI.currententity->curstate.body = 1; // force helmet
 
 		lighting.plightvec = dir;
@@ -3442,7 +3442,7 @@ static int R_StudioDrawModel( int flags )
 		int		result;
 
 		if( RI.currententity->curstate.renderamt <= 0 ||
-			RI.currententity->curstate.renderamt > ENGINE_GET_PARM( PARM_MAX_CLIENTS ) )
+			RI.currententity->curstate.renderamt > gp_cl->maxclients )
 			return 0;
 
 		// get copy of player

--- a/ref/gl/gl_warp.c
+++ b/ref/gl/gl_warp.c
@@ -526,7 +526,7 @@ static void R_CloudTexCoord( vec3_t v, float speed, float *s, float *t )
 	float	length, speedscale;
 	vec3_t	dir;
 
-	speedscale = gpGlobals->time * speed;
+	speedscale = gp_cl->time * speed;
 	speedscale -= (int)speedscale & ~127;
 
 	VectorSubtract( v, RI.vieworg, dir );
@@ -813,8 +813,8 @@ void EmitWaterPolys( msurface_t *warp, qboolean reverse )
 		{
 			if( waveHeight )
 			{
-				nv = r_turbsin[(int)(gpGlobals->time * 160.0f + v[1] + v[0]) & 255] + 8.0f;
-				nv = (r_turbsin[(int)(v[0] * 5.0f + gpGlobals->time * 171.0f - v[1]) & 255] + 8.0f ) * 0.8f + nv;
+				nv = r_turbsin[(int)(gp_cl->time * 160.0f + v[1] + v[0]) & 255] + 8.0f;
+				nv = (r_turbsin[(int)(v[0] * 5.0f + gp_cl->time * 171.0f - v[1]) & 255] + 8.0f ) * 0.8f + nv;
 				nv = nv * waveHeight + v[2];
 			}
 			else nv = v[2];
@@ -824,8 +824,8 @@ void EmitWaterPolys( msurface_t *warp, qboolean reverse )
 
 			if( !r_ripple.value )
 			{
-				s = os + r_turbsin[(int)((ot * 0.125f + gpGlobals->time) * TURBSCALE) & 255];
-				t = ot + r_turbsin[(int)((os * 0.125f + gpGlobals->time) * TURBSCALE) & 255];
+				s = os + r_turbsin[(int)((ot * 0.125f + gp_cl->time) * TURBSCALE) & 255];
+				t = ot + r_turbsin[(int)((os * 0.125f + gp_cl->time) * TURBSCALE) & 255];
 			}
 			else
 			{
@@ -865,7 +865,7 @@ void R_ResetRipples( void )
 {
 	g_ripple.curbuf = g_ripple.buf[0];
 	g_ripple.oldbuf = g_ripple.buf[1];
-	g_ripple.time = g_ripple.oldtime = gpGlobals->time - 0.1;
+	g_ripple.time = g_ripple.oldtime = gp_cl->time - 0.1;
 	memset( g_ripple.buf, 0, sizeof( g_ripple.buf ));
 }
 
@@ -936,14 +936,14 @@ static int MostSignificantBit( unsigned int v )
 
 void R_AnimateRipples( void )
 {
-	double frametime = gpGlobals->time - g_ripple.time;
+	double frametime = gp_cl->time - g_ripple.time;
 
 	g_ripple.update = r_ripple.value && frametime >= r_ripple_updatetime.value;
 
 	if( !g_ripple.update )
 		return;
 
-	g_ripple.time = gpGlobals->time;
+	g_ripple.time = gp_cl->time;
 
 	R_SwapBufs();
 

--- a/ref/soft/r_beams.c
+++ b/ref/soft/r_beams.c
@@ -881,11 +881,7 @@ static qboolean R_BeamComputePoint( int beamEnt, vec3_t pt )
 	if( attach > 0 )
 		VectorCopy( ent->attachment[attach - 1], pt );
 	else if( ent->index == ( gp_cl->playernum + 1 ))
-	{
-		vec3_t simorg;
-		gEngfuncs.GetPredictedOrigin( simorg );
-		VectorCopy( simorg, pt );
-	}
+		VectorCopy( gp_cl->simorg, pt );
 	else VectorCopy( ent->origin, pt );
 
 	return true;

--- a/ref/soft/r_beams.c
+++ b/ref/soft/r_beams.c
@@ -880,7 +880,7 @@ static qboolean R_BeamComputePoint( int beamEnt, vec3_t pt )
 	// get attachment
 	if( attach > 0 )
 		VectorCopy( ent->attachment[attach - 1], pt );
-	else if( ent->index == ENGINE_GET_PARM( PARM_PLAYER_INDEX ) )
+	else if( ent->index == ( gp_cl->playernum + 1 ))
 	{
 		vec3_t simorg;
 		gEngfuncs.GetPredictedOrigin( simorg );

--- a/ref/soft/r_beams.c
+++ b/ref/soft/r_beams.c
@@ -611,7 +611,7 @@ void R_DrawBeamFollow( BEAM *pbeam, float frametime )
 	if( pnew )
 	{
 		VectorCopy( pbeam->source, pnew->org );
-		pnew->die = gpGlobals->time + pbeam->amplitude;
+		pnew->die = gp_cl->time + pbeam->amplitude;
 		VectorClear( pnew->vel );
 
 		pnew->next = particles;
@@ -658,7 +658,7 @@ void R_DrawBeamFollow( BEAM *pbeam, float frametime )
 	VectorMA( delta, -pbeam->width, normal, last2 );
 
 	div = 1.0f / pbeam->amplitude;
-	fraction = ( pbeam->die - gpGlobals->time ) * div;
+	fraction = ( pbeam->die - gp_cl->time ) * div;
 
 	vLast = 0.0f;
 	vStep = 1.0f;
@@ -694,7 +694,7 @@ void R_DrawBeamFollow( BEAM *pbeam, float frametime )
 
 		if( particles->next != NULL )
 		{
-			fraction = (particles->die - gpGlobals->time) * div;
+			fraction = (particles->die - gp_cl->time) * div;
 		}
 		else
 		{
@@ -929,7 +929,7 @@ qboolean R_BeamRecomputeEndpoints( BEAM *pbeam )
 		else if( !FBitSet( pbeam->flags, FBEAM_FOREVER ))
 		{
 			ClearBits( pbeam->flags, FBEAM_ENDENTITY );
-			pbeam->die = gpGlobals->time;
+			pbeam->die = gp_cl->time;
 			return false;
 		}
 		else
@@ -962,7 +962,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 	if( !model || model->type != mod_sprite )
 	{
 		pbeam->flags &= ~FBEAM_ISACTIVE; // force to ignore
-		pbeam->die = gpGlobals->time;
+		pbeam->die = gp_cl->time;
 		return;
 	}
 
@@ -1020,7 +1020,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 	if( pbeam->flags & ( FBEAM_FADEIN|FBEAM_FADEOUT ))
 	{
 		// update life cycle
-		pbeam->t = pbeam->freq + ( pbeam->die - gpGlobals->time );
+		pbeam->t = pbeam->freq + ( pbeam->die - gp_cl->time );
 		if( pbeam->t != 0.0f ) pbeam->t = 1.0f - pbeam->freq / pbeam->t;
 	}
 
@@ -1068,7 +1068,7 @@ void R_BeamDraw( BEAM *pbeam, float frametime )
 
 	TriRenderMode( FBitSet( pbeam->flags, FBEAM_SOLID ) ? kRenderNormal : kRenderTransAdd );
 
-	if( !TriSpriteTexture( model, (int)(pbeam->frame + pbeam->frameRate * gpGlobals->time) % pbeam->frameCount ))
+	if( !TriSpriteTexture( model, (int)(pbeam->frame + pbeam->frameRate * gp_cl->time) % pbeam->frameCount ))
 	{
 		ClearBits( pbeam->flags, FBEAM_ISACTIVE );
 		return;
@@ -1173,8 +1173,8 @@ static void R_BeamSetup( BEAM *pbeam, vec3_t start, vec3_t end, int modelIndex, 
 	VectorCopy( end, pbeam->target );
 	VectorSubtract( end, start, pbeam->delta );
 
-	pbeam->freq = speed * gpGlobals->time;
-	pbeam->die = life + gpGlobals->time;
+	pbeam->freq = speed * gp_cl->time;
+	pbeam->die = life + gp_cl->time;
 	pbeam->amplitude = amplitude;
 	pbeam->brightness = brightness;
 	pbeam->width = width;
@@ -1304,7 +1304,7 @@ void GAME_EXPORT CL_DrawBeams( int fTrans, BEAM *active_beams )
 		if( !fTrans && !FBitSet( pBeam->flags, FBEAM_SOLID ))
 			continue;
 
-		R_BeamDraw( pBeam, gpGlobals->time -   gpGlobals->oldtime );
+		R_BeamDraw( pBeam, gp_cl->time -   gp_cl->oldtime );
 	}
 
 	//pglShadeModel( GL_FLAT );

--- a/ref/soft/r_bsp.c
+++ b/ref/soft/r_bsp.c
@@ -950,7 +950,7 @@ void R_RenderWorld (void)
 
 	// auto cycle the world frame for texture animation
 	RI.currententity = CL_GetEntityByIndex(0);
-	//RI.currententity->frame = (int)(gpGlobals->time*2);
+	//RI.currententity->frame = (int)(gp_cl->time*2);
 
 	VectorCopy (RI.vieworg, tr.modelorg);
 	RI.currentmodel = WORLDMODEL;

--- a/ref/soft/r_context.c
+++ b/ref/soft/r_context.c
@@ -17,6 +17,8 @@ GNU General Public License for more details.
 
 ref_api_t      gEngfuncs;
 ref_globals_t *gpGlobals;
+ref_client_t  *gp_cl;
+ref_host_t    *gp_host;
 gl_globals_t tr;
 ref_speeds_t r_stats;
 poolhandle_t r_temppool;
@@ -563,6 +565,9 @@ int EXPORT GAME_EXPORT GetRefAPI( int version, ref_interface_t *funcs, ref_api_t
 	memcpy( funcs, &gReffuncs, sizeof( ref_interface_t ));
 	memcpy( &gEngfuncs, engfuncs, sizeof( ref_api_t ));
 	gpGlobals = globals;
+
+	gp_cl = (ref_client_t *)ENGINE_GET_PARM( PARM_GET_CLIENT_PTR );
+	gp_host = (ref_host_t *)ENGINE_GET_PARM( PARM_GET_HOST_PTR );
 
 	return REF_API_VERSION;
 }

--- a/ref/soft/r_edge.c
+++ b/ref/soft/r_edge.c
@@ -864,9 +864,9 @@ void D_CalcGradients (msurface_t *pface)
 	{
 
 		if(pface->flags & SURF_DRAWTURB)
-			sadjust += 0x10000 * (-128 * ( (gpGlobals->time * 0.25f) - (int)(gpGlobals->time * 0.25f) ));
+			sadjust += 0x10000 * (-128 * ( (gp_cl->time * 0.25f) - (int)(gp_cl->time * 0.25f) ));
 		else
-			sadjust += 0x10000 * (-128 * ( (gpGlobals->time * 0.77f) - (int)(gpGlobals->time * 0.77f) ));
+			sadjust += 0x10000 * (-128 * ( (gp_cl->time * 0.77f) - (int)(gp_cl->time * 0.77f) ));
 		bbextents = ((pface->extents[0] << 16) >> miplevel) - 1;
 	}
 	else

--- a/ref/soft/r_light.c
+++ b/ref/soft/r_light.c
@@ -39,7 +39,7 @@ void GAME_EXPORT CL_RunLightStyles( void )
 {
 	int		i, k, flight, clight;
 	float		l, lerpfrac, backlerp;
-	float		frametime = (gpGlobals->time -   gpGlobals->oldtime);
+	float		frametime = (gp_cl->time -   gp_cl->oldtime);
 	float		scale;
 	lightstyle_t	*ls;
 
@@ -163,7 +163,7 @@ void R_PushDlights( void )
 	{
 		l = gEngfuncs.GetDynamicLight( i );
 
-		if( l->die < gpGlobals->time || !l->radius )
+		if( l->die < gp_cl->time || !l->radius )
 			continue;
 
 		//if( GL_FrustumCullSphere( &RI.frustum, l->origin, l->radius, 15 ))

--- a/ref/soft/r_local.h
+++ b/ref/soft/r_local.h
@@ -297,7 +297,6 @@ typedef struct
 	// get from engine
 	cl_entity_t *entities;
 	movevars_t *movevars;
-	model_t **models;
 	color24 *palette;
 	cl_entity_t *viewent;
 
@@ -676,6 +675,13 @@ void TriBrightness( float brightness );
 #define ENGINE_GET_PARM_ (*gEngfuncs.EngineGetParm)
 #define ENGINE_GET_PARM( parm ) ENGINE_GET_PARM_( (parm), 0 )
 
+extern ref_api_t      gEngfuncs;
+extern ref_globals_t *gpGlobals;
+extern ref_client_t  *gp_cl;
+extern ref_host_t    *gp_host;
+
+DECLARE_ENGINE_SHARED_CVAR_LIST()
+
 //
 // helper funcs
 //
@@ -686,15 +692,10 @@ static inline cl_entity_t *CL_GetEntityByIndex( int index )
 
 static inline model_t *CL_ModelHandle( int index )
 {
-	return tr.models[index];
+	return gp_cl->models[index];
 }
 
-#define WORLDMODEL (tr.models[1])
-
-extern ref_api_t      gEngfuncs;
-extern ref_globals_t *gpGlobals;
-
-DECLARE_ENGINE_SHARED_CVAR_LIST()
+#define WORLDMODEL (gp_cl->models[1])
 
 // todo: gl_cull.c
 #define R_CullModel(...) 0

--- a/ref/soft/r_local.h
+++ b/ref/soft/r_local.h
@@ -78,10 +78,10 @@ extern poolhandle_t r_temppool;
 #define RP_NONVIEWERREF	(RP_ENVVIEW)
 #define R_ModelOpaque( rm )	( rm == kRenderNormal )
 #define R_StaticEntity( ent )	( VectorIsNull( ent->origin ) && VectorIsNull( ent->angles ))
-#define RP_LOCALCLIENT( e )	((e) != NULL && (e)->index == gEngfuncs.GetPlayerIndex() && e->player )
+#define RP_LOCALCLIENT( e )	((e) != NULL && (e)->index == ( gp_cl->playernum + 1 ) && e->player )
 #define RP_NORMALPASS()	( FBitSet( RI.params, RP_NONVIEWERREF ) == 0 )
 
-#define CL_IsViewEntityLocalPlayer() ( ENGINE_GET_PARM( PARM_VIEWENT_INDEX ) == ENGINE_GET_PARM( PARM_PLAYER_INDEX ) )
+#define CL_IsViewEntityLocalPlayer() ( gp_cl->viewentity == ( gp_cl->playernum + 1 ))
 
 #define CULL_VISIBLE	0		// not culled
 #define CULL_BACKSIDE	1		// backside of transparent wall

--- a/ref/soft/r_main.c
+++ b/ref/soft/r_main.c
@@ -1939,10 +1939,9 @@ qboolean GAME_EXPORT R_Init( void )
 	}
 
 	// see R_ProcessEntData for tr.entities initialization
-	tr.models = gEngfuncs.pfnGetModels();
-	tr.movevars = gEngfuncs.pfnGetMoveVars();
-	tr.palette = gEngfuncs.CL_GetPaletteColor();
-	tr.viewent = gEngfuncs.GetViewModel();
+	tr.movevars = (movevars_t *)ENGINE_GET_PARM( PARM_GET_MOVEVARS_PTR );
+	tr.palette = (color24 *)ENGINE_GET_PARM( PARM_GET_PALETTE_PTR );
+	tr.viewent = (cl_entity_t *)ENGINE_GET_PARM( PARM_GET_VIEWENT_PTR );
 
 	R_InitBlit( glblit );
 

--- a/ref/soft/r_main.c
+++ b/ref/soft/r_main.c
@@ -441,8 +441,8 @@ void R_SetupFrustum( void )
 
 	/*if( RP_NORMALPASS() && ( ENGINE_GET_PARM( PARM_WATER_LEVEL ) >= 3 ) && ENGINE_GET_PARM( PARM_QUAKE_COMPATIBLE ))
 	{
-		RI.fov_x = atan( tan( DEG2RAD( RI.fov_x ) / 2 ) * ( 0.97 + sin( gpGlobals->time * 1.5 ) * 0.03 )) * 2 / (M_PI / 180.0);
-		RI.fov_y = atan( tan( DEG2RAD( RI.fov_y ) / 2 ) * ( 1.03 - sin( gpGlobals->time * 1.5 ) * 0.03 )) * 2 / (M_PI / 180.0);
+		RI.fov_x = atan( tan( DEG2RAD( RI.fov_x ) / 2 ) * ( 0.97 + sin( gp_cl->time * 1.5 ) * 0.03 )) * 2 / (M_PI / 180.0);
+		RI.fov_y = atan( tan( DEG2RAD( RI.fov_y ) / 2 ) * ( 1.03 - sin( gp_cl->time * 1.5 ) * 0.03 )) * 2 / (M_PI / 180.0);
 	}*/
 
 	// build the transformation matrix for the given view angles
@@ -1171,7 +1171,7 @@ void R_DrawBEntitiesOnList (void)
 			dlight_t *l = gEngfuncs.GetDynamicLight( k );
 			vec3_t origin_l, oldorigin;
 
-			if( l->die < gpGlobals->time || !l->radius )
+			if( l->die < gp_cl->time || !l->radius )
 				continue;
 
 			VectorCopy( l->origin, oldorigin ); // save lightorigin
@@ -1326,7 +1326,7 @@ void R_DrawBrushModel(cl_entity_t *pent)
 			dlight_t *l = gEngfuncs.GetDynamicLight( k );
 			vec3_t origin_l, oldorigin;
 
-			if( l->die < gpGlobals->time || !l->radius )
+			if( l->die < gp_cl->time || !l->radius )
 				continue;
 
 			VectorCopy( l->origin, oldorigin ); // save lightorigin
@@ -1561,7 +1561,7 @@ void GAME_EXPORT R_RenderScene( void )
 
 	// frametime is valid only for normal pass
 	if( RP_NORMALPASS( ))
-		tr.frametime = gpGlobals->time -   gpGlobals->oldtime;
+		tr.frametime = gp_cl->time -   gp_cl->oldtime;
 	else tr.frametime = 0.0;
 
 	// begin a new frame
@@ -1984,16 +1984,16 @@ int CL_FxBlend( cl_entity_t *e )
 	switch( e->curstate.renderfx )
 	{
 	case kRenderFxPulseSlowWide:
-		blend = e->curstate.renderamt + 0x40 * sin( gpGlobals->time * 2 + offset );
+		blend = e->curstate.renderamt + 0x40 * sin( gp_cl->time * 2 + offset );
 		break;
 	case kRenderFxPulseFastWide:
-		blend = e->curstate.renderamt + 0x40 * sin( gpGlobals->time * 8 + offset );
+		blend = e->curstate.renderamt + 0x40 * sin( gp_cl->time * 8 + offset );
 		break;
 	case kRenderFxPulseSlow:
-		blend = e->curstate.renderamt + 0x10 * sin( gpGlobals->time * 2 + offset );
+		blend = e->curstate.renderamt + 0x10 * sin( gp_cl->time * 2 + offset );
 		break;
 	case kRenderFxPulseFast:
-		blend = e->curstate.renderamt + 0x10 * sin( gpGlobals->time * 8 + offset );
+		blend = e->curstate.renderamt + 0x10 * sin( gp_cl->time * 8 + offset );
 		break;
 	case kRenderFxFadeSlow:
 		if( RP_NORMALPASS( ))
@@ -2032,27 +2032,27 @@ int CL_FxBlend( cl_entity_t *e )
 		blend = e->curstate.renderamt;
 		break;
 	case kRenderFxStrobeSlow:
-		blend = 20 * sin( gpGlobals->time * 4 + offset );
+		blend = 20 * sin( gp_cl->time * 4 + offset );
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxStrobeFast:
-		blend = 20 * sin( gpGlobals->time * 16 + offset );
+		blend = 20 * sin( gp_cl->time * 16 + offset );
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxStrobeFaster:
-		blend = 20 * sin( gpGlobals->time * 36 + offset );
+		blend = 20 * sin( gp_cl->time * 36 + offset );
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxFlickerSlow:
-		blend = 20 * (sin( gpGlobals->time * 2 ) + sin( gpGlobals->time * 17 + offset ));
+		blend = 20 * (sin( gp_cl->time * 2 ) + sin( gp_cl->time * 17 + offset ));
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;
 	case kRenderFxFlickerFast:
-		blend = 20 * (sin( gpGlobals->time * 16 ) + sin( gpGlobals->time * 23 + offset ));
+		blend = 20 * (sin( gp_cl->time * 16 ) + sin( gp_cl->time * 23 + offset ));
 		if( blend < 0 ) blend = 0;
 		else blend = e->curstate.renderamt;
 		break;

--- a/ref/soft/r_part.c
+++ b/ref/soft/r_part.c
@@ -86,7 +86,7 @@ void GAME_EXPORT CL_DrawParticles( double frametime, particle_t *cl_active_parti
 			p->color = bound( 0, p->color, 255 );
 			color = tr.palette[p->color];
 
-			alpha = 255 * (p->die - gpGlobals->time) * 16.0f;
+			alpha = 255 * (p->die - gp_cl->time) * 16.0f;
 			if( alpha > 255 || p->type == pt_static )
 				alpha = 255;
 
@@ -200,7 +200,7 @@ void GAME_EXPORT CL_DrawTracers( double frametime, particle_t *cl_active_tracers
 
 	for( p = cl_active_tracers; p; p = p->next )
 	{
-		atten = (p->die - gpGlobals->time);
+		atten = (p->die - gp_cl->time);
 		if( atten > 0.1f ) atten = 0.1f;
 
 		VectorScale( p->vel, ( p->ramp * atten ), delta );
@@ -268,7 +268,7 @@ void GAME_EXPORT CL_DrawTracers( double frametime, particle_t *cl_active_tracers
 			p->vel[1] *= scale;
 			p->vel[2] -= gravity;
 
-			p->packedColor = 255 * (p->die - gpGlobals->time) * 2;
+			p->packedColor = 255 * (p->die - gp_cl->time) * 2;
 			if( p->packedColor > 255 ) p->packedColor = 255;
 		}
 		else if( p->type == pt_slowgrav )

--- a/ref/soft/r_scan.c
+++ b/ref/soft/r_scan.c
@@ -100,7 +100,7 @@ void Turbulent8 (espan_t *pspan)
 	float			sdivz, tdivz, zi, z, du, dv, spancountminus1;
 	float			sdivz16stepu, tdivz16stepu, zi16stepu;
 
-	r_turb_turb = sintable + ((int)(gpGlobals->time*SPEED)&(CYCLE-1));
+	r_turb_turb = sintable + ((int)(gp_cl->time*SPEED)&(CYCLE-1));
 
 	r_turb_sstep = 0;	// keep compiler happy
 	r_turb_tstep = 0;	// ditto
@@ -239,7 +239,7 @@ void TurbulentZ8 (espan_t *pspan, int alpha1)
 	if( alpha == 0 )
 		return;
 
-	r_turb_turb = sintable + ((int)(gpGlobals->time*SPEED)&(CYCLE-1));
+	r_turb_turb = sintable + ((int)(gp_cl->time*SPEED)&(CYCLE-1));
 
 	r_turb_sstep = 0;	// keep compiler happy
 	r_turb_tstep = 0;	// ditto

--- a/ref/soft/r_sprite.c
+++ b/ref/soft/r_sprite.c
@@ -430,7 +430,7 @@ mspriteframe_t *R_GetSpriteFrame( const model_t *pModel, int frame, float yaw )
 
 		// when loading in Mod_LoadSpriteGroup, we guaranteed all interval values
 		// are positive, so we don't have to worry about division by zero
-		targettime = gpGlobals->time - ((int)( gpGlobals->time / fullinterval )) * fullinterval;
+		targettime = gp_cl->time - ((int)( gp_cl->time / fullinterval )) * fullinterval;
 
 		for( i = 0; i < (numframes - 1); i++ )
 		{
@@ -494,25 +494,25 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 				// this can be happens when rendering switched between single and angled frames
 				// or change model on replace delta-entity
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 1.0f;
 			}
 
-			if( ent->latched.sequencetime < gpGlobals->time )
+			if( ent->latched.sequencetime < gp_cl->time )
 			{
 				if( frame != ent->latched.prevblending[1] )
 				{
 					ent->latched.prevblending[0] = ent->latched.prevblending[1];
 					ent->latched.prevblending[1] = frame;
-					ent->latched.sequencetime = gpGlobals->time;
+					ent->latched.sequencetime = gp_cl->time;
 					lerpFrac = 0.0f;
 				}
-				else lerpFrac = (gpGlobals->time - ent->latched.sequencetime) * 11.0f;
+				else lerpFrac = (gp_cl->time - ent->latched.sequencetime) * 11.0f;
 			}
 			else
 			{
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 0.0f;
 			}
 		}
@@ -526,7 +526,7 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 		{
 			// reset interpolation on change model
 			ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-			ent->latched.sequencetime = gpGlobals->time;
+			ent->latched.sequencetime = gp_cl->time;
 			lerpFrac = 0.0f;
 		}
 
@@ -541,7 +541,7 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 		numframes = pspritegroup->numframes;
 		fullinterval = pintervals[numframes-1];
 		jinterval = pintervals[1] - pintervals[0];
-		time = gpGlobals->time;
+		time = gp_cl->time;
 		jtime = 0.0f;
 
 		// when loading in Mod_LoadSpriteGroup, we guaranteed all interval values
@@ -580,25 +580,25 @@ float R_GetSpriteFrameInterpolant( cl_entity_t *ent, mspriteframe_t **oldframe, 
 				// this can be happens when rendering switched between single and angled frames
 				// or change model on replace delta-entity
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 1.0f;
 			}
 
-			if( ent->latched.sequencetime < gpGlobals->time )
+			if( ent->latched.sequencetime < gp_cl->time )
 			{
 				if( frame != ent->latched.prevblending[1] )
 				{
 					ent->latched.prevblending[0] = ent->latched.prevblending[1];
 					ent->latched.prevblending[1] = frame;
-					ent->latched.sequencetime = gpGlobals->time;
+					ent->latched.sequencetime = gp_cl->time;
 					lerpFrac = 0.0f;
 				}
-				else lerpFrac = (gpGlobals->time - ent->latched.sequencetime) * ent->curstate.framerate;
+				else lerpFrac = (gp_cl->time - ent->latched.sequencetime) * ent->curstate.framerate;
 			}
 			else
 			{
 				ent->latched.prevblending[0] = ent->latched.prevblending[1] = frame;
-				ent->latched.sequencetime = gpGlobals->time;
+				ent->latched.sequencetime = gp_cl->time;
 				lerpFrac = 0.0f;
 			}
 		}

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -163,8 +163,8 @@ static void R_StudioSetupTimings( void )
 	if( RI.drawWorld )
 	{
 		// synchronize with server time
-		g_studio.time = gpGlobals->time;
-		g_studio.frametime = gpGlobals->time -   gpGlobals->oldtime;
+		g_studio.time = gp_cl->time;
+		g_studio.frametime = gp_cl->time -   gp_cl->oldtime;
 	}
 	else
 	{
@@ -413,8 +413,8 @@ pfnGetEngineTimes
 static void pfnGetEngineTimes( int *framecount, double *current, double *old )
 {
 	if( framecount ) *framecount = tr.realframecount;
-	if( current ) *current = gpGlobals->time;
-	if( old ) *old =   gpGlobals->oldtime;
+	if( current ) *current = gp_cl->time;
+	if( old ) *old =   gp_cl->oldtime;
 }
 
 /*
@@ -2516,7 +2516,7 @@ static void R_StudioClientEvents( void )
 
 		ClearBits( e->curstate.effects, EF_MUZZLEFLASH );
 		VectorCopy( e->attachment[0], el->origin );
-		el->die = gpGlobals->time + 0.05f;
+		el->die = gp_cl->time + 0.05f;
 		el->color.r = 255;
 		el->color.g = 192;
 		el->color.b = 64;

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -169,8 +169,8 @@ static void R_StudioSetupTimings( void )
 	else
 	{
 		// menu stuff
-		g_studio.time = gpGlobals->realtime;
-		g_studio.frametime = gpGlobals->frametime;
+		g_studio.time = gp_host->realtime;
+		g_studio.frametime = gp_host->frametime;
 	}
 }
 
@@ -2532,7 +2532,7 @@ static void R_StudioClientEvents( void )
 		return;
 
 	end = R_StudioEstimateFrame( e, pseqdesc, g_studio.time );
-	start = end - e->curstate.framerate * gpGlobals->frametime * pseqdesc->fps;
+	start = end - e->curstate.framerate * gp_host->frametime * pseqdesc->fps;
 	pevent = (mstudioevent_t *)((byte *)m_pStudioHeader + pseqdesc->eventindex);
 
 	if( e->latched.sequencetime == e->curstate.animtime )

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -3373,7 +3373,7 @@ void R_RunViewmodelEvents( void )
 
 	R_StudioSetupTimings();
 
-	gEngfuncs.GetPredictedOrigin( simorg );
+	VectorCopy( gp_cl->simorg, simorg );
 	for( i = 0; i < 4; i++ )
 		VectorCopy( simorg, RI.currententity->attachment[i] );
 	RI.currentmodel = RI.currententity->model;

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -1320,7 +1320,7 @@ R_StudioDynamicLight
 */
 void R_StudioDynamicLight( cl_entity_t *ent, alight_t *plight )
 {
-	movevars_t	*mv = gEngfuncs.pfnGetMoveVars();
+	movevars_t	*mv = tr.movevars;
 	vec3_t		lightDir, vecSrc, vecEnd;
 	vec3_t		origin, dist, finalLight;
 	float		add, radius, total;

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -3063,7 +3063,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 
 	m_nPlayerIndex = pplayer->number - 1;
 
-	if( m_nPlayerIndex < 0 || m_nPlayerIndex >= ENGINE_GET_PARM( PARM_MAX_CLIENTS ) )
+	if( m_nPlayerIndex < 0 || m_nPlayerIndex >= gp_cl->maxclients )
 		return 0;
 
 	RI.currentmodel = R_StudioSetupPlayerModel( m_nPlayerIndex );
@@ -3145,7 +3145,7 @@ static int R_StudioDrawPlayer( int flags, entity_state_t *pplayer )
 			RI.currententity->curstate.body = 255;
 		}
 
-		if( !( !gpGlobals->developer && ENGINE_GET_PARM( PARM_MAX_CLIENTS ) == 1 ) && ( RI.currentmodel == RI.currententity->model ))
+		if( !( !gpGlobals->developer && gp_cl->maxclients == 1 ) && ( RI.currentmodel == RI.currententity->model ))
 			RI.currententity->curstate.body = 1; // force helmet
 
 		lighting.plightvec = dir;
@@ -3208,7 +3208,7 @@ static int R_StudioDrawModel( int flags )
 		int		result;
 
 		if( RI.currententity->curstate.renderamt <= 0 ||
-			RI.currententity->curstate.renderamt > ENGINE_GET_PARM( PARM_MAX_CLIENTS ) )
+			RI.currententity->curstate.renderamt > gp_cl->maxclients )
 			return 0;
 
 		// get copy of player

--- a/ref/soft/r_surf.c
+++ b/ref/soft/r_surf.c
@@ -401,7 +401,7 @@ texture_t *R_TextureAnim( texture_t *b )
 			speed = 10;
 		else speed = 20;
 
-		reletive = (int)(gpGlobals->time * speed) % base->anim_total;
+		reletive = (int)(gp_cl->time * speed) % base->anim_total;
 	}
 
 
@@ -455,7 +455,7 @@ texture_t *R_TextureAnimation( msurface_t *s )
 			speed = 10;
 		else speed = 20;
 
-		reletive = (int)(gpGlobals->time * speed) % base->anim_total;
+		reletive = (int)(gp_cl->time * speed) % base->anim_total;
 	}
 
 	count = 0;


### PR DESCRIPTION
Discussion on SourceHut: https://lists.sr.ht/~a1batross/xash3d-fwgs/patches/48142

This set of patches fixes the earliest bug since renderers split: timings.

It eliminates the need to synchronize renderers timings by passing a pointer from engine to renderer in a form of API structure. The structure in the API was designed to be compatible with internal engine structures that holds these values.

It also fixes another bug: truncated client time. For some reason it was in single-precision float all this time and nobody noticed.

Possible Questions:

Q: Why have structures when it's possible to pass separate pointers to double?

A: I had this in the non-published version of RefAPI 6 however turning `gpGlobals->time` into a pointer enables dereferencing it. The `->` operator does two things here: it will be always evaluated FIRST (as of C standard) and it already dereferences the pointer. I thought it's more aesthetically pleasant to work with a structure than a single variable pointer. The downside of this is a set of static assertions in the engine, however it's an engine problem to keep it compatible.

Q: Why not to rename everything in the engine to use these shared structures?

A: I considered this too but didn't want to go with this, as replacing every `cl.{time,oldtime}` and `host.{realtime,frametime}` into something else would probably not only touch hundreds of lines in renderers but thousands in the engine. Also calling client time `cl.time` just makes sense.

Changes since v1:
* As suggested by mittorn, we now use PARMs to get engine pointers.
* It also eliminates older functions that were introduced in RefAPI 5.
* ref_client_t and ref_host_t now expose more data to avoid excessive EngineGetParm calls. Though not everything was replaced, it's outside of the scope of this patch set and can be easily fixed later without breaking compatibility. 

Changes since v2:
* No changes. Sorry, I put wrong in-reply-to.
