### PR TITLE
More verbose reporting of engine build information to masterserver

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -1635,9 +1635,17 @@ static size_t NONNULL CL_BuildMasterServerScanRequest( char *buf, size_t size, u
 #ifndef XASH_ALL_SERVERS
 	Info_SetValueForKey( info, "gamedir", GI->gamefolder, remaining );
 #endif
-	Info_SetValueForKey( info, "clver", XASH_VERSION, remaining ); // let master know about client version
+	// let master know about client version
+	Info_SetValueForKey( info, "clver", XASH_VERSION, remaining );
 	Info_SetValueForKey( info, "nat", nat ? "1" : "0", remaining );
+	Info_SetValueForKey( info, "commit", Q_buildcommit(), remaining );
+	Info_SetValueForKey( info, "branch", Q_buildbranch(), remaining );
+	Info_SetValueForKey( info, "os", Q_buildos(), remaining );
+	Info_SetValueForKey( info, "arch", Q_buildarch(), remaining );
 
+	Q_snprintf( temp, sizeof( temp ), "%d", Q_buildnum() );
+	Info_SetValueForKey( info, "buildnum", temp, remaining );
+	
 	Q_snprintf( temp, sizeof( temp ), "%x", *key );
 	Info_SetValueForKey( info, "key", temp, remaining );
 


### PR DESCRIPTION
This can be pretty useful for statistical purposes and for tracking how many users using outdated/vulnerable Xash3D builds, and we can enforce such users to immediately update their Xash3D installation, for example. 

But masterserver should be updated to support such things too.

Reported information:
1. Xash3D version string
2. Build number
3. VCS commit hash
4. VCS branch name
5. Platform name
6. Architecture name
