### PR TITLE
Improvements for player custom sprays feature

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -39,6 +39,7 @@ CVAR_DEFINE_AUTO( cl_download_ingame, "1", FCVAR_ARCHIVE, "allow to downloading 
 CVAR_DEFINE_AUTO( cl_logofile, "lambda", FCVAR_ARCHIVE, "player logo name" );
 CVAR_DEFINE_AUTO( cl_logocolor, "orange", FCVAR_ARCHIVE, "player logo color" );
 CVAR_DEFINE_AUTO( cl_logoext, "bmp", FCVAR_ARCHIVE, "temporary cvar to tell engine which logo must be packed" );
+CVAR_DEFINE_AUTO( cl_logomaxdim, "328", FCVAR_ARCHIVE, "upper limit for player custom logos dimension, in units" );
 CVAR_DEFINE_AUTO( cl_test_bandwidth, "1", FCVAR_ARCHIVE, "test network bandwith before connection" );
 
 CVAR_DEFINE( cl_draw_particles, "r_drawparticles", "1", FCVAR_CHEAT, "render particles" );
@@ -2895,6 +2896,7 @@ static void CL_InitLocal( void )
 	Cvar_RegisterVariable( &cl_logofile );
 	Cvar_RegisterVariable( &cl_logocolor );
 	Cvar_RegisterVariable( &cl_logoext );
+	Cvar_RegisterVariable( &cl_logomaxdim );
 	Cvar_RegisterVariable( &cl_test_bandwidth );
 
 	Voice_RegisterCvars();

--- a/engine/common/hpak.c
+++ b/engine/common/hpak.c
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 
 #define HPAK_MAX_ENTRIES	0x8000
 #define HPAK_ENTRY_MIN_SIZE	(512)
-#define HPAK_ENTRY_MAX_SIZE	(128 * 1024)
+#define HPAK_ENTRY_MAX_SIZE	(512 * 1024)
 
 typedef struct hash_pack_queue_s
 {
@@ -29,7 +29,7 @@ typedef struct hash_pack_queue_s
 	struct hash_pack_queue_s	*next;
 } hash_pack_queue_t;
 
-static CVAR_DEFINE_AUTO( hpk_maxsize, "4", FCVAR_ARCHIVE, "set limit by size for all HPK-files ( 0 - unlimited )" );
+static CVAR_DEFINE_AUTO( hpk_maxsize, "4", FCVAR_ARCHIVE, "set limit by size in megabytes for all HPK-files ( 0 - unlimited )" );
 static hash_pack_queue_t	*gp_hpak_queue = NULL;
 static hpak_header_t	hash_pack_header;
 static hpak_info_t	hash_pack_info;

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -675,6 +675,7 @@ typedef int (*REFAPI)( int version, ref_interface_t *pFunctionTable, ref_api_t* 
 	ENGINE_SHARED_CVAR( f, gl_vsync ) \
 	ENGINE_SHARED_CVAR( f, gl_clear ) \
 	ENGINE_SHARED_CVAR( f, cl_himodels ) \
+	ENGINE_SHARED_CVAR( f, cl_logomaxdim ) \
 	ENGINE_SHARED_CVAR( f, cl_lightstyle_lerping ) \
 	ENGINE_SHARED_CVAR( f, tracerred ) \
 	ENGINE_SHARED_CVAR( f, tracergreen ) \

--- a/ref/gl/gl_decals.c
+++ b/ref/gl/gl_decals.c
@@ -811,15 +811,27 @@ void R_DecalShoot( int textureIndex, int entityIndex, int modelIndex, vec3_t pos
 	decalInfo.m_Flags = flags;
 
 	R_GetDecalDimensions( textureIndex, &width, &height );
-	decalInfo.m_Size = width >> 1;
-	if(( height >> 1 ) > decalInfo.m_Size )
-		decalInfo.m_Size = height >> 1;
-
-	decalInfo.m_scale = bound( MIN_DECAL_SCALE, scale, MAX_DECAL_SCALE );
 
 	// compute the decal dimensions in world space
-	decalInfo.m_decalWidth = width / decalInfo.m_scale;
-	decalInfo.m_decalHeight = height / decalInfo.m_scale;
+	if( FBitSet( flags, FDECAL_CUSTOM ))
+	{
+		const int upperLimit = cl_logomaxdim->value;
+		if( width > upperLimit || height > upperLimit )
+		{
+			float coeff = (float)Q_max( width, height ) / upperLimit;
+			decalInfo.m_Size = Q_max( width, height ) / 2 / coeff;
+			decalInfo.m_scale = coeff;
+			decalInfo.m_decalWidth = width / coeff;
+			decalInfo.m_decalHeight = height / coeff;
+		}
+	}
+	else
+	{
+		decalInfo.m_Size = Q_max( width, height ) / 2;
+		decalInfo.m_scale = bound( MIN_DECAL_SCALE, scale, MAX_DECAL_SCALE );
+		decalInfo.m_decalWidth = width / decalInfo.m_scale;
+		decalInfo.m_decalHeight = height / decalInfo.m_scale;
+	}
 
 	R_DecalNode( model, &model->nodes[hull->firstclipnode], &decalInfo );
 }

--- a/ref/soft/r_decals.c
+++ b/ref/soft/r_decals.c
@@ -835,15 +835,27 @@ void GAME_EXPORT R_DecalShoot( int textureIndex, int entityIndex, int modelIndex
 	decalInfo.m_Flags = flags;
 
 	R_GetDecalDimensions( textureIndex, &width, &height );
-	decalInfo.m_Size = width >> 1;
-	if(( height >> 1 ) > decalInfo.m_Size )
-		decalInfo.m_Size = height >> 1;
-
-	decalInfo.m_scale = bound( MIN_DECAL_SCALE, scale, MAX_DECAL_SCALE );
 
 	// compute the decal dimensions in world space
-	decalInfo.m_decalWidth = width / decalInfo.m_scale;
-	decalInfo.m_decalHeight = height / decalInfo.m_scale;
+	if( FBitSet( flags, FDECAL_CUSTOM ))
+	{
+		const int upperLimit = cl_logomaxdim->value;
+		if( width > upperLimit || height > upperLimit )
+		{
+			float coeff = (float)Q_max( width, height ) / upperLimit;
+			decalInfo.m_Size = Q_max( width, height ) / 2 / coeff;
+			decalInfo.m_scale = coeff;
+			decalInfo.m_decalWidth = width / coeff;
+			decalInfo.m_decalHeight = height / coeff;
+		}
+	}
+	else
+	{
+		decalInfo.m_Size = Q_max( width, height ) / 2;
+		decalInfo.m_scale = bound( MIN_DECAL_SCALE, scale, MAX_DECAL_SCALE );
+		decalInfo.m_decalWidth = width / decalInfo.m_scale;
+		decalInfo.m_decalHeight = height / decalInfo.m_scale;
+	}
 
 	R_DecalNode( model, &model->nodes[hull->firstclipnode], &decalInfo );
 }


### PR DESCRIPTION
By default, spray in-game dimensions are defined by relation `1 image pixel = 1 world unit`. But usually, we want to use high-resolution sprays without covering entire map with spray, and instead have some tolerable size. But also, we don't want to lose control for spray dimensions with image resolution. Therefore, solution that matches both criteria is controlling upper limit for spray in-game dimensions (because more advanced solutions like having option for each player to set scale for spray are not available, and it looks like more mod-specific stuff rather than something that should be inside engine). 
New console variable `cl_logomaxdim` are used for setting sprays size upper limit.

Also, maximum spray file size raised from 128 to 512 kilobytes. Why not.