### PR TITLE
fix incorrect mouse cursor position on high-dpi windows in SDL2 backend

### DIFF
--- a/engine/platform/sdl/in_sdl.c
+++ b/engine/platform/sdl/in_sdl.c
@@ -43,7 +43,18 @@ Platform_GetMousePos
 */
 void GAME_EXPORT Platform_GetMousePos( int *x, int *y )
 {
+    float factorX;
+    float factorY;
+    {
+        int w1, w2, h1, h2;
+        SDL_GL_GetDrawableSize( host.hWnd, &w1, &h1 );
+        SDL_GetWindowSize( host.hWnd, &w2, &h2 );
+        factorX = (float)w1 / w2;
+        factorY = (float)h1 / h2;
+    }
 	SDL_GetMouseState( x, y );
+    *x = *x * factorX;
+    *y = *y * factorY;
 }
 
 /*

--- a/engine/platform/sdl/vid_sdl.c
+++ b/engine/platform/sdl/vid_sdl.c
@@ -576,10 +576,8 @@ static qboolean VID_SetScreenResolution( int width, int height, window_mode_t wi
 	SDL_DisplayMode got;
 	Uint32 wndFlags = 0;
 
-#if !XASH_APPLE
 	if( vid_highdpi.value )
 		SetBits( wndFlags, SDL_WINDOW_ALLOW_HIGHDPI );
-#endif
 
 	SDL_SetWindowBordered( host.hWnd, SDL_FALSE );
 


### PR DESCRIPTION
When using SDL2 as the backend for input and video, the mouse cursor position is incorrect, leading to issues navigating menu ui or vguis with the mouse. This patch corrects the issue so the mouse cursor position matches the video output on high-dpi displays.