### PR TITLE
Connection bandwidth test fixes

### DIFF
--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -922,7 +922,7 @@ static void SV_GenerateTestPacket( void )
 	// testpacket already generated once, exit
 	// testpacket and lookup table takes ~300k of memory
 	// disable for low memory mode
-	if( svs.testpacket_buf || XASH_LOW_MEMORY >= 0 )
+	if( svs.testpacket_buf || XASH_LOW_MEMORY > 0 )
 		return;
 
 	// don't need in singleplayer with full client

--- a/engine/server/sv_init.c
+++ b/engine/server/sv_init.c
@@ -926,7 +926,7 @@ static void SV_GenerateTestPacket( void )
 		return;
 
 	// don't need in singleplayer with full client
-	if( svs.maxclients <= 1 && !Host_IsDedicated( ))
+	if( svs.maxclients <= 1 )
 		return;
 
 	file = FS_Open( "gfx.wad", "rb", false );


### PR DESCRIPTION
- Fixed bug when `svs.testpacket_buf` was not being created on server at all
- Reduced overall server connection time (test probe delay reduced to 1.0 seconds)
- Count of test probes changed to 5, probe sizes are 64000, 32000, 10666, 5200, 1400
- Allowed to use bandwidth test on listen servers (why it even was disabled?)
- Fixed reconnection attempts after bandwidth test (they wasn't working as intended - just sending `bandwidth` packets instead of `getchallenge`)