### PR TITLE
Refapi 8 logo

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -36,9 +36,10 @@ CVAR_DEFINE_AUTO( cl_resend, "6.0", 0, "time to resend connect" );
 CVAR_DEFINE( cl_allow_download, "cl_allowdownload", "1", FCVAR_ARCHIVE, "allow to downloading resources from the server" );
 CVAR_DEFINE_AUTO( cl_allow_upload, "1", FCVAR_ARCHIVE, "allow to uploading resources to the server" );
 CVAR_DEFINE_AUTO( cl_download_ingame, "1", FCVAR_ARCHIVE, "allow to downloading resources while client is active" );
-CVAR_DEFINE_AUTO( cl_logofile, "lambda", FCVAR_ARCHIVE, "player logo name" );
-CVAR_DEFINE_AUTO( cl_logocolor, "orange", FCVAR_ARCHIVE, "player logo color" );
-CVAR_DEFINE_AUTO( cl_logoext, "bmp", FCVAR_ARCHIVE, "temporary cvar to tell engine which logo must be packed" );
+static CVAR_DEFINE_AUTO( cl_logofile, "lambda", FCVAR_ARCHIVE, "player logo name" );
+static CVAR_DEFINE_AUTO( cl_logocolor, "orange", FCVAR_ARCHIVE, "player logo color" );
+static CVAR_DEFINE_AUTO( cl_logoext, "bmp", FCVAR_ARCHIVE, "temporary cvar to tell engine which logo must be packed" );
+CVAR_DEFINE_AUTO( cl_logomaxdim, "96", FCVAR_ARCHIVE, "maximum decal dimension" );
 CVAR_DEFINE_AUTO( cl_test_bandwidth, "1", FCVAR_ARCHIVE, "test network bandwith before connection" );
 
 CVAR_DEFINE( cl_draw_particles, "r_drawparticles", "1", FCVAR_CHEAT, "render particles" );
@@ -2939,6 +2940,7 @@ static void CL_InitLocal( void )
 	Cvar_RegisterVariable( &cl_logofile );
 	Cvar_RegisterVariable( &cl_logocolor );
 	Cvar_RegisterVariable( &cl_logoext );
+	Cvar_RegisterVariable( &cl_logomaxdim );
 	Cvar_RegisterVariable( &cl_test_bandwidth );
 
 	Voice_RegisterCvars();

--- a/engine/client/cl_tent.c
+++ b/engine/client/cl_tent.c
@@ -2927,16 +2927,26 @@ static void CL_PlayerDecal( int playernum, int customIndex, int entityIndex, flo
 		{
 			if( !pCust->nUserData1 )
 			{
-				int sprayTextureIndex;
 				char decalname[MAX_VA_STRING];
+				int width, height;
 
 				Q_snprintf( decalname, sizeof( decalname ), "player%dlogo%d", playernum, customIndex );
-				sprayTextureIndex = ref.dllFuncs.GL_FindTexture( decalname );
-				if( sprayTextureIndex != 0 )
-				{
-					ref.dllFuncs.GL_FreeTexture( sprayTextureIndex );
-				}
+				textureIndex = ref.dllFuncs.GL_FindTexture( decalname );
+				if( textureIndex != 0 )
+					ref.dllFuncs.GL_FreeTexture( textureIndex );
+
 				pCust->nUserData1 = GL_LoadTextureInternal( decalname, pCust->pInfo, TF_DECAL );
+
+				width = REF_GET_PARM( PARM_TEX_WIDTH, pCust->nUserData1 );
+				height = REF_GET_PARM( PARM_TEX_HEIGHT, pCust->nUserData1 );
+
+				if( width > cl_logomaxdim.value || height > cl_logomaxdim.value )
+				{
+					double scale = cl_logomaxdim.value / Q_max( width, height );
+					width = round( width * scale );
+					height = round( height * scale );
+					ref.dllFuncs.R_OverrideTextureSourceSize( pCust->nUserData1, width, height ); // default custom decal from HL1
+				}
 			}
 			textureIndex = pCust->nUserData1;
 		}

--- a/engine/client/client.h
+++ b/engine/client/client.h
@@ -654,8 +654,7 @@ extern gameui_static_t	gameui;
 // cvars
 //
 extern convar_t	mp_decals;
-extern convar_t	cl_logofile;
-extern convar_t	cl_logocolor;
+extern convar_t	cl_logomaxdim;
 extern convar_t	cl_allow_download;
 extern convar_t	cl_allow_upload;
 extern convar_t	cl_download_ingame;

--- a/engine/common/custom.c
+++ b/engine/common/custom.c
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 #include "common.h"
 #include "custom.h"
 #include "ref_common.h"
+#include "hpak.h" // be aware of HPK limits
 
 static rgbdata_t *CustomDecal_LoadImage( const char *path, void *raw, int size )
 {
@@ -115,11 +116,11 @@ qboolean COM_CreateCustomization( customization_t *pListHead, resource_t *pResou
 		{
 			if( !FBitSet( flags, FCUST_IGNOREINIT ))
 			{
-				if( pResource->nDownloadSize >= (1 * 1024) && pResource->nDownloadSize <= ( 128 * 1024 ))
+				if( pResource->nDownloadSize >= HPAK_ENTRY_MIN_SIZE && pResource->nDownloadSize <= HPAK_ENTRY_MAX_SIZE )
 				{
 					pCust->bTranslated = true;
 					pCust->nUserData1 = 0;
-					pCust->nUserData2 = 1;
+					pCust->nUserData2 = 7;
 
 					if( !FBitSet( flags, FCUST_WIPEDATA ))
 						pCust->pInfo = CustomDecal_LoadImage( pResource->szFileName, pCust->pBuffer, pCust->resource.nDownloadSize );

--- a/engine/common/hpak.c
+++ b/engine/common/hpak.c
@@ -17,8 +17,6 @@ GNU General Public License for more details.
 #include "hpak.h"
 
 #define HPAK_MAX_ENTRIES	0x8000
-#define HPAK_ENTRY_MIN_SIZE	(512)
-#define HPAK_ENTRY_MAX_SIZE	(128 * 1024)
 
 typedef struct hash_pack_queue_s
 {
@@ -29,7 +27,7 @@ typedef struct hash_pack_queue_s
 	struct hash_pack_queue_s	*next;
 } hash_pack_queue_t;
 
-static CVAR_DEFINE_AUTO( hpk_maxsize, "4", FCVAR_ARCHIVE, "set limit by size for all HPK-files ( 0 - unlimited )" );
+static CVAR_DEFINE_AUTO( hpk_maxsize, "8", FCVAR_ARCHIVE, "set limit by size for all HPK-files ( 0 - unlimited )" );
 static hash_pack_queue_t	*gp_hpak_queue = NULL;
 static hpak_header_t	hash_pack_header;
 static hpak_info_t	hash_pack_info;
@@ -517,7 +515,7 @@ void HPAK_CheckSize( const char *filename )
 	Q_strncpy( pakname, filename, sizeof( pakname ));
 	COM_ReplaceExtension( pakname, ".hpk", sizeof( pakname ));
 
-	if( FS_FileSize( pakname, false ) > ( maxsize * 1048576 ))
+	if( FS_FileSize( pakname, false ) > ( maxsize * 1024 * 1024 ))
 	{
 		Con_Printf( "Server: Size of %s > %f MB, deleting.\n", filename, hpk_maxsize.value );
 		Log_Printf( "Server: Size of %s > %f MB, deleting.\n", filename, hpk_maxsize.value );

--- a/engine/common/hpak.h
+++ b/engine/common/hpak.h
@@ -17,6 +17,9 @@ GNU General Public License for more details.
 
 #include "custom.h"
 
+#define HPAK_ENTRY_MIN_SIZE	(512)
+#define HPAK_ENTRY_MAX_SIZE	(256 * 1024)
+
 /*
 ========================================================================
 .HPK archive format	(Hash PAK - HPK)

--- a/engine/common/imagelib/imagelib.h
+++ b/engine/common/imagelib/imagelib.h
@@ -103,8 +103,8 @@ typedef struct imglib_s
 #define IMAGE_MAXHEIGHT	8192
 #define LUMP_MAXWIDTH	1024	// WorldCraft limits
 #define LUMP_MAXHEIGHT	1024
-#define PLDECAL_MAXWIDTH  512
-#define PLDECAL_MAXHEIGHT 512
+#define PLDECAL_MAXWIDTH  768 // total of ~2mb uncompressed rgba data
+#define PLDECAL_MAXHEIGHT 768
 
 enum
 {


### PR DESCRIPTION
Now that in RefAPI 8 we have a less intrusive (to smelly decal code) way to control decal scale sizes, I brought back @SNMetamorph's suggestion.

Except few things:
* `hpk_maxsize` is increased to 8 megabytes, however I think most players won't get this, since Valve sets this cvar to 4 in HL and CS (and for some reason it's 15.4 in TFC?). Not to mention, some less tech-savvy players set this cvar to absolutely random values, expecting it to magically improve their shooting skills. Shall we rename it and enforce our own defaults here? 
* Logo max size is now 768 pixels, which corresponds to 2.25 megabytes of VRAM. In the worst possible case, 32 players spamming high quality clan logos will take 72 megabytes. I think, this isn't too much for modern PCs and Android devices.
* Customization and HPAK entry size is limited to 256 kilobytes. Again, in the worst possible case, with HPAK limit set to 8 megabytes, the engine will be able to cache logos at least for 32 players, which neatly fits our maxplayers limit and 16 players with Valve's `hpk_maxsize` default. 

In my opinion, 768px logo re-compressed with `pngquant` looks pretty awesome. If using this tool feels inconvenient (strangely, I wasn't able to find an online version of it), turns out it has a C API and can be easily linked to the menu.dll where player logo UI resides anyway.