### PR TITLE
Loading BSP2 maps in a single binary

### DIFF
--- a/common/bspfile.h
+++ b/common/bspfile.h
@@ -16,8 +16,6 @@ GNU General Public License for more details.
 #ifndef BSPFILE_H
 #define BSPFILE_H
 
-//#define SUPPORT_BSP2_FORMAT		// allow to loading Darkplaces BSP2 maps (with broke binary compatibility)
-
 /*
 ==============================================================================
 
@@ -65,7 +63,6 @@ BRUSH MODELS
 #define MAX_MAP_CLIPNODES_BSP2  524288
 
 // these limis not using by modelloader but only for displaying 'mapstats' correctly
-#ifdef SUPPORT_BSP2_FORMAT
 #define MAX_MAP_MODELS		2048		// embedded models
 #define MAX_MAP_ENTSTRING		0x200000		// 2 Mb should be enough
 #define MAX_MAP_PLANES		131072		// can be increased without problems
@@ -75,18 +72,6 @@ BRUSH MODELS
 #define MAX_MAP_VERTS		524288		// can be increased without problems
 #define MAX_MAP_FACES		262144		// can be increased without problems
 #define MAX_MAP_MARKSURFACES		524288		// can be increased without problems
-#else
-// increased to match PrimeXT compilers
-#define MAX_MAP_MODELS		1024		// embedded models
-#define MAX_MAP_ENTSTRING		0x100000		// 1 Mb should be enough
-#define MAX_MAP_PLANES		65536		// can be increased without problems
-#define MAX_MAP_NODES		32767		// because negative shorts are leafs
-#define MAX_MAP_CLIPNODES		MAX_MAP_CLIPNODES_HLBSP		// because negative shorts are contents
-#define MAX_MAP_LEAFS		32767		// signed short limit
-#define MAX_MAP_VERTS		65535		// unsigned short limit
-#define MAX_MAP_FACES		65535		// unsigned short limit
-#define MAX_MAP_MARKSURFACES		65535		// unsigned short limit
-#endif
 
 #define MAX_MAP_ENTITIES		8192		// network limit
 #define MAX_MAP_TEXINFO		MAX_MAP_FACES	// in theory each face may have personal texinfo

--- a/common/com_model.h
+++ b/common/com_model.h
@@ -60,15 +60,17 @@ typedef struct
 	vec3_t		position;
 } mvertex_t;
 
-typedef struct
+typedef struct mclipnode32_s
 {
-	int		planenum;
-#ifdef SUPPORT_BSP2_FORMAT
-	int		children[2];	// negative numbers are contents
-#else
-	short		children[2];	// negative numbers are contents
-#endif
-} mclipnode_t;
+	int planenum;
+	int children[2]; // negative numbers are contents
+} mclipnode32_t;
+
+typedef struct mclipnode16_s
+{
+	int   planenum;
+	short children[2];	// negative numbers are contents
+} mclipnode16_t;
 
 // size is matched but representation is not
 typedef struct
@@ -291,7 +293,11 @@ struct msurface_s
 
 typedef struct hull_s
 {
-	mclipnode_t	*clipnodes;
+	union
+	{
+		mclipnode16_t *clipnodes16;
+		mclipnode32_t *clipnodes32;
+	};
 	mplane_t		*planes;
 	int		firstclipnode;
 	int		lastclipnode;
@@ -356,7 +362,11 @@ typedef struct model_s
 	int		*surfedges;
 
 	int		numclipnodes;
-	mclipnode_t	*clipnodes;
+	union
+	{
+		mclipnode16_t *clipnodes16;
+		mclipnode32_t *clipnodes32;
+	};
 
 	int		nummarksurfaces;
 	msurface_t	**marksurfaces;

--- a/common/com_model.h
+++ b/common/com_model.h
@@ -73,15 +73,16 @@ typedef struct mclipnode16_s
 } mclipnode16_t;
 
 // size is matched but representation is not
-typedef struct
+typedef struct medge32_s
 {
-#ifdef SUPPORT_BSP2_FORMAT
 	unsigned int	v[2];
-#else
+} medge32_t;
+
+typedef struct medge16_s
+{
 	unsigned short	v[2];
 	unsigned int	cachededgeoffset;
-#endif
-} medge_t;
+} medge16_t;
 
 typedef struct texture_s
 {
@@ -347,7 +348,12 @@ typedef struct model_s
 	mvertex_t		*vertexes;
 
 	int		numedges;
-	medge_t		*edges;
+	union
+	{
+		medge16_t *edges16;
+		medge32_t *edges32;
+	};
+
 
 	int		numnodes;
 	mnode_t		*nodes;

--- a/engine/client/cl_efrag.c
+++ b/engine/client/cl_efrag.c
@@ -127,8 +127,10 @@ static void R_SplitEntityOnNode( mnode_t *node )
 	}
 
 	// recurse down the contacted sides
-	if( sides & 1 ) R_SplitEntityOnNode( node->children[0] );
-	if( sides & 2 ) R_SplitEntityOnNode( node->children[1] );
+	if( sides & 1 )
+		R_SplitEntityOnNode( node_child( node, 0, cl.worldmodel ));
+	if( sides & 2 )
+		R_SplitEntityOnNode( node_child( node, 1, cl.worldmodel ));
 }
 
 /*

--- a/engine/client/cl_render.c
+++ b/engine/client/cl_render.c
@@ -138,10 +138,7 @@ intptr_t CL_RenderGetParm( const int parm, const int arg, const qboolean checkRe
 	switch( parm )
 	{
 	case PARM_BSP2_SUPPORTED:
-#ifdef SUPPORT_BSP2_FORMAT
 		return 1;
-#endif
-		return 0;
 	case PARAM_GAMEPAUSED:
 		return cl.paused;
 	case PARM_CLIENT_INGAME:

--- a/engine/client/cl_view.c
+++ b/engine/client/cl_view.c
@@ -466,8 +466,8 @@ static void R_ShowTree_r( mnode_t *node, float x, float y, float scale, int show
 		R_DrawNodeConnection( x, y, x + scale, y + scale );
 	}
 
-	R_ShowTree_r( node->children[1], x - scale, y + scale, downScale, shownodes, viewleaf );
-	R_ShowTree_r( node->children[0], x + scale, y + scale, downScale, shownodes, viewleaf );
+	R_ShowTree_r( node_child( node, 1, cl.worldmodel ), x - scale, y + scale, downScale, shownodes, viewleaf );
+	R_ShowTree_r( node_child( node, 0, cl.worldmodel ), x + scale, y + scale, downScale, shownodes, viewleaf );
 
 	world.recursion_level--;
 }
@@ -482,7 +482,7 @@ static void R_ShowTree( void )
 		return;
 
 	world.recursion_level = 0;
-	viewleaf = Mod_PointInLeaf( refState.vieworg, cl.worldmodel->nodes );
+	viewleaf = Mod_PointInLeaf( refState.vieworg, cl.worldmodel->nodes, cl.worldmodel );
 
 	ref.dllFuncs.TriRenderMode( kRenderTransTexture );
 

--- a/engine/client/mod_dbghulls.c
+++ b/engine/client/mod_dbghulls.c
@@ -470,16 +470,16 @@ out_free:
  * This is a stack of the clipnodes we have traversed
  * "sides" indicates which side we went down each time
  */
-static mclipnode_t	*node_stack[MAX_CLIPNODE_DEPTH];
+static int	node_stack[MAX_CLIPNODE_DEPTH];
 static int	side_stack[MAX_CLIPNODE_DEPTH];
 static uint	node_stack_depth;
 
-static void push_node( mclipnode_t *node, int side )
+static void push_node( int nodenum, int side )
 {
 	if( node_stack_depth == MAX_CLIPNODE_DEPTH )
 		Host_Error( "node stack overflow\n" );
 
-	node_stack[node_stack_depth] = node;
+	node_stack[node_stack_depth] = nodenum;
 	side_stack[node_stack_depth] = side;
 	node_stack_depth++;
 }
@@ -502,22 +502,27 @@ static void free_hull_polys( hullnode_t *hull_polys )
 	}
 }
 
-static void hull_windings_r( hull_t *hull, mclipnode_t *node, hullnode_t *polys, hull_model_t *model );
+static void hull_windings_r( hull_t *hull, int nodenum, hullnode_t *polys, hull_model_t *model );
 
-static void do_hull_recursion( hull_t *hull, mclipnode_t *node, int side, hullnode_t *polys, hull_model_t *model )
+static void do_hull_recursion( hull_t *hull, int nodenum, int side, hullnode_t *polys, hull_model_t *model )
 {
 	winding_t	*w, *next;
+	int childnum;
 
-	if( node->children[side] >= 0 )
+	if( world.version == QBSP2_VERSION )
+		childnum = hull->clipnodes32[nodenum].children[side];
+	else
+		childnum = hull->clipnodes16[nodenum].children[side];
+
+	if( childnum >= 0 )
 	{
-		mclipnode_t *child = hull->clipnodes + node->children[side];
-		push_node( node, side );
-		hull_windings_r( hull, child, polys, model );
+		push_node( nodenum, side );
+		hull_windings_r( hull, childnum, polys, model );
 		pop_node();
 	}
 	else
 	{
-		switch( node->children[side] )
+		switch( childnum )
 		{
 		case CONTENTS_EMPTY:
 		case CONTENTS_WATER:
@@ -542,19 +547,24 @@ static void do_hull_recursion( hull_t *hull, mclipnode_t *node, int side, hullno
 			}
 			break;
 		default:
-			Host_Error( "bad contents: %i\n", node->children[side] );
+			Host_Error( "bad contents: %i\n", childnum );
 			break;
 		}
 	}
 }
 
-static void hull_windings_r( hull_t *hull, mclipnode_t *node, hullnode_t *polys, hull_model_t *model )
+static void hull_windings_r( hull_t *hull, int nodenum, hullnode_t *polys, hull_model_t *model )
 {
-	mplane_t		*plane = hull->planes + node->planenum;
+	mplane_t *plane;
 	hullnode_t	frontlist = LIST_HEAD_INIT( frontlist );
 	hullnode_t	backlist = LIST_HEAD_INIT( backlist );
 	winding_t		*w, *next, *front, *back;
 	int	i;
+
+	if( world.version == QBSP2_VERSION )
+		plane = hull->planes + hull->clipnodes32[nodenum].planenum;
+	else
+		plane = hull->planes + hull->clipnodes16[nodenum].planenum;
 
 	list_for_each_entry_safe( w, next, polys, chain )
 	{
@@ -601,7 +611,13 @@ static void hull_windings_r( hull_t *hull, mclipnode_t *node, hullnode_t *polys,
 
 	for( i = 0; w && i < node_stack_depth; i++ )
 	{
-		mplane_t *p = hull->planes + node_stack[i]->planenum;
+		mplane_t *p;
+
+		if( world.version == QBSP2_VERSION )
+			p = hull->planes + hull->clipnodes32[node_stack[i]].planenum;
+		else
+			p = hull->planes + hull->clipnodes16[node_stack[i]].planenum;
+
 		w = winding_clip( w, p, false, side_stack[i], 0.00001 );
 	}
 
@@ -625,8 +641,8 @@ static void hull_windings_r( hull_t *hull, mclipnode_t *node, hullnode_t *polys,
 		Con_Printf( S_WARN "new winding was clipped away!\n" );
 	}
 
-	do_hull_recursion( hull, node, 0, &frontlist, model );
-	do_hull_recursion( hull, node, 1, &backlist, model );
+	do_hull_recursion( hull, nodenum, 0, &frontlist, model );
+	do_hull_recursion( hull, nodenum, 1, &backlist, model );
 }
 
 static void remove_paired_polys( hull_model_t *model )
@@ -655,7 +671,7 @@ static void make_hull_windings( hull_t *hull, hull_model_t *model )
 
 	if( hull->planes != NULL )
 	{
-		hull_windings_r( hull, hull->clipnodes + hull->firstclipnode, &head, model );
+		hull_windings_r( hull, hull->firstclipnode, &head, model );
 		remove_paired_polys( model );
 	}
 	Con_Reportf( "%i hull polys\n", model->num_polys );

--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -300,6 +300,12 @@ static qboolean R_Init_Video_( const int type )
 	return R_Init_Video( type );
 }
 
+static mleaf_t *pfnMod_PointInLeaf( const vec3_t p, mnode_t *node )
+{
+	// FIXME: get rid of this on next RefAPI update
+	return Mod_PointInLeaf( p, node, cl.models[1] );
+}
+
 static const ref_api_t gEngfuncs =
 {
 	pfnEngineGetParm,
@@ -340,7 +346,7 @@ static const ref_api_t gEngfuncs =
 
 	Mod_SampleSizeForFace,
 	Mod_BoxVisible,
-	Mod_PointInLeaf,
+	pfnMod_PointInLeaf,
 	R_DrawWorldHull,
 	R_DrawModelHull,
 

--- a/engine/client/s_main.c
+++ b/engine/client/s_main.c
@@ -996,7 +996,7 @@ static void S_UpdateAmbientSounds( void )
 	// calc ambient sound levels
 	if( !cl.worldmodel ) return;
 
-	leaf = Mod_PointInLeaf( s_listener.origin, cl.worldmodel->nodes );
+	leaf = Mod_PointInLeaf( s_listener.origin, cl.worldmodel->nodes, cl.worldmodel );
 
 	if( !leaf || !s_ambient_level.value )
 	{

--- a/engine/common/com_strings.h
+++ b/engine/common/com_strings.h
@@ -72,8 +72,6 @@ GNU General Public License for more details.
 
 #define CVAR_GLCONFIG_DESCRIPTION	"enable or disable %s"
 
-#define DEFAULT_BSP_BUILD_ERROR	"%s can't be loaded in this build. Please rebuild engine with enabled SUPPORT_BSP2_FORMAT\n"
-
 #define DEFAULT_UPDATE_PAGE "https://github.com/FWGS/xash3d-fwgs/releases/latest"
 
 #define XASH_ENGINE_NAME "Xash3D FWGS"

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -3594,13 +3594,6 @@ static qboolean Mod_LoadBmodelLumps( model_t *mod, const byte *mod_base, qboolea
 	Q_strncpy( loadstat.name, mod->name, sizeof( loadstat.name ));
 	wadvalue[0] = '\0';
 
-#ifndef SUPPORT_BSP2_FORMAT
-	if( header->version == QBSP2_VERSION )
-	{
-		Con_Printf( S_ERROR DEFAULT_BSP_BUILD_ERROR, mod->name );
-		return false;
-	}
-#endif
 	switch( header->version )
 	{
 	case HLBSP_VERSION:
@@ -3765,15 +3758,6 @@ qboolean Mod_TestBmodelLumps( file_t *f, const char *name, const byte *mod_base,
 	Q_strncpy( loadstat.name, name, sizeof( loadstat.name ));
 	if( silent )
 		SetBits( flags, LUMP_SILENT );
-
-#ifndef SUPPORT_BSP2_FORMAT
-	if( header->version == QBSP2_VERSION )
-	{
-		if( !FBitSet( flags, LUMP_SILENT ))
-			Con_Printf( S_ERROR DEFAULT_BSP_BUILD_ERROR, name );
-		return false;
-	}
-#endif
 
 	switch( header->version )
 	{

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -385,6 +385,35 @@ static const mlumpinfo_t extlumps[EXTRA_LUMPS] =
 	},
 };
 
+#define BOX_CLIPNODES_INITIALIZER \
+	{ \
+		.planenum = 0, \
+		.children = { CONTENTS_EMPTY, 1 }, \
+	}, \
+	{ \
+		.planenum = 1, \
+		.children = { 2, CONTENTS_EMPTY }, \
+	}, \
+	{ \
+		.planenum = 2, \
+		.children = { CONTENTS_EMPTY, 3 }, \
+	}, \
+	{ \
+		.planenum = 3, \
+		.children = { 4, CONTENTS_EMPTY }, \
+	}, \
+	{ \
+		.planenum = 4, \
+		.children = { CONTENTS_EMPTY, 5 }, \
+	}, \
+	{ \
+		.planenum = 5, \
+		.children = { CONTENTS_SOLID, CONTENTS_EMPTY }, \
+	}, \
+
+const mclipnode16_t box_clipnodes16[6] = { BOX_CLIPNODES_INITIALIZER };
+const mclipnode32_t box_clipnodes32[6] = { BOX_CLIPNODES_INITIALIZER };
+
 /*
 ===============================================================================
 

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -3048,7 +3048,6 @@ static void Mod_LoadSurfaces( model_t *mod, dbspmodel_t *bmod )
 		if( samples == 1 || samples == 3 )
 		{
 			bmod->lightmap_samples = (int)samples;
-			Con_Reportf( "lighting: %s\n", (bmod->lightmap_samples == 1) ? "monochrome" : "colored" );
 			bmod->lightmap_samples = Q_max( bmod->lightmap_samples, 1 ); // avoid division by zero
 		}
 		else Con_DPrintf( S_WARN "lighting invalid samplecount: %g, defaulting to %i\n", samples, bmod->lightmap_samples );
@@ -3544,6 +3543,8 @@ static void Mod_LoadLighting( model_t *mod, dbspmodel_t *bmod )
 		Host_Error( "%s: bad lightmap sample count %i\n", __func__, bmod->lightmap_samples );
 		break;
 	}
+
+	Con_Reportf( "lighting: %s\n", FBitSet( mod->flags, MODEL_COLORED_LIGHTING ) ? "colored" : "monochrome" );
 
 	// not supposed to be load ?
 	if( FBitSet( host.features, ENGINE_LOAD_DELUXEDATA ))

--- a/engine/common/mod_local.h
+++ b/engine/common/mod_local.h
@@ -135,6 +135,8 @@ extern poolhandle_t     com_studiocache;
 extern convar_t		mod_studiocache;
 extern convar_t		r_wadtextures;
 extern convar_t		r_showhull;
+extern const mclipnode16_t box_clipnodes16[6];
+extern const mclipnode32_t box_clipnodes32[6];
 
 //
 // model.c

--- a/engine/common/mod_local.h
+++ b/engine/common/mod_local.h
@@ -167,13 +167,12 @@ void Mod_LoadAliasModel( model_t *mod, const void *buffer, qboolean *loaded );
 //
 void Mod_LoadBrushModel( model_t *mod, const void *buffer, qboolean *loaded );
 qboolean Mod_TestBmodelLumps( file_t *f, const char *name, const byte *mod_base, qboolean silent, dlump_t *entities );
-qboolean Mod_HeadnodeVisible( mnode_t *node, const byte *visbits, int *lastleaf );
 int Mod_FatPVS( const vec3_t org, float radius, byte *visbuffer, int visbytes, qboolean merge, qboolean fullvis, qboolean false );
 qboolean Mod_BoxVisible( const vec3_t mins, const vec3_t maxs, const byte *visbits );
 int Mod_CheckLump( const char *filename, const int lump, int *lumpsize );
 int Mod_ReadLump( const char *filename, const int lump, void **lumpdata, int *lumpsize );
 int Mod_SaveLump( const char *filename, const int lump, void *lumpdata, int lumpsize );
-mleaf_t *Mod_PointInLeaf( const vec3_t p, mnode_t *node );
+mleaf_t *Mod_PointInLeaf( const vec3_t p, mnode_t *node, model_t *mod );
 int Mod_SampleSizeForFace( const msurface_t *surf );
 byte *Mod_GetPVSForPoint( const vec3_t p );
 void Mod_UnloadBrushModel( model_t *mod );

--- a/engine/common/mod_studio.c
+++ b/engine/common/mod_studio.c
@@ -50,10 +50,8 @@ static matrix3x4			studio_bones[MAXSTUDIOBONES];
 static uint			studio_hull_hitgroup[MAXSTUDIOBONES];
 static uint			cache_hull_hitgroup[MAXSTUDIOBONES];
 static mstudiocache_t		cache_studio[STUDIO_CACHESIZE];
-static mclipnode16_t			studio_clipnodes16[6];
-static mclipnode32_t			studio_clipnodes32[6];
-static mplane_t			studio_planes[768];
-static mplane_t			cache_planes[768];
+static mplane_t			studio_planes[MAXSTUDIOBONES * 6];
+static mplane_t			cache_planes[MAXSTUDIOBONES * 6];
 
 // current cache state
 static int			cache_current;
@@ -67,36 +65,14 @@ Mod_InitStudioHull
 */
 void Mod_InitStudioHull( void )
 {
-	int	i, side;
+	int	i;
 
 	if( studio_hull[0].planes != NULL )
 		return;	// already initailized
 
-	for( i = 0; i < 6; i++ )
-	{
-		studio_clipnodes16[i].planenum = i;
-		studio_clipnodes32[i].planenum = i;
-
-		side = i & 1;
-
-		studio_clipnodes16[i].children[side] = CONTENTS_EMPTY;
-		studio_clipnodes32[i].children[side] = CONTENTS_EMPTY;
-
-		if( i != 5 )
-		{
-			studio_clipnodes16[i].children[side^1] = i + 1;
-			studio_clipnodes32[i].children[side^1] = i + 1;
-		}
-		else
-		{
-			studio_clipnodes16[i].children[side^1] = CONTENTS_SOLID;
-			studio_clipnodes32[i].children[side^1] = CONTENTS_SOLID;
-		}
-	}
-
 	for( i = 0; i < MAXSTUDIOBONES; i++ )
 	{
-		studio_hull[i].clipnodes16 = studio_clipnodes16;
+		studio_hull[i].clipnodes16 = (mclipnode16_t *)box_clipnodes16;
 		studio_hull[i].planes = &studio_planes[i*6];
 		studio_hull[i].firstclipnode = 0;
 		studio_hull[i].lastclipnode = 5;
@@ -283,9 +259,9 @@ hull_t *Mod_HullForStudio( model_t *model, float frame, int sequence, vec3_t ang
 	for( i = j = 0; i < mod_studiohdr->numhitboxes; i++, j += 6 )
 	{
 		if( world.version == QBSP2_VERSION )
-			studio_hull[i].clipnodes32 = studio_clipnodes32;
+			studio_hull[i].clipnodes32 = (mclipnode32_t *)box_clipnodes32;
 		else
-			studio_hull[i].clipnodes16 = studio_clipnodes16;
+			studio_hull[i].clipnodes16 = (mclipnode16_t *)box_clipnodes16;
 
 		if( bSkipShield && i == 21 )
 			continue;	// CS stuff

--- a/engine/common/pm_surface.c
+++ b/engine/common/pm_surface.c
@@ -112,6 +112,9 @@ msurface_t *PM_RecursiveSurfCheck( model_t *mod, mnode_t *node, vec3_t p1, vec3_
 	int		i, side;
 	msurface_t	*surf;
 	vec3_t		mid;
+	mnode_t *children[2];
+	int numsurfaces, firstsurface;
+
 loc0:
 	if( node->contents < 0 )
 		return NULL;
@@ -119,15 +122,17 @@ loc0:
 	t1 = PlaneDiff( p1, node->plane );
 	t2 = PlaneDiff( p2, node->plane );
 
+	node_children( children, node, mod );
+
 	if( t1 >= -FRAC_EPSILON && t2 >= -FRAC_EPSILON )
 	{
-		node = node->children[0];
+		node = children[0];
 		goto loc0;
 	}
 
 	if( t1 < FRAC_EPSILON && t2 < FRAC_EPSILON )
 	{
-		node = node->children[1];
+		node = children[1];
 		goto loc0;
 	}
 
@@ -137,13 +142,15 @@ loc0:
 
 	VectorLerp( p1, frac, p2, mid );
 
-	if(( surf = PM_RecursiveSurfCheck( mod, node->children[side], p1, mid )) != NULL )
+	if(( surf = PM_RecursiveSurfCheck( mod, children[side], p1, mid )) != NULL )
 		return surf;
 
 	// walk through real faces
-	for( i = 0; i < node->numsurfaces; i++ )
+	numsurfaces = node_numsurfaces( node, mod );
+	firstsurface = node_firstsurface( node, mod );
+	for( i = 0; i < numsurfaces; i++ )
 	{
-		msurface_t	*surf = &mod->surfaces[node->firstsurface + i];
+		msurface_t	*surf = &mod->surfaces[firstsurface + i];
 		mextrasurf_t	*info = surf->info;
 		mfacebevel_t	*fb = info->bevel;
 		int		j, contents;
@@ -172,7 +179,7 @@ loc0:
 		return NULL; // through the fence
 	}
 
-	return PM_RecursiveSurfCheck( mod, node->children[side^1], mid, p2 );
+	return PM_RecursiveSurfCheck( mod, children[side^1], mid, p2 );
 }
 
 /*
@@ -227,6 +234,9 @@ static int PM_TestLine_r( model_t *mod, mnode_t *node, vec_t p1f, vec_t p2f, con
 	float	frac, midf;
 	int	i, r, side;
 	vec3_t	mid;
+	mnode_t *children[2];
+	int numsurfaces, firstsurface;
+
 loc0:
 	if( node->contents < 0 )
 	{
@@ -242,15 +252,17 @@ loc0:
 	front = PlaneDiff( start, node->plane );
 	back = PlaneDiff( stop, node->plane );
 
+	node_children( children, node, mod );
+
 	if( front >= -FRAC_EPSILON && back >= -FRAC_EPSILON )
 	{
-		node = node->children[0];
+		node = children[0];
 		goto loc0;
 	}
 
 	if( front < FRAC_EPSILON && back < FRAC_EPSILON )
 	{
-		node = node->children[1];
+		node = children[1];
 		goto loc0;
 	}
 
@@ -261,7 +273,7 @@ loc0:
 	VectorLerp( start, frac, stop, mid );
 	midf = p1f + ( p2f - p1f ) * frac;
 
-	r = PM_TestLine_r( mod, node->children[side], p1f, midf, start, mid, trace );
+	r = PM_TestLine_r( mod, children[side], p1f, midf, start, mid, trace );
 
 	if( r != CONTENTS_EMPTY )
 	{
@@ -272,9 +284,11 @@ loc0:
 	}
 
 	// walk through real faces
-	for( i = 0; i < node->numsurfaces; i++ )
+	numsurfaces = node_numsurfaces( node, mod );
+	firstsurface = node_firstsurface( node, mod );
+	for( i = 0; i < numsurfaces; i++ )
 	{
-		msurface_t	*surf = &mod->surfaces[node->firstsurface + i];
+		msurface_t	*surf = &mod->surfaces[firstsurface + i];
 		mextrasurf_t	*info = surf->info;
 		mfacebevel_t	*fb = info->bevel;
 		int		j, contents;
@@ -308,7 +322,7 @@ loc0:
 		return contents;
 	}
 
-	return PM_TestLine_r( mod, node->children[!side], midf, p2f, mid, stop, trace );
+	return PM_TestLine_r( mod, children[!side], midf, p2f, mid, stop, trace );
 }
 
 int PM_TestLineExt( playermove_t *pmove, physent_t *ents, int numents, const vec3_t start, const vec3_t end, int flags )

--- a/engine/common/pm_trace.c
+++ b/engine/common/pm_trace.c
@@ -25,8 +25,6 @@ GNU General Public License for more details.
 #define PM_AllowHitBoxTrace( model, hull ) ( model && model->type == mod_studio && ( FBitSet( model->flags, STUDIO_TRACE_HITBOX ) || hull == 2 ))
 
 static mplane_t	pm_boxplanes[6];
-static mclipnode16_t pm_boxclipnodes16[6];
-static mclipnode32_t pm_boxclipnodes32[6];
 static hull_t pm_boxhull;
 
 // default hullmins
@@ -66,34 +64,15 @@ can just be stored out and get a proper hull_t structure.
 */
 void PM_InitBoxHull( void )
 {
-	int	i, side;
+	int	i;
 
-	pm_boxhull.clipnodes16 = pm_boxclipnodes16;
+	pm_boxhull.clipnodes16 = (mclipnode16_t *)box_clipnodes16;
 	pm_boxhull.planes = pm_boxplanes;
 	pm_boxhull.firstclipnode = 0;
 	pm_boxhull.lastclipnode = 5;
 
 	for( i = 0; i < 6; i++ )
 	{
-		pm_boxclipnodes16[i].planenum = i;
-		pm_boxclipnodes32[i].planenum = i;
-
-		side = i & 1;
-
-		pm_boxclipnodes16[i].children[side] = CONTENTS_EMPTY;
-		pm_boxclipnodes32[i].children[side] = CONTENTS_EMPTY;
-
-		if( i != 5 )
-		{
-			pm_boxclipnodes16[i].children[side^1] = i + 1;
-			pm_boxclipnodes32[i].children[side^1] = i + 1;
-		}
-		else
-		{
-			pm_boxclipnodes16[i].children[side^1] = CONTENTS_SOLID;
-			pm_boxclipnodes32[i].children[side^1] = i + 1;
-		}
-
 		pm_boxplanes[i].type = i>>1;
 		pm_boxplanes[i].normal[i>>1] = 1.0f;
 		pm_boxplanes[i].signbits = 0;
@@ -119,9 +98,9 @@ static hull_t *PM_HullForBox( const vec3_t mins, const vec3_t maxs )
 	pm_boxplanes[5].dist = mins[2];
 
 	if( world.version == QBSP2_VERSION )
-		pm_boxhull.clipnodes32 = pm_boxclipnodes32;
+		pm_boxhull.clipnodes32 = (mclipnode32_t *)box_clipnodes32;
 	else
-		pm_boxhull.clipnodes16 = pm_boxclipnodes16;
+		pm_boxhull.clipnodes16 = (mclipnode16_t *)box_clipnodes16;
 
 	return &pm_boxhull;
 }

--- a/engine/edict.h
+++ b/engine/edict.h
@@ -16,11 +16,8 @@
 #ifndef EDICT_H
 #define EDICT_H
 
-#ifdef SUPPORT_BSP2_FORMAT
-#define MAX_ENT_LEAFS	24		// Orignally was 16
-#else
-#define MAX_ENT_LEAFS	48
-#endif
+#define MAX_ENT_LEAFS_32	24		// Orignally was 16
+#define MAX_ENT_LEAFS_16	48
 
 #include "progdefs.h"
 
@@ -33,11 +30,12 @@ struct edict_s
 	int		headnode;		// -1 to use normal leaf check
 
 	int		num_leafs;
-#ifdef SUPPORT_BSP2_FORMAT
-	int		leafnums[MAX_ENT_LEAFS];
-#else
-	short		leafnums[MAX_ENT_LEAFS];
-#endif
+	union
+	{
+		int   leafnums32[MAX_ENT_LEAFS_32];
+		short leafnums16[MAX_ENT_LEAFS_16];
+	};
+
 	float		freetime;		// sv.time when the object was freed
 
 	void*		pvPrivateData;	// Alloced and freed by engine, used by DLLs

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -80,6 +80,7 @@ GNU General Public License for more details.
 #define MODEL_LIQUID		BIT( 2 )	// model has only point hull
 #define MODEL_TRANSPARENT		BIT( 3 )	// have transparent surfaces
 #define MODEL_COLORED_LIGHTING	BIT( 4 )	// lightmaps stored as RGB
+
 #define MODEL_WORLD			BIT( 29 )	// it's a worldmodel
 #define MODEL_CLIENT		BIT( 30 )	// client sprite
 

--- a/engine/server/server.h
+++ b/engine/server/server.h
@@ -67,6 +67,8 @@ extern int SV_UPDATE_BACKUP;
 #define MAX_PUSHED_ENTS	256
 #define MAX_VIEWENTS	128
 
+#define MAX_ENT_LEAFS( ext ) (( ext ) ? MAX_ENT_LEAFS_32 : MAX_ENT_LEAFS_16 )
+
 #define FCL_RESEND_USERINFO	BIT( 0 )
 #define FCL_RESEND_MOVEVARS	BIT( 1 )
 #define FCL_SKIP_NET_MESSAGE	BIT( 2 )

--- a/engine/server/sv_world.c
+++ b/engine/server/sv_world.c
@@ -40,9 +40,10 @@ HULL BOXES
 ===============================================================================
 */
 
-static hull_t	box_hull;
-static mclipnode_t	box_clipnodes[6];
-static mplane_t	box_planes[6];
+static hull_t        box_hull;
+static mclipnode16_t box_clipnodes16[6];
+static mclipnode32_t box_clipnodes32[6];
+static mplane_t      box_planes[6];
 
 /*
 ===================
@@ -56,20 +57,31 @@ static void SV_InitBoxHull( void )
 {
 	int	i, side;
 
-	box_hull.clipnodes = box_clipnodes;
+	box_hull.clipnodes16 = box_clipnodes16;
 	box_hull.planes = box_planes;
 	box_hull.firstclipnode = 0;
 	box_hull.lastclipnode = 5;
 
 	for( i = 0; i < 6; i++ )
 	{
-		box_clipnodes[i].planenum = i;
+		box_clipnodes16[i].planenum = i;
+		box_clipnodes32[i].planenum = i;
 
 		side = i & 1;
 
-		box_clipnodes[i].children[side] = CONTENTS_EMPTY;
-		if( i != 5 ) box_clipnodes[i].children[side^1] = i + 1;
-		else box_clipnodes[i].children[side^1] = CONTENTS_SOLID;
+		box_clipnodes16[i].children[side] = CONTENTS_EMPTY;
+		box_clipnodes32[i].children[side] = CONTENTS_EMPTY;
+
+		if( i != 5 )
+		{
+			box_clipnodes16[i].children[side^1] = i + 1;
+			box_clipnodes32[i].children[side^1] = i + 1;
+		}
+		else
+		{
+			box_clipnodes16[i].children[side^1] = CONTENTS_SOLID;
+			box_clipnodes32[i].children[side^1] = CONTENTS_SOLID;
+		}
 
 		box_planes[i].type = i>>1;
 		box_planes[i].normal[i>>1] = 1;
@@ -166,6 +178,11 @@ static hull_t *SV_HullForBox( const vec3_t mins, const vec3_t maxs )
 	box_planes[3].dist = mins[1];
 	box_planes[4].dist = maxs[2];
 	box_planes[5].dist = mins[2];
+
+	if( world.version == QBSP2_VERSION )
+		box_hull.clipnodes32 = box_clipnodes32;
+	else
+		box_hull.clipnodes16 = box_clipnodes16;
 
 	return &box_hull;
 }

--- a/engine/server/sv_world.c
+++ b/engine/server/sv_world.c
@@ -41,8 +41,6 @@ HULL BOXES
 */
 
 static hull_t        box_hull;
-static mclipnode16_t box_clipnodes16[6];
-static mclipnode32_t box_clipnodes32[6];
 static mplane_t      box_planes[6];
 
 /*
@@ -55,34 +53,15 @@ can just be stored out and get a proper hull_t structure.
 */
 static void SV_InitBoxHull( void )
 {
-	int	i, side;
+	int	i;
 
-	box_hull.clipnodes16 = box_clipnodes16;
+	box_hull.clipnodes16 = (mclipnode16_t *)box_clipnodes16;
 	box_hull.planes = box_planes;
 	box_hull.firstclipnode = 0;
 	box_hull.lastclipnode = 5;
 
 	for( i = 0; i < 6; i++ )
 	{
-		box_clipnodes16[i].planenum = i;
-		box_clipnodes32[i].planenum = i;
-
-		side = i & 1;
-
-		box_clipnodes16[i].children[side] = CONTENTS_EMPTY;
-		box_clipnodes32[i].children[side] = CONTENTS_EMPTY;
-
-		if( i != 5 )
-		{
-			box_clipnodes16[i].children[side^1] = i + 1;
-			box_clipnodes32[i].children[side^1] = i + 1;
-		}
-		else
-		{
-			box_clipnodes16[i].children[side^1] = CONTENTS_SOLID;
-			box_clipnodes32[i].children[side^1] = CONTENTS_SOLID;
-		}
-
 		box_planes[i].type = i>>1;
 		box_planes[i].normal[i>>1] = 1;
 		box_planes[i].signbits = 0;
@@ -180,9 +159,9 @@ static hull_t *SV_HullForBox( const vec3_t mins, const vec3_t maxs )
 	box_planes[5].dist = mins[2];
 
 	if( world.version == QBSP2_VERSION )
-		box_hull.clipnodes32 = box_clipnodes32;
+		box_hull.clipnodes32 = (mclipnode32_t *)box_clipnodes32;
 	else
-		box_hull.clipnodes16 = box_clipnodes16;
+		box_hull.clipnodes16 = (mclipnode16_t *)box_clipnodes16;
 
 	return &box_hull;
 }

--- a/ref/gl/gl_decals.c
+++ b/ref/gl/gl_decals.c
@@ -670,10 +670,14 @@ static void R_DecalNodeSurfaces( model_t *model, mnode_t *node, decalinfo_t *dec
 	// iterate over all surfaces in the node
 	msurface_t	*surf;
 	int		i;
+	int firstsurface, numsurfaces;
 
-	surf = model->surfaces + node->firstsurface;
+	firstsurface = node_firstsurface( node, model );
+	numsurfaces  = node_numsurfaces( node, model );
 
-	for( i = 0; i < node->numsurfaces; i++, surf++ )
+	surf = model->surfaces + firstsurface;
+
+	for( i = 0; i < numsurfaces; i++, surf++ )
 	{
 		// never apply decals on the water or sky surfaces
 		if( surf->flags & (SURF_DRAWTURB|SURF_DRAWSKY|SURF_CONVEYOR))
@@ -695,6 +699,7 @@ static void R_DecalNode( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 {
 	mplane_t	*splitplane;
 	float	dist;
+	mnode_t *children[2];
 
 	Assert( node != NULL );
 
@@ -706,6 +711,7 @@ static void R_DecalNode( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 
 	splitplane = node->plane;
 	dist = DotProduct( decalinfo->m_Position, splitplane->normal ) - splitplane->dist;
+	node_children( children, node, model );
 
 	// This is arbitrarily set to 10 right now. In an ideal world we'd have the
 	// exact surface but we don't so, this tells me which planes are "sort of
@@ -717,19 +723,19 @@ static void R_DecalNode( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 	// have a surface normal
 	if( dist > decalinfo->m_Size )
 	{
-		R_DecalNode( model, node->children[0], decalinfo );
+		R_DecalNode( model, children[0], decalinfo );
 	}
 	else if( dist < -decalinfo->m_Size )
 	{
-		R_DecalNode( model, node->children[1], decalinfo );
+		R_DecalNode( model, children[1], decalinfo );
 	}
 	else
 	{
 		if( dist < DECAL_DISTANCE && dist > -DECAL_DISTANCE )
 			R_DecalNodeSurfaces( model, node, decalinfo );
 
-		R_DecalNode( model, node->children[0], decalinfo );
-		R_DecalNode( model, node->children[1], decalinfo );
+		R_DecalNode( model, children[0], decalinfo );
+		R_DecalNode( model, children[1], decalinfo );
 	}
 }
 

--- a/ref/gl/gl_rlight.c
+++ b/ref/gl/gl_rlight.c
@@ -104,27 +104,33 @@ void R_MarkLights( dlight_t *light, int bit, mnode_t *node )
 	float		dist;
 	msurface_t	*surf;
 	int		i;
+	mnode_t *children[2];
+	int firstsurface, numsurfaces;
 
 	if( !node || node->contents < 0 )
 		return;
 
 	dist = PlaneDiff( light->origin, node->plane );
 
+	node_children( children, node, RI.currentmodel );
+	firstsurface = node_firstsurface( node, RI.currentmodel );
+	numsurfaces = node_numsurfaces( node, RI.currentmodel );
+
 	if( dist > light->radius )
 	{
-		R_MarkLights( light, bit, node->children[0] );
+		R_MarkLights( light, bit, children[0] );
 		return;
 	}
 	if( dist < -light->radius )
 	{
-		R_MarkLights( light, bit, node->children[1] );
+		R_MarkLights( light, bit, children[1] );
 		return;
 	}
 
 	// mark the polygons
-	surf = RI.currentmodel->surfaces + node->firstsurface;
+	surf = RI.currentmodel->surfaces + firstsurface;
 
-	for( i = 0; i < node->numsurfaces; i++, surf++ )
+	for( i = 0; i < numsurfaces; i++, surf++ )
 	{
 		if( !BoundsAndSphereIntersect( surf->info->mins, surf->info->maxs, light->origin, light->radius ))
 			continue;	// no intersection
@@ -137,8 +143,8 @@ void R_MarkLights( dlight_t *light, int bit, mnode_t *node )
 		surf->dlightbits |= bit;
 	}
 
-	R_MarkLights( light, bit, node->children[0] );
-	R_MarkLights( light, bit, node->children[1] );
+	R_MarkLights( light, bit, children[0] );
+	R_MarkLights( light, bit, children[1] );
 }
 
 /*
@@ -202,6 +208,8 @@ static qboolean R_RecursiveLightPoint( model_t *model, mnode_t *node, float p1f,
 	mtexinfo_t	*tex;
 	matrix3x4		tbn;
 	vec3_t		mid;
+	mnode_t *children[2];
+	int firstsurface, numsurfaces;
 
 	// didn't hit anything
 	if( !node || node->contents < 0 )
@@ -210,13 +218,17 @@ static qboolean R_RecursiveLightPoint( model_t *model, mnode_t *node, float p1f,
 		return false;
 	}
 
+	node_children( children, node, model );
+	firstsurface = node_firstsurface( node, model );
+	numsurfaces = node_numsurfaces( node, model );
+
 	// calculate mid point
 	front = PlaneDiff( start, node->plane );
 	back = PlaneDiff( end, node->plane );
 
 	side = front < 0;
 	if(( back < 0 ) == side )
-		return R_RecursiveLightPoint( model, node->children[side], p1f, p2f, cv, start, end );
+		return R_RecursiveLightPoint( model, children[side], p1f, p2f, cv, start, end );
 
 	frac = front / ( front - back );
 
@@ -224,7 +236,7 @@ static qboolean R_RecursiveLightPoint( model_t *model, mnode_t *node, float p1f,
 	midf = p1f + ( p2f - p1f ) * frac;
 
 	// co down front side
-	if( R_RecursiveLightPoint( model, node->children[side], p1f, midf, cv, start, mid ))
+	if( R_RecursiveLightPoint( model, children[side], p1f, midf, cv, start, mid ))
 		return true; // hit something
 
 	if(( back < 0 ) == side )
@@ -234,10 +246,10 @@ static qboolean R_RecursiveLightPoint( model_t *model, mnode_t *node, float p1f,
 	}
 
 	// check for impact on this node
-	surf = model->surfaces + node->firstsurface;
+	surf = model->surfaces + firstsurface;
 	VectorCopy( mid, g_trace_lightspot );
 
-	for( i = 0; i < node->numsurfaces; i++, surf++ )
+	for( i = 0; i < numsurfaces; i++, surf++ )
 	{
 		int	smax, tmax;
 
@@ -326,7 +338,7 @@ static qboolean R_RecursiveLightPoint( model_t *model, mnode_t *node, float p1f,
 	}
 
 	// go down back side
-	return R_RecursiveLightPoint( model, node->children[!side], midf, p2f, cv, mid, end );
+	return R_RecursiveLightPoint( model, children[!side], midf, p2f, cv, mid, end );
 }
 
 /*

--- a/ref/gl/gl_rmain.c
+++ b/ref/gl/gl_rmain.c
@@ -600,6 +600,7 @@ watertexture to grab fog values from it
 static gl_texture_t *R_RecursiveFindWaterTexture( const mnode_t *node, const mnode_t *ignore, qboolean down )
 {
 	gl_texture_t *tex = NULL;
+	mnode_t *children[2];
 
 	// assure the initial node is not null
 	// we could check it here, but we would rather check it
@@ -637,15 +638,17 @@ static gl_texture_t *R_RecursiveFindWaterTexture( const mnode_t *node, const mno
 
 	// this is a regular node
 	// traverse children
-	if( node->children[0] && ( node->children[0] != ignore ))
+	node_children( children, node, WORLDMODEL );
+
+	if( children[0] && ( children[0] != ignore ))
 	{
-		tex = R_RecursiveFindWaterTexture( node->children[0], node, true );
+		tex = R_RecursiveFindWaterTexture( children[0], node, true );
 		if( tex ) return tex;
 	}
 
-	if( node->children[1] && ( node->children[1] != ignore ))
+	if( children[1] && ( children[1] != ignore ))
 	{
-		tex = R_RecursiveFindWaterTexture( node->children[1], node, true );
+		tex = R_RecursiveFindWaterTexture( children[1], node, true );
 		if( tex )	return tex;
 	}
 

--- a/ref/gl/gl_rsurf.c
+++ b/ref/gl/gl_rsurf.c
@@ -125,12 +125,25 @@ static void R_TextureCoord( const vec3_t v, const msurface_t *surf, vec2_t coord
 static void R_GetEdgePosition( const model_t *mod, const msurface_t *fa, int i, vec3_t vec )
 {
 	const int lindex = mod->surfedges[fa->firstedge + i];
-	const medge_t *pedges = mod->edges;
 
-	if( lindex > 0 )
-		VectorCopy( mod->vertexes[pedges[lindex].v[0]].position, vec );
+	if( tr.world->version == QBSP2_VERSION )
+	{
+		const medge32_t *pedges = mod->edges32;
+
+		if( lindex > 0 )
+			VectorCopy( mod->vertexes[pedges[lindex].v[0]].position, vec );
+		else
+			VectorCopy( mod->vertexes[pedges[-lindex].v[1]].position, vec );
+	}
 	else
-		VectorCopy( mod->vertexes[pedges[-lindex].v[1]].position, vec );
+	{
+		const medge16_t *pedges = mod->edges16;
+
+		if( lindex > 0 )
+			VectorCopy( mod->vertexes[pedges[lindex].v[0]].position, vec );
+		else
+			VectorCopy( mod->vertexes[pedges[-lindex].v[1]].position, vec );
+	}
 }
 
 static void BoundPoly( int numverts, float *verts, vec3_t mins, vec3_t maxs )

--- a/ref/soft/r_bsp.c
+++ b/ref/soft/r_bsp.c
@@ -356,13 +356,13 @@ void R_DrawSolidClippedSubmodelPolygons( model_t *pmodel, mnode_t *topnode )
 	mplane_t   *pplane;
 	mvertex_t  bverts[MAX_BMODEL_VERTS];
 	bedge_t    bedges[MAX_BMODEL_EDGES], *pbedge;
-	medge_t    *pedge, *pedges;
+	medge16_t  *pedge, *pedges;
 
 // FIXME: use bounding-box-based frustum clipping info?
 
 	psurf = &pmodel->surfaces[pmodel->firstmodelsurface];
 	numsurfaces = pmodel->nummodelsurfaces;
-	pedges = pmodel->edges;
+	pedges = pmodel->edges16;
 
 	for( i = 0; i < numsurfaces; i++, psurf++ )
 	{

--- a/ref/soft/r_decals.c
+++ b/ref/soft/r_decals.c
@@ -679,23 +679,24 @@ static void R_DecalSurface( msurface_t *surf, decalinfo_t *decalinfo )
 static void R_DecalNodeSurfaces( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 {
 	// iterate over all surfaces in the node
-	msurface_t *surf;
-	int        i;
+	msurface_t	*surf;
+	int		i;
+	int firstsurface, numsurfaces;
 
-	surf = model->surfaces + node->firstsurface;
+	firstsurface = node_firstsurface( node, model );
+	numsurfaces  = node_numsurfaces( node, model );
 
-	for( i = 0; i < node->numsurfaces; i++, surf++ )
+	surf = model->surfaces + firstsurface;
+
+	for( i = 0; i < numsurfaces; i++, surf++ )
 	{
 		// never apply decals on the water or sky surfaces
-		if( surf->flags & ( SURF_DRAWTURB | SURF_DRAWSKY | SURF_CONVEYOR ))
+		if( surf->flags & (SURF_DRAWTURB|SURF_DRAWSKY|SURF_CONVEYOR))
 			continue;
-
-		// we can implement alpha testing without stencil
-		// if( surf->flags & SURF_TRANSPARENT && !glState.stencilEnabled )
-		// continue;
 
 		R_DecalSurface( surf, decalinfo );
 	}
+
 }
 
 // -----------------------------------------------------------------------------
@@ -707,6 +708,7 @@ static void R_DecalNode( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 {
 	mplane_t *splitplane;
 	float    dist;
+	mnode_t  *children[2];
 
 	Assert( node != NULL );
 
@@ -718,6 +720,7 @@ static void R_DecalNode( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 
 	splitplane = node->plane;
 	dist = DotProduct( decalinfo->m_Position, splitplane->normal ) - splitplane->dist;
+	node_children( children, node, model );
 
 	// This is arbitrarily set to 10 right now. In an ideal world we'd have the
 	// exact surface but we don't so, this tells me which planes are "sort of
@@ -729,19 +732,19 @@ static void R_DecalNode( model_t *model, mnode_t *node, decalinfo_t *decalinfo )
 	// have a surface normal
 	if( dist > decalinfo->m_Size )
 	{
-		R_DecalNode( model, node->children[0], decalinfo );
+		R_DecalNode( model, children[0], decalinfo );
 	}
 	else if( dist < -decalinfo->m_Size )
 	{
-		R_DecalNode( model, node->children[1], decalinfo );
+		R_DecalNode( model, children[1], decalinfo );
 	}
 	else
 	{
 		if( dist < DECAL_DISTANCE && dist > -DECAL_DISTANCE )
 			R_DecalNodeSurfaces( model, node, decalinfo );
 
-		R_DecalNode( model, node->children[0], decalinfo );
-		R_DecalNode( model, node->children[1], decalinfo );
+		R_DecalNode( model, children[0], decalinfo );
+		R_DecalNode( model, children[1], decalinfo );
 	}
 }
 

--- a/ref/soft/r_local.h
+++ b/ref/soft/r_local.h
@@ -933,7 +933,7 @@ typedef struct edge_s
 	unsigned short surfs[2];
 	struct edge_s  *nextremove;
 	float          nearzi;
-	medge_t        *owner;
+	medge16_t      *owner;
 } edge_t;
 
 

--- a/ref/soft/r_main.c
+++ b/ref/soft/r_main.c
@@ -524,6 +524,7 @@ watertexture to grab fog values from it
 static image_t *R_RecursiveFindWaterTexture( const mnode_t *node, const mnode_t *ignore, qboolean down )
 {
 	image_t *tex = NULL;
+	mnode_t *children[2];
 
 	// assure the initial node is not null
 	// we could check it here, but we would rather check it
@@ -561,18 +562,18 @@ static image_t *R_RecursiveFindWaterTexture( const mnode_t *node, const mnode_t 
 
 	// this is a regular node
 	// traverse children
-	if( node->children[0] && ( node->children[0] != ignore ))
+	node_children( children, node, WORLDMODEL );
+
+	if( children[0] && ( children[0] != ignore ))
 	{
-		tex = R_RecursiveFindWaterTexture( node->children[0], node, true );
-		if( tex )
-			return tex;
+		tex = R_RecursiveFindWaterTexture( children[0], node, true );
+		if( tex ) return tex;
 	}
 
-	if( node->children[1] && ( node->children[1] != ignore ))
+	if( children[1] && ( children[1] != ignore ))
 	{
-		tex = R_RecursiveFindWaterTexture( node->children[1], node, true );
-		if( tex )
-			return tex;
+		tex = R_RecursiveFindWaterTexture( children[1], node, true );
+		if( tex )	return tex;
 	}
 
 	// for down recursion, return immediately
@@ -796,9 +797,9 @@ static mnode_t *R_FindTopnode( vec3_t mins, vec3_t maxs )
 
 		// not split yet; recurse down the contacted side
 		if( sides & 1 )
-			node = node->children[0];
+			node = node_child( node, 0, WORLDMODEL );
 		else
-			node = node->children[1];
+			node = node_child( node, 1, WORLDMODEL );
 	}
 }
 

--- a/ref/soft/r_main.c
+++ b/ref/soft/r_main.c
@@ -1393,6 +1393,12 @@ void GAME_EXPORT R_NewMap( void )
 	R_ClearDecals(); // clear all level decals
 	R_StudioResetPlayerModels();
 
+	if( FBitSet( world->flags, MODEL_QBSP2 ))
+	{
+		gEngfuncs.Host_Error( "Sorry, ref_soft can't load maps in BSP2 format.\n" );
+		return;
+	}
+
 	r_cnumsurfs = sw_maxsurfs.value;
 
 	if( r_cnumsurfs <= MINSURFACES )

--- a/ref/soft/r_rast.c
+++ b/ref/soft/r_rast.c
@@ -37,7 +37,7 @@ int             c_faceclip;                                             // numbe
 clipplane_t     *entity_clipplanes;
 clipplane_t     world_clipplanes[16];
 
-medge_t         *r_pedge;
+medge16_t       *r_pedge;
 
 qboolean        r_leftclipped, r_rightclipped;
 static qboolean makeleftedge, makerightedge;
@@ -68,7 +68,7 @@ msurface_t *r_skyfaces;
 mplane_t   r_skyplanes[6];
 mtexinfo_t r_skytexinfo[6];
 mvertex_t  *r_skyverts;
-medge_t    *r_skyedges;
+medge16_t  *r_skyedges;
 int        *r_skysurfedges;
 
 // I just copied this data from a box map...
@@ -438,7 +438,7 @@ void R_RenderFace( msurface_t *fa, int clipflags )
 	mplane_t    *pplane;
 	float       distinv;
 	vec3_t      p_normal;
-	medge_t     *pedges, tedge;
+	medge16_t   *pedges, tedge;
 	clipplane_t *pclip;
 
 	// translucent surfaces are not drawn by the edge renderer
@@ -490,7 +490,7 @@ void R_RenderFace( msurface_t *fa, int clipflags )
 	r_nearzi = 0;
 	r_nearzionly = false;
 	makeleftedge = makerightedge = false;
-	pedges = RI.currentmodel->edges;
+	pedges = RI.currentmodel->edges16;
 	r_lastvertvalid = false;
 
 	for( i = 0; i < fa->numedges; i++ )
@@ -560,7 +560,7 @@ void R_RenderFace( msurface_t *fa, int clipflags )
 				else
 				{
 					// it's cached if the cached edge is valid and is owned
-					// by this medge_t
+					// by this medge16_t
 					if((((uintptr_t)edge_p - (uintptr_t)r_edges )
 					    > r_pedge->cachededgeoffset )
 					   && (((edge_t *)((uintptr_t)r_edges
@@ -651,7 +651,7 @@ void R_RenderBmodelFace( bedge_t *pedges, msurface_t *psurf )
 	mplane_t    *pplane;
 	float       distinv;
 	vec3_t      p_normal;
-	medge_t     tedge;
+	medge16_t   tedge;
 	clipplane_t *pclip;
 
 	/*if (psurf->texinfo->flags & (SURF_TRANS33|SURF_TRANS66))

--- a/wscript
+++ b/wscript
@@ -91,7 +91,7 @@ SUBDIRS = [
 	Subproject('3rdparty/gl-wes-v2',    lambda x: not x.env.DEDICATED and x.env.GLWES),
 	Subproject('3rdparty/gl4es',        lambda x: not x.env.DEDICATED and x.env.GL4ES),
 	Subproject('ref/gl',                lambda x: not x.env.DEDICATED and (x.env.GL or x.env.NANOGL or x.env.GLWES or x.env.GL4ES)),
-	Subproject('ref/soft',              lambda x: not x.env.DEDICATED and not x.env.SUPPORT_BSP2_FORMAT and x.env.SOFT),
+	Subproject('ref/soft',              lambda x: not x.env.DEDICATED and x.env.SOFT),
 	Subproject('ref/null',              lambda x: not x.env.DEDICATED and x.env.NULL),
 	Subproject('3rdparty/bzip2',        lambda x: not x.env.DEDICATED and not x.env.HAVE_SYSTEM_BZ2),
 	Subproject('3rdparty/opus',         lambda x: not x.env.DEDICATED and not x.env.HAVE_SYSTEM_OPUS),
@@ -147,9 +147,6 @@ def options(opt):
 
 	grp.add_option('--enable-bundled-deps', action = 'store_true', dest = 'BUILD_BUNDLED_DEPS', default = False,
 		help = 'prefer to build bundled dependencies (like opus) instead of relying on system provided')
-
-	grp.add_option('--enable-bsp2', action = 'store_true', dest = 'SUPPORT_BSP2_FORMAT', default = False,
-		help = 'build engine and renderers with BSP2 map support(recommended for Quake, breaks compatibility!) [default: %(default)s]')
 
 	grp.add_option('--enable-hl25-extended-structs', action = 'store_true', dest = 'SUPPORT_HL25_EXTENDED_STRUCTS', default = False,
 		help = 'build engine and renderers with HL25 extended structs compatibility (might be required for some mods) [default: %(default)s]')
@@ -395,9 +392,7 @@ def configure(conf):
 	conf.env.ENABLE_XAR    = conf.options.ENABLE_XAR
 	conf.env.ENABLE_FUZZER = conf.options.ENABLE_FUZZER
 	conf.env.DEDICATED     = conf.options.DEDICATED
-	conf.env.SUPPORT_BSP2_FORMAT = conf.options.SUPPORT_BSP2_FORMAT
 
-	conf.define_cond('SUPPORT_BSP2_FORMAT', conf.options.SUPPORT_BSP2_FORMAT)
 	conf.define_cond('SUPPORT_HL25_EXTENDED_STRUCTS', conf.options.SUPPORT_HL25_EXTENDED_STRUCTS)
 
 	# disable game_launch compiling on platform where it's not needed


### PR DESCRIPTION
This is tough. We basically split all extended structures into two versions, one with 16-bit fields for Q1BSP and HLBSP (including BSP30ext) and another with 32-bit fields for QBSP2.

What it does is allow us to use the same engine binary for all supported formats and letting custom renderers, like PrimeXT, finally support QBSP2 alongside classic BSP formats.

What it doesn't, however, allow is to re-use existing custom renderers from Half-Life 1. Most, if not all of them, will probably crash after reading world `model_t` and getting wrong offsets and pointers when QBSP2 map is loaded.

Running a simple benchmark didn't show any significant drop in performance.