### PR TITLE
Minor logging improvements

### DIFF
--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -1187,6 +1187,11 @@ static void Host_InitCommon( int argc, char **argv, const char *progname, qboole
 		Con_Printf( "^3BUGCOMP^7: GoldSrc bug-compatibility enabled\n" );
 	}
 
+	// print current developer level to simplify processing users feedback
+	if( developer > 0 ) {
+		Con_Printf( "Developer level: ^3%i\n", developer );
+	}
+
 	Cmd_AddCommand( "exec", Host_Exec_f, "execute a script file" );
 	Cmd_AddCommand( "memlist", Host_MemStats_f, "prints memory pool information" );
 	Cmd_AddRestrictedCommand( "userconfigd", Host_Userconfigd_f, "execute all scripts from userconfig.d" );

--- a/engine/common/sys_con.c
+++ b/engine/common/sys_con.c
@@ -135,6 +135,8 @@ void Sys_InitLog( void )
 		mode = "a";
 	else mode = "w";
 
+	Q_strncpy( s_ld.title, "Xash3D FWGS", sizeof( s_ld.title ));
+
 	// create log if needed
 	if( s_ld.log_active )
 	{

--- a/engine/common/sys_con.c
+++ b/engine/common/sys_con.c
@@ -153,6 +153,7 @@ void Sys_InitLog( void )
 		fprintf( s_ld.logfile, "=================================================================================\n" );
 		fprintf( s_ld.logfile, "\t%s (build %i commit %s (%s-%s)) started at %s\n", s_ld.title, Q_buildnum(), Q_buildcommit(), Q_buildos(), Q_buildarch(), Q_timestamp( TIME_FULL ) );
 		fprintf( s_ld.logfile, "=================================================================================\n" );
+		fflush( s_ld.logfile );
 	}
 }
 

--- a/engine/common/sys_con.c
+++ b/engine/common/sys_con.c
@@ -150,9 +150,9 @@ void Sys_InitLog( void )
 
 		s_ld.logfileno = fileno( s_ld.logfile );
 
-		fprintf( s_ld.logfile, "=================================================================================\n" );
-		fprintf( s_ld.logfile, "\t%s (build %i commit %s (%s-%s)) started at %s\n", s_ld.title, Q_buildnum(), Q_buildcommit(), Q_buildos(), Q_buildarch(), Q_timestamp( TIME_FULL ) );
-		fprintf( s_ld.logfile, "=================================================================================\n" );
+		fprintf( s_ld.logfile, "==========================================================================================================\n" );
+		fprintf( s_ld.logfile, "\t%s (build %i / commit %s-%s / %s / %s) started at %s\n", s_ld.title, Q_buildnum(), Q_buildcommit(), Q_buildbranch(), Q_buildos(), Q_buildarch(), Q_timestamp( TIME_FULL ));
+		fprintf( s_ld.logfile, "==========================================================================================================\n" );
 		fflush( s_ld.logfile );
 	}
 }

--- a/public/build.c
+++ b/public/build.c
@@ -253,3 +253,16 @@ const char *Q_buildcommit( void )
 #endif
 }
 
+/*
+=============
+Q_buildbranch
+
+Returns current branch name in VCS as string. For now it's just a stub.
+P.S: I don't know how to implement it from waf side, so a1ba, please do it :)
+=============
+*/
+const char *Q_buildbranch( void )
+{
+	return "branch";
+}
+

--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -55,6 +55,7 @@ const char *Q_buildos( void );
 const char *Q_ArchitectureStringByID( const int arch, const uint abi, const int endianness, const qboolean is64 );
 const char *Q_buildarch( void );
 const char *Q_buildcommit( void );
+const char *Q_buildbranch( void );
 
 //
 // crtlib.c


### PR DESCRIPTION
Provides better experience processing users feedback about bugs. Earlier, we couldn't be able to know are user turned on `-dev` feature for more verbose logs or not. Also, we wasn't be able to know are user downloaded engine build from "master" branch rather than experimental one (that's common problem, on GitHub it's kinda confusing for normies)