### PR TITLE
engine: platform: introduce for Platform_NanoSleep, to be used for better sleeping in between frames for lowering CPU usage

### DIFF
--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -698,17 +698,17 @@ static qboolean Host_Autosleep( double dt, double scale )
 		static double timewindow; // allocate a time window for sleeps
 		static int counter; // for debug
 		static double realsleeptime;
-		const double sleeptime = sleep * 0.001;
+		const double sleeptime = sleep * 0.000001;
 
 		if( dt < targetframetime * scale )
 		{
 			// if we have allocated time window, try to sleep
 			if( timewindow > realsleeptime )
 			{
-				// Platform_Sleep isn't guaranteed to sleep an exact amount of milliseconds
+				// Platform_Sleep isn't guaranteed to sleep an exact amount of microseconds
 				// so we measure the real sleep time and use it to decrease the window
 				double t1 = Sys_DoubleTime(), t2;
-				Platform_Sleep( sleep ); // in msec!
+				Platform_NanoSleep( sleep * 1000 ); // in usec!
 				t2 = Sys_DoubleTime();
 				realsleeptime = t2 - t1;
 

--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -1512,7 +1512,7 @@ static int NET_SendLong( netsrc_t sock, int net_socket, const char *buf, size_t 
 				total_sent += size;
 			len -= size;
 			packet_number++;
-			Platform_Sleep( 1 );
+			Platform_NanoSleep( 100 * 1000 );
 		}
 
 		return total_sent;

--- a/engine/platform/platform.h
+++ b/engine/platform/platform.h
@@ -70,6 +70,8 @@ void Android_Shutdown( void );
 #endif
 
 #if XASH_WIN32
+void Win32_Init( void );
+void Win32_Shutdown( void );
 void Wcon_CreateConsole( qboolean con_showalways );
 void Wcon_DestroyConsole( void );
 void Wcon_InitConsoleCommands( void );
@@ -124,6 +126,7 @@ static inline void Platform_Init( qboolean con_showalways, const char *basedir )
 #elif XASH_DOS
 	DOS_Init( );
 #elif XASH_WIN32
+	Win32_Init( );
 	Wcon_CreateConsole( con_showalways );
 #elif XASH_LINUX
 	Linux_Init( );
@@ -140,6 +143,7 @@ static inline void Platform_Shutdown( void )
 	DOS_Shutdown( );
 #elif XASH_WIN32
 	Wcon_DestroyConsole( );
+	Win32_Shutdown( );
 #elif XASH_LINUX
 	Linux_Shutdown( );
 #endif
@@ -175,6 +179,37 @@ static inline void Platform_Sleep( int msec )
 	Sleep( msec );
 #else
 	// stub
+#endif
+}
+
+static inline qboolean Platform_NanoSleep( int nsec )
+{
+	// SDL2 doesn't have nanosleep, so use low-level functions here
+	// When this code will be ported to SDL3, use SDL_DelayNS
+#if XASH_POSIX
+	struct timespec ts = {
+		.tv_sec = 0,
+		.tv_nsec = nsec, // just don't put large numbers here
+	};
+	return nanosleep( &ts, NULL ) == 0;
+#elif XASH_WIN32
+	extern HANDLE g_waitable_timer;
+	const LARGE_INTEGER ts = { -nsec };
+
+	if( !g_waitable_timer )
+		return false;
+
+	if( !SetWaitableTimer( g_waitable_timer, &ts, 0, NULL, NULL, FALSE ))
+	{
+		CloseHandle( g_waitable_timer );
+		g_waitable_timer = 0;
+		return false;
+	}
+
+	if( WaitForSingleObject( g_waitable_timer, 1000 ) != WAIT_OBJECT_0 )
+		return false;
+
+	return true;
 #endif
 }
 

--- a/engine/platform/win32/sys_win.c
+++ b/engine/platform/win32/sys_win.c
@@ -79,10 +79,12 @@ void Win32_Shutdown( void )
 
 qboolean Win32_NanoSleep( int nsec )
 {
-	const LARGE_INTEGER ts = { -nsec };
+	LARGE_INTEGER ts;
 
 	if( !g_waitable_timer )
 		return false;
+
+	ts.QuadPart = { -nsec / 100 };
 
 	if( !SetWaitableTimer( g_waitable_timer, &ts, 0, NULL, NULL, FALSE ))
 	{


### PR DESCRIPTION
There were reports about high CPU usage with high framerates, especially on the servers.

As it seems, it might've been caused by insufficient accuracy of `Platform_Sleep`, which only accepts milliseconds. If we imagine game running at 500+ FPS, `Platform_Sleep` instantly becomes useless.

With this PR, `sleeptime` cvar resolution changes from milliseconds down to microseconds.