### PR TITLE
Enable vsync by default

### DIFF
--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -10,7 +10,7 @@ ref_globals_t refState;
 
 static const char* r_skyBoxSuffix[SKYBOX_MAX_SIDES] = { "rt", "bk", "lf", "ft", "up", "dn" };
 
-CVAR_DEFINE_AUTO( gl_vsync, "0", FCVAR_ARCHIVE,  "enable vertical syncronization" );
+CVAR_DEFINE_AUTO( gl_vsync, "1", FCVAR_ARCHIVE,  "enable vertical syncronization" );
 CVAR_DEFINE_AUTO( r_showtextures, "0", FCVAR_CHEAT, "show all uploaded textures" );
 CVAR_DEFINE_AUTO( r_adjust_fov, "1", FCVAR_ARCHIVE, "making FOV adjustment for wide-screens" );
 CVAR_DEFINE_AUTO( r_decals, "4096", FCVAR_ARCHIVE, "sets the maximum number of decals" );


### PR DESCRIPTION
This is the first setting I change after installing xash3d-fwgs. Some distros even patch xash3d-fwgs to enable vsync by default (e.g. [Batocera](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/ports/xash3d/xash3d-fwgs/0001-Enable-VSync-by-default.patch)).

Let's enable vsync by default here.