### PR TITLE
Support building for Windows-on-ARM targets

### DIFF
--- a/engine/common/crashhandler.c
+++ b/engine/common/crashhandler.c
@@ -129,6 +129,22 @@ static void Sys_StackTrace( PEXCEPTION_POINTERS pInfo )
 	stackframe.AddrBStore.Mode = AddrModeFlat;
 	stackframe.AddrStack.Offset = context.IntSp;
 	stackframe.AddrStack.Mode = AddrModeFlat;
+#elif _M_ARM
+	image = IMAGE_FILE_MACHINE_ARMNT;
+	stackframe.AddrPC.Offset = context.Pc;
+	stackframe.AddrPC.Mode = AddrModeFlat;
+	stackframe.AddrFrame.Offset = context.R11;
+	stackframe.AddrFrame.Mode = AddrModeFlat;
+	stackframe.AddrStack.Offset = context.Sp;
+	stackframe.AddrStack.Mode = AddrModeFlat;
+#elif _M_ARM64
+	image = IMAGE_FILE_MACHINE_ARM64;
+	stackframe.AddrPC.Offset = context.Pc;
+	stackframe.AddrPC.Mode = AddrModeFlat;
+	stackframe.AddrFrame.Offset = context.Fp;
+	stackframe.AddrFrame.Mode = AddrModeFlat;
+	stackframe.AddrStack.Offset = context.Sp;
+	stackframe.AddrStack.Mode = AddrModeFlat;	
 #elif
 #error
 #endif


### PR DESCRIPTION
I had this lying around since 2021. Might as well upload this, considering that MS is pushing hard for Windows on ARM devices.

These are the minimum required changes to make the codebase build for both ARM32 and ARM64 targets on Windows. Tested to work on both ARM and ARM64 targets.

References:
- [Overview of ARM64 ABI conventions](https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions)
- [Overview of ARM32 ABI Conventions](https://learn.microsoft.com/en-us/cpp/build/overview-of-arm-abi-conventions)