### PR TITLE
Enabled touch controls by default for Nintendo Switch & PS Vita

### DIFF
--- a/common/defaults.h
+++ b/common/defaults.h
@@ -140,13 +140,13 @@ Default build-depended cvar and constant values
 
 // Platform overrides
 #if XASH_NSWITCH
-	#define DEFAULT_TOUCH_ENABLE "0"
+	#define DEFAULT_TOUCH_ENABLE "1"
 	#define DEFAULT_M_IGNORE     "1"
 	#define DEFAULT_MODE_WIDTH   1280
 	#define DEFAULT_MODE_HEIGHT  720
 	#define DEFAULT_ALLOWCONSOLE 1
 #elif XASH_PSVITA
-	#define DEFAULT_TOUCH_ENABLE "0"
+	#define DEFAULT_TOUCH_ENABLE "1"
 	#define DEFAULT_M_IGNORE     "1"
 	#define DEFAULT_MODE_WIDTH   960
 	#define DEFAULT_MODE_HEIGHT  544


### PR DESCRIPTION
Required for #2111