### PR TITLE
Restore r_shadows

### DIFF
--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -154,8 +154,7 @@ void R_StudioInit( void )
 
 	Matrix3x4_LoadIdentity( g_studio.rotationmatrix );
 
-	// g-cont. cvar disabled by Valve
-//	gEngfuncs.Cvar_RegisterVariable( &r_shadows );
+	gEngfuncs.Cvar_RegisterVariable( &r_shadows );
 
 	g_studio.interpolate = true;
 	g_studio.framecount = 0;


### PR DESCRIPTION
This restores the r_shadows cvar as it's also been re-enabled in HL25 and seems to be working fine.