### PR TITLE
gha: adds SDL2 to OSX builds (resolves #1791)

### DIFF
--- a/scripts/gha/build_apple.sh
+++ b/scripts/gha/build_apple.sh
@@ -10,5 +10,7 @@ popd
 
 ./waf configure --enable-utils --enable-tests --enable-lto build install --destdir=bin || die_configure
 
+cp -vr /Library/Frameworks/SDL2.framework bin
+
 mkdir -p artifacts/
 tar -cJvf artifacts/xash3d-fwgs-apple-$ARCH.tar.xz -C bin . # skip the bin directory from resulting tar archive


### PR DESCRIPTION
This PR updates `build_apple.sh` to copy over SDL2 from `/Library/Frameworks`. SDL2 is installed in there by `dep_apple.sh`.