### PR TITLE
engine: client: fix TE_BLOODSPRITE behaviour to GoldSrc

### DIFF
--- a/engine/client/cl_tent.c
+++ b/engine/client/cl_tent.c
@@ -955,7 +955,6 @@ void GAME_EXPORT R_BloodSprite( const vec3_t org, int colorIndex, int modelIndex
 				if( pTemp->entity.curstate.frame > 8.0f )
 					pTemp->entity.curstate.frame = pTemp->frameMax;
 
-				pTemp->entity.baseline.origin[2] += COM_RandomFloat( 4.0f, 16.0f ) * size;
 				pTemp->entity.angles[2] = COM_RandomFloat( 0.0f, 360.0f );
 				pTemp->bounceFactor	= 0.0f;
 			}


### PR DESCRIPTION
Right now when you land a headshot, enemy will launch blood so high since blood height are scaled with damage.
This is different from goldsrc.

Below tested using M3 in CSCZ for worst case scenario.

Before:
![before2](https://github.com/user-attachments/assets/0469e6a0-55dd-41a9-b678-caf12071ef5b)

After:
![after](https://github.com/user-attachments/assets/4d45e3d9-8e6d-48f9-98a7-41e6e73c2824)

GoldSrc:
![goldsrc](https://github.com/user-attachments/assets/5565d1fa-0649-493a-bcf7-6de21c0b9e01)
