### PR TITLE
Use C99 flexible array members

### DIFF
--- a/common/com_model.h
+++ b/common/com_model.h
@@ -127,13 +127,22 @@ typedef struct
 	int		flags;		// sky or slime, no lightmap or 256 subdivision
 } mtexinfo_t;
 
+// a1ba: changed size to avoid undefined behavior. Check your allocations if you take this header!
+// For example:
+//  before: malloc( sizeof( glpoly_t ) + ( numverts - 4 ) * VERTEXSIZE * sizeof( float ))
+//  after (C): malloc( sizeof( glpoly_t ) + numverts * VERTEXSIZE * sizeof( float ))
+//  after (C++): malloc( sizeof( glpoly_t ) + ( numverts - 1 ) * VERTEXSIZE * sizeof( float ))
 typedef struct glpoly_s
 {
 	struct glpoly_s	*next;
 	struct glpoly_s	*chain;
 	int		numverts;
 	int		flags;          		// for SURF_UNDERWATER
-	float		verts[4][VERTEXSIZE];	// variable sized (xyz s1t1 s2t2)
+#ifdef __cplusplus
+	float	verts[1][VERTEXSIZE]; // variable sized (xyz s1t1 s2t2)
+#else
+	float	verts[][VERTEXSIZE]; // variable sized (xyz s1t1 s2t2)
+#endif
 } glpoly_t;
 
 typedef struct mnode_s

--- a/engine/client/s_main.c
+++ b/engine/client/s_main.c
@@ -1092,7 +1092,7 @@ rawchan_t *S_FindRawChannel( int entnum, qboolean create )
 	if( !raw_channels[best] )
 	{
 		raw_samples = MAX_RAW_SAMPLES;
-		raw_channels[best] = Mem_Calloc( sndpool, sizeof( *ch ) + sizeof( portable_samplepair_t ) * ( raw_samples - 1 ));
+		raw_channels[best] = Mem_Calloc( sndpool, sizeof( *ch ) + sizeof( portable_samplepair_t ) * raw_samples );
 	}
 
 	ch = raw_channels[best];

--- a/engine/client/sound.h
+++ b/engine/client/sound.h
@@ -116,7 +116,7 @@ typedef struct rawchan_s
 	float                 oldtime;       // catch time jumps
 	wavdata_t             sound_info;    // advance play position
 	size_t                max_samples;   // buffer length
-	portable_samplepair_t rawsamples[1]; // variable sized
+	portable_samplepair_t rawsamples[]; // variable sized
 } rawchan_t;
 
 typedef struct channel_s

--- a/engine/common/mod_local.h
+++ b/engine/common/mod_local.h
@@ -74,7 +74,7 @@ typedef struct winding_s
 	struct winding_s	*pair;
 	hullnode_t	chain;
 	int		numpoints;
-	vec3_t		p[4];		// variable sized
+	vec3_t		p[];		// variable sized
 } winding_t;
 
 typedef struct

--- a/engine/common/net_chan.c
+++ b/engine/common/net_chan.c
@@ -513,7 +513,7 @@ static fragbuf_t *Netchan_AllocFragbuf( int fragment_size )
 {
 	fragbuf_t	*buf;
 
-	buf = (fragbuf_t *)Mem_Calloc( net_mempool, sizeof( fragbuf_t ) + ( fragment_size - 1 ) );
+	buf = (fragbuf_t *)Mem_Calloc( net_mempool, sizeof( fragbuf_t ) + fragment_size );
 	MSG_Init( &buf->frag_message, "Frag Message", buf->frag_message_buf, fragment_size );
 
 	return buf;

--- a/engine/common/netchan.h
+++ b/engine/common/netchan.h
@@ -190,7 +190,7 @@ typedef struct fragbuf_s
 	char		filename[MAX_OSPATH];		// name of the file to save out on remote host
 	int		foffset;				// offset in file from which to read data
 	int		size;				// size of data to read at that offset
-	byte frag_message_buf[1]; // the actual data sits here (flexible)
+	byte frag_message_buf[]; // the actual data sits here (flexible)
 } fragbuf_t;
 
 // Waiting list of fragbuf chains

--- a/filesystem/pak.c
+++ b/filesystem/pak.c
@@ -69,7 +69,7 @@ struct pack_s
 {
 	file_t *handle;
 	int		numfiles;
-	dpackfile_t files[1]; // flexible
+	dpackfile_t files[]; // flexible
 };
 
 /*
@@ -150,7 +150,7 @@ static pack_t *FS_LoadPackPAK( const char *packfile, int *error )
 		return NULL;
 	}
 
-	pack = (pack_t *)Mem_Calloc( fs_mempool, sizeof( pack_t ) + sizeof( dpackfile_t ) * ( numpackfiles - 1 ));
+	pack = (pack_t *)Mem_Calloc( fs_mempool, sizeof( pack_t ) + sizeof( dpackfile_t ) * numpackfiles );
 	FS_Seek( packhandle, header.dirofs, SEEK_SET );
 
 	if( header.dirlen != FS_Read( packhandle, (void *)pack->files, header.dirlen ))

--- a/filesystem/zip.c
+++ b/filesystem/zip.c
@@ -125,7 +125,7 @@ struct zip_s
 {
 	file_t *handle;
 	int		numfiles;
-	zipfile_t files[1]; // flexible
+	zipfile_t files[]; // flexible
 };
 
 // #define ENABLE_CRC_CHECK // known to be buggy because of possible libpublic crc32 bug, disabled
@@ -285,7 +285,7 @@ static zip_t *FS_LoadZip( const char *zipfile, int *error )
 	FS_Seek( zip->handle, header_eocd.central_directory_offset, SEEK_SET );
 
 	// Calc count of files in archive
-	zip = (zip_t *)Mem_Realloc( fs_mempool, zip, sizeof( *zip ) + sizeof( *info ) * ( header_eocd.total_central_directory_record - 1 ));
+	zip = (zip_t *)Mem_Realloc( fs_mempool, zip, sizeof( *zip ) + sizeof( *info ) * header_eocd.total_central_directory_record );
 	info = zip->files;
 
 	for( i = 0; i < header_eocd.total_central_directory_record; i++ )

--- a/ref/gl/gl_decals.c
+++ b/ref/gl/gl_decals.c
@@ -507,7 +507,7 @@ static glpoly_t *R_DecalCreatePoly( decalinfo_t *decalinfo, decal_t *pdecal, msu
 
 	// allocate glpoly
 	// REFTODO: com_studiocache pool!
-	poly = Mem_Calloc( r_temppool, sizeof( glpoly_t ) + ( lnumverts - 4 ) * VERTEXSIZE * sizeof( float ));
+	poly = Mem_Calloc( r_temppool, sizeof( glpoly_t ) + lnumverts * VERTEXSIZE * sizeof( float ));
 	poly->next = pdecal->polys;
 	poly->flags = surf->flags;
 	pdecal->polys = poly;

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -196,7 +196,7 @@ static void SubdividePolygon_r( model_t *loadmodel, msurface_t *warpface, int nu
 		ClearBits( warpface->flags, SURF_DRAWTURB_QUADS );
 
 	// add a point in the center to help keep warp valid
-	poly = Mem_Calloc( loadmodel->mempool, sizeof( glpoly_t ) + (numverts - 4) * VERTEXSIZE * sizeof( float ));
+	poly = Mem_Calloc( loadmodel->mempool, sizeof( glpoly_t ) + numverts * VERTEXSIZE * sizeof( float ));
 	poly->next = warpface->polys;
 	poly->flags = warpface->flags;
 	warpface->polys = poly;
@@ -328,7 +328,7 @@ void GL_BuildPolygonFromSurface( model_t *mod, msurface_t *fa )
 	fa->polys = NULL;
 
 	// quake simple models (healthkits etc) need to be reconstructed their polys because LM coords has changed after the map change
-	poly = Mem_Realloc( mod->mempool, poly, sizeof( glpoly_t ) + ( lnumverts - 4 ) * VERTEXSIZE * sizeof( float ));
+	poly = Mem_Realloc( mod->mempool, poly, sizeof( glpoly_t ) + lnumverts * VERTEXSIZE * sizeof( float ));
 	poly->next = fa->polys;
 	poly->flags = fa->flags;
 	fa->polys = poly;

--- a/ref/gl/gl_warp.c
+++ b/ref/gl/gl_warp.c
@@ -415,7 +415,7 @@ static void R_CloudVertex( float s, float t, int axis, vec3_t v )
 R_CloudTexCoord
 =============
 */
-static void R_CloudTexCoord( vec3_t v, float speed, float *s, float *t )
+static void R_CloudTexCoord( const vec3_t v, float speed, float *s, float *t )
 {
 	float	length, speedscale;
 	vec3_t	dir;
@@ -438,17 +438,17 @@ static void R_CloudTexCoord( vec3_t v, float speed, float *s, float *t )
 R_CloudDrawPoly
 ===============
 */
-static void R_CloudDrawPoly( glpoly_t *p )
+static void R_CloudDrawPoly( const float *verts )
 {
+	const float	*v;
 	float	s, t;
-	float	*v;
 	int		i;
 
 	GL_SetRenderMode( kRenderNormal );
 	GL_Bind( XASH_TEXTURE0, tr.solidskyTexture );
 
 	pglBegin( GL_QUADS );
-	for( i = 0, v = p->verts[0]; i < 4; i++, v += VERTEXSIZE )
+	for( i = 0, v = verts; i < 4; i++, v += VERTEXSIZE )
 	{
 		R_CloudTexCoord( v, 8.0f, &s, &t );
 		pglTexCoord2f( s, t );
@@ -460,7 +460,7 @@ static void R_CloudDrawPoly( glpoly_t *p )
 	GL_Bind( XASH_TEXTURE0, tr.alphaskyTexture );
 
 	pglBegin( GL_QUADS );
-	for( i = 0, v = p->verts[0]; i < 4; i++, v += VERTEXSIZE )
+	for( i = 0, v = verts; i < 4; i++, v += VERTEXSIZE )
 	{
 		R_CloudTexCoord( v, 16.0f, &s, &t );
 		pglTexCoord2f( s, t );
@@ -479,10 +479,10 @@ R_CloudRenderSide
 static void R_CloudRenderSide( int axis )
 {
 	vec3_t	verts[4];
+	float	final_verts[4][VERTEXSIZE];
 	float	di, qi, dj, qj;
 	vec3_t	vup, vright;
 	vec3_t	temp, temp2;
-	glpoly_t	p[1];
 	int	i, j;
 
 	R_CloudVertex( -1.0f, -1.0f, axis, verts[0] );
@@ -493,7 +493,6 @@ static void R_CloudRenderSide( int axis )
 	VectorSubtract( verts[2], verts[3], vup );
 	VectorSubtract( verts[2], verts[1], vright );
 
-	p->numverts = 4;
 	di = SKYCLOUDS_QUALITY;
 	qi = 1.0f / di;
 	dj = (axis < 4) ? di * 2 : di; //subdivide vertically more than horizontally on skybox sides
@@ -512,17 +511,17 @@ static void R_CloudRenderSide( int axis )
 			VectorScale( vright, qi * i, temp );
 			VectorScale( vup, qj * j, temp2 );
 			VectorAdd( temp, temp2, temp );
-			VectorAdd( verts[0], temp, p->verts[0] );
+			VectorAdd( verts[0], temp, final_verts[0] );
 
 			VectorScale( vup, qj, temp );
-			VectorAdd( p->verts[0], temp, p->verts[1] );
+			VectorAdd( final_verts[0], temp, final_verts[1] );
 
 			VectorScale( vright, qi, temp );
-			VectorAdd( p->verts[1], temp, p->verts[2] );
+			VectorAdd( final_verts[1], temp, final_verts[2] );
 
-			VectorAdd( p->verts[0], temp, p->verts[3] );
+			VectorAdd( final_verts[0], temp, final_verts[3] );
 
-			R_CloudDrawPoly( p );
+			R_CloudDrawPoly( final_verts[0] );
 		}
 	}
 }

--- a/ref/soft/r_decals.c
+++ b/ref/soft/r_decals.c
@@ -527,7 +527,7 @@ static glpoly_t *R_DecalCreatePoly( decalinfo_t *decalinfo, decal_t *pdecal, msu
 
 	// allocate glpoly
 	// REFTODO: com_studiocache pool!
-	poly = Mem_Calloc( r_temppool, sizeof( glpoly_t ) + ( lnumverts - 4 ) * VERTEXSIZE * sizeof( float ));
+	poly = Mem_Calloc( r_temppool, sizeof( glpoly_t ) + lnumverts * VERTEXSIZE * sizeof( float ));
 	poly->next = pdecal->polys;
 	poly->flags = surf->flags;
 	pdecal->polys = poly;


### PR DESCRIPTION
Now that we're on C99, nothing stops us from normally using the standard, non-UB, non-compiler-specific way for flexible array members.

The only somewhat breaking change is the `glpoly_t` struct redefinition. But because it's never allocated on client side, nor it's never a part of another struct, it doesn't break binary compatibility. Ideally, mods better take this change too, because it less confuses the compiler.

Fixes https://github.com/FWGS/xash3d-fwgs/issues/1743

cc @mittorn 