### PR TITLE
IPv6 support for sv_downloadurl (sv_downloadurl_ipv6)

### DIFF
--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -2829,6 +2829,63 @@ static httpserver_t *HTTP_ParseURL( const char *url )
 	return server;
 }
 
+
+/*
+==================
+HTTP_ParseURL_IPv6
+==================
+*/
+static httpserver_t *HTTP_ParseURL_IPv6( const char *url )
+{
+	httpserver_t *server;
+	int i;
+
+	url = Q_strstr( url, "http://[" );
+
+	if( !url )
+		return NULL;
+
+	url += 8;
+	server = Z_Calloc( sizeof( httpserver_t ));
+	i = 0;
+
+	while( *url && ( *url != ']' ) && ( *url != '/' ) && ( *url != '\r' ) && ( *url != '\n' ))
+	{
+		if( i > sizeof( server->host ))
+			return NULL;
+
+		server->host[i++] = *url++;
+	}
+
+	server->host[i] = 0;
+
+	if( *url == ':' )
+	{
+		server->port = Q_atoi( ++url );
+
+		while( *url && ( *url != '/' ) && ( *url != '\r' ) && ( *url != '\n' ))
+			url++;
+	}
+	else
+		server->port = 80;
+
+	i = 0;
+
+	while( *url && ( *url != '\r' ) && ( *url != '\n' ))
+	{
+		if( i > sizeof( server->path ))
+			return NULL;
+
+		server->path[i++] = *url++;
+	}
+
+	server->path[i] = 0;
+	server->next = NULL;
+	server->needfree = false;
+
+	return server;
+}
+
 /*
 =======================
 HTTP_AddCustomServer
@@ -2836,6 +2893,8 @@ HTTP_AddCustomServer
 */
 void HTTP_AddCustomServer( const char *url )
 {
+	// todo condition
+	// httpserver_t *server = HTTP_ParseURL_IPv6( url );
 	httpserver_t *server = HTTP_ParseURL( url );
 
 	if( !server )
@@ -2996,6 +3055,8 @@ void HTTP_Init( void )
 	{
 		while(( line = COM_ParseFile( line, token, sizeof( token ))))
 		{
+			// todo condition
+			// httpserver_t *server = HTTP_ParseURL_IPv6( token );
 			httpserver_t *server = HTTP_ParseURL( token );
 
 			if( !server )

--- a/engine/server/server.h
+++ b/engine/server/server.h
@@ -414,6 +414,7 @@ extern convar_t		sv_maxupdaterate;
 extern convar_t		sv_minrate;
 extern convar_t		sv_maxrate;
 extern convar_t		sv_downloadurl;
+extern convar_t		sv_downloadurl_ipv6;
 extern convar_t		sv_newunit;
 extern convar_t		sv_clienttrace;
 extern convar_t		sv_failuretime;

--- a/engine/server/sv_custom.c
+++ b/engine/server/sv_custom.c
@@ -562,12 +562,14 @@ void SV_SendResources( sv_client_t *cl, sizebuf_t *msg )
 	MSG_WriteLong( msg, svs.spawncount );
 	MSG_WriteLong( msg, 0 );
 
-	if ( COM_CheckString( sv_downloadurl_ipv6.string ) && Q_strlen( sv_downloadurl_ipv6.string ) < 256 )
+	if ( cl->netchan.remote_address.type6 == NA_IP6 && // If remote is IPv6 - check for sv_downloadurl_ipv6 first #1559
+			 COM_CheckString( sv_downloadurl_ipv6.string ) && Q_strlen( sv_downloadurl_ipv6.string ) < 256 )
 	{
 		MSG_BeginServerCmd( msg, svc_resourcelocation );
 		MSG_WriteString( msg, sv_downloadurl_ipv6.string );
 	}
-	else if( COM_CheckString( sv_downloadurl.string ) && Q_strlen( sv_downloadurl.string ) < 256 )
+
+	else if ( COM_CheckString( sv_downloadurl.string ) && Q_strlen( sv_downloadurl.string ) < 256 )
 	{
 		MSG_BeginServerCmd( msg, svc_resourcelocation );
 		MSG_WriteString( msg, sv_downloadurl.string );

--- a/engine/server/sv_custom.c
+++ b/engine/server/sv_custom.c
@@ -562,7 +562,12 @@ void SV_SendResources( sv_client_t *cl, sizebuf_t *msg )
 	MSG_WriteLong( msg, svs.spawncount );
 	MSG_WriteLong( msg, 0 );
 
-	if( COM_CheckString( sv_downloadurl.string ) && Q_strlen( sv_downloadurl.string ) < 256 )
+	if ( COM_CheckString( sv_downloadurl_ipv6.string ) && Q_strlen( sv_downloadurl_ipv6.string ) < 256 )
+	{
+		MSG_BeginServerCmd( msg, svc_resourcelocation );
+		MSG_WriteString( msg, sv_downloadurl_ipv6.string );
+	}
+	else if( COM_CheckString( sv_downloadurl.string ) && Q_strlen( sv_downloadurl.string ) < 256 )
 	{
 		MSG_BeginServerCmd( msg, svc_resourcelocation );
 		MSG_WriteString( msg, sv_downloadurl.string );

--- a/engine/server/sv_main.c
+++ b/engine/server/sv_main.c
@@ -53,6 +53,7 @@ CVAR_DEFINE( sv_allow_download, "sv_allowdownload", "1", FCVAR_SERVER, "allow do
 static CVAR_DEFINE_AUTO( sv_allow_dlfile, "1", 0, "compatibility cvar, does nothing" );
 CVAR_DEFINE_AUTO( sv_uploadmax, "0.5", FCVAR_SERVER, "max size to upload custom resources (500 kB as default)" );
 CVAR_DEFINE_AUTO( sv_downloadurl, "", FCVAR_PROTECTED, "location from which clients can download missing files" );
+CVAR_DEFINE_AUTO( sv_downloadurl_ipv6, "", FCVAR_PROTECTED, "IPv6 location from which clients can download missing files (higher priority)" );
 CVAR_DEFINE( sv_consistency, "mp_consistency", "1", FCVAR_SERVER, "enbale consistency check in multiplayer" );
 CVAR_DEFINE_AUTO( mp_logecho, "1", 0, "log multiplayer frags to server logfile" );
 CVAR_DEFINE_AUTO( mp_logfile, "1", 0, "log multiplayer frags to console" );
@@ -934,6 +935,7 @@ void SV_Init( void )
 	Cvar_RegisterVariable( &sv_instancedbaseline );
 	Cvar_RegisterVariable( &sv_consistency );
 	Cvar_RegisterVariable( &sv_downloadurl );
+	Cvar_RegisterVariable( &sv_downloadurl_ipv6 );
 	Cvar_RegisterVariable( &sv_novis );
 	Cvar_RegisterVariable( &sv_hostmap );
 	Cvar_DirectSet( &sv_hostmap, GI->startmap );

--- a/engine/server/sv_main.c
+++ b/engine/server/sv_main.c
@@ -52,8 +52,8 @@ CVAR_DEFINE_AUTO( sv_allow_upload, "1", FCVAR_SERVER, "allow uploading custom re
 CVAR_DEFINE( sv_allow_download, "sv_allowdownload", "1", FCVAR_SERVER, "allow downloading custom resources to the client" );
 static CVAR_DEFINE_AUTO( sv_allow_dlfile, "1", 0, "compatibility cvar, does nothing" );
 CVAR_DEFINE_AUTO( sv_uploadmax, "0.5", FCVAR_SERVER, "max size to upload custom resources (500 kB as default)" );
-CVAR_DEFINE_AUTO( sv_downloadurl, "", FCVAR_PROTECTED, "location from which clients can download missing files" );
-CVAR_DEFINE_AUTO( sv_downloadurl_ipv6, "", FCVAR_PROTECTED, "IPv6 location from which clients can download missing files (higher priority)" );
+CVAR_DEFINE_AUTO( sv_downloadurl, "", FCVAR_PROTECTED, "IPv4 location from which clients can download missing files (applying for IPv4 connections" );
+CVAR_DEFINE_AUTO( sv_downloadurl_ipv6, "", FCVAR_PROTECTED, "IPv6 location from which clients can download missing files (applying for IPv6 connections)" );
 CVAR_DEFINE( sv_consistency, "mp_consistency", "1", FCVAR_SERVER, "enbale consistency check in multiplayer" );
 CVAR_DEFINE_AUTO( mp_logecho, "1", 0, "log multiplayer frags to server logfile" );
 CVAR_DEFINE_AUTO( mp_logfile, "1", 0, "log multiplayer frags to console" );


### PR DESCRIPTION
Solution compatible with previous protocol / clients as implements new option `sv_downloadurl_ipv6`

Details described in #1559

Client-side already tested - I can provide IPv6 links in `server.cfg` and download resources from there, but stuck on server-side part, as don't know how to check remote connection type and return `sv_downloadurl_ipv6` for IPv6 clients instead of `sv_downloadurl`

Here is the subject with example:
https://github.com/FWGS/xash3d-fwgs/issues/1559#issuecomment-1892163611