### PR TITLE
Modifications for Mac App Bundle

### DIFF
--- a/engine/common/filesystem_engine.c
+++ b/engine/common/filesystem_engine.c
@@ -186,7 +186,11 @@ static qboolean FS_DetermineRootDirectory( char *out, size_t size )
 	Sys_Error( "couldn't find Xash3D data directory" );
 	return false;
 #elif ( XASH_SDL == 2 ) && !XASH_NSWITCH // GetBasePath not impl'd in switch-sdl2
+#if XASH_APPLE
+	path = SDL_GetPrefPath(NULL, "Xash3D");
+#else
 	path = SDL_GetBasePath();
+#endif
 	if( path != NULL )
 	{
 		Q_strncpy( out, path, size );

--- a/engine/platform/sdl/sys_sdl.c
+++ b/engine/platform/sdl/sys_sdl.c
@@ -80,6 +80,14 @@ static void SDLCALL SDLash_LogOutputFunction( void *userdata, int category, SDL_
 
 void SDLash_Init( void )
 {
+#if XASH_APPLE
+	char buf[MAX_VA_STRING];
+	char *path;
+	path = SDL_GetBasePath();
+	Q_snprintf( buf, sizeof( buf ), "%svalve/extras.pk3", path );
+	setenv("XASH3D_EXTRAS_PAK1", buf, true);
+#endif
+
 	SDL_LogSetOutputFunction( SDLash_LogOutputFunction, NULL );
 
 	if( host_developer.value >= 2 )

--- a/scripts/waifulib/sdl2.py
+++ b/scripts/waifulib/sdl2.py
@@ -23,6 +23,9 @@ def options(opt):
 	grp.add_option('--skip-sdl2-sanity-check', action='store_false', default = True, dest='SDL_SANITY_CHECK',
 		help = 'skip checking SDL sanity [default: %(default)s]')
 
+	grp.add_option('--sdl-use-pkgconfig', action='store_true', default = False, dest='SDL_USE_PKGCONFIG',
+		help = 'force use of pkg-config to find sdl [default: %(default)s]')
+
 def my_dirname(path):
 	# really dumb, will not work with /path/framework//, but still enough
 	if path[-1] == '/':
@@ -70,7 +73,7 @@ def configure(conf):
 
 	if conf.options.SDL_PATH:
 		sdl2_configure_path(conf, conf.options.SDL_PATH, libname)
-	elif conf.env.DEST_OS == 'darwin':
+	elif conf.env.DEST_OS == 'darwin' and conf.options.SDL_USE_PKGCONFIG == False:
 		sdl2_configure_path(conf, '/Library/Frameworks/%s.framework' % libname, libname)
 	else:
 		try:


### PR DESCRIPTION
- Looks for game data in SDL pref path (Application Support)
- Sets XASH3D_EXTRAS_PAK1 to SDL base path (Resources dir in App Bundle
- Added option to force search for SDL dylib via pkgconfig on Darwin instead of Framework (option for Mac Source Ports build process)