### PR TITLE
Soft-deprecate nanogl and gl-wes-v2

### DIFF
--- a/wscript
+++ b/wscript
@@ -196,8 +196,6 @@ def configure(conf):
 	# modify options dictionary early
 	if conf.env.DEST_OS == 'android':
 		conf.options.NO_VGUI          = True # skip vgui
-		conf.options.NANOGL           = True
-		conf.options.GLWES            = True
 		conf.options.GL4ES            = True
 		conf.options.GLES3COMPAT      = True
 		conf.options.GL               = False


### PR DESCRIPTION
The only platform using them is Android, therefore it's only single commit that removes it from build. I suggest fully migrating to gl2_shim and in worst case gl4es for this platform.

cc @mittorn 