### PR TITLE
Implement DNS resolve thread through SDL2 functions

### DIFF
--- a/wscript
+++ b/wscript
@@ -233,7 +233,6 @@ def configure(conf):
 	elif conf.env.DEST_OS == 'psvita':
 		conf.options.NO_VGUI          = True
 		conf.options.GL               = True
-		conf.options.NO_ASYNC_RESOLVE = True
 		conf.options.USE_STBTT        = True
 		# we'll specify -fPIC by hand for shared libraries only
 		enforce_pic                   = False

--- a/wscript
+++ b/wscript
@@ -228,7 +228,6 @@ def configure(conf):
 	elif conf.env.DEST_OS == 'nswitch':
 		conf.options.NO_VGUI          = True
 		conf.options.GL               = True
-		conf.options.NO_ASYNC_RESOLVE = True
 		conf.options.USE_STBTT        = True
 	elif conf.env.DEST_OS == 'psvita':
 		conf.options.NO_VGUI          = True


### PR DESCRIPTION
As a desperate attempt to have async resolve on platforms where POSIX threads aren't available.

In current version, SDL2 is preferred on all platforms where the SDL2 (i.e. full client) is enabled. I quickly tested it on Linux, and it works for me.