### PR TITLE
engine: client: lower the bandwidth test fragment sizes to 1400 and less, as using 64k, 32k and more is unreliable

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -1183,7 +1183,11 @@ Returns bandwidth test fragment size
 */
 static int CL_GetTestFragmentSize( void )
 {
-	const int fragmentSizes[CL_TEST_RETRIES] = { 64000, 32000, 10666, 5200, 1400 };
+	// const int fragmentSizes[CL_TEST_RETRIES] = { 64000, 32000, 10666, 5200, 1400 };
+
+	// it turns out, even if we pass the bandwidth test, it doesn't mean we can use such large fragments
+	// as a temporary solution, use smaller fragment sizes
+	const int fragmentSizes[CL_TEST_RETRIES] = { 1400, 1200, 1000, 800, 508 };
 	if( cls.connect_retry >= 0 && cls.connect_retry < CL_TEST_RETRIES )
 		return bound( FRAGMENT_MIN_SIZE, fragmentSizes[cls.connect_retry], FRAGMENT_MAX_SIZE );
 	else


### PR DESCRIPTION
Fixes #2060

Until we don't have a better way to determine path MTU, just lower the bandwidth test values.