### PR TITLE
ref_api: R_GetWindowHandle method

### DIFF
--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -433,6 +433,8 @@ static const ref_api_t gEngfuncs =
 	&clgame.drawFuncs,
 
 	&g_fsapi,
+
+	R_GetWindowHandle,
 };
 
 static void R_UnloadProgs( void )

--- a/engine/platform/dos/vid_dos.c
+++ b/engine/platform/dos/vid_dos.c
@@ -543,12 +543,9 @@ qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *
 	return true;
 }
 
-window_handle_t R_GetWindowHandle( void )
+qboolean R_GetWindowHandle( void **handle, int type )
 {
-	window_handle_t handle;
-	handle.type = REF_WINDOW_TYPE_NONE;
-	handle.handle = NULL;
-	return handle;
+	return FALSE;
 }
 
 #endif

--- a/engine/platform/dos/vid_dos.c
+++ b/engine/platform/dos/vid_dos.c
@@ -543,9 +543,12 @@ qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *
 	return true;
 }
 
-window_handle_t *R_GetWindowHandle( void )
+window_handle_t R_GetWindowHandle( void )
 {
-	return NULL;
+	window_handle_t handle;
+	handle.type = REF_WINDOW_TYPE_NONE;
+	handle.handle = NULL;
+	return handle;
 }
 
 #endif

--- a/engine/platform/dos/vid_dos.c
+++ b/engine/platform/dos/vid_dos.c
@@ -543,4 +543,9 @@ qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *
 	return true;
 }
 
+window_handle_t *R_GetWindowHandle( void )
+{
+	return NULL;
+}
+
 #endif

--- a/engine/platform/linux/vid_fbdev.c
+++ b/engine/platform/linux/vid_fbdev.c
@@ -246,4 +246,9 @@ qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *
 	return true;
 }
 
+window_handle_t *R_GetWindowHandle( void )
+{
+	return NULL;
+}
+
 #endif

--- a/engine/platform/linux/vid_fbdev.c
+++ b/engine/platform/linux/vid_fbdev.c
@@ -246,9 +246,12 @@ qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *
 	return true;
 }
 
-window_handle_t *R_GetWindowHandle( void )
+window_handle_t R_GetWindowHandle( void )
 {
-	return NULL;
+	window_handle_t handle;
+	handle.type = REF_WINDOW_TYPE_NONE;
+	handle.handle = NULL;
+	return handle;
 }
 
 #endif

--- a/engine/platform/linux/vid_fbdev.c
+++ b/engine/platform/linux/vid_fbdev.c
@@ -246,12 +246,9 @@ qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *
 	return true;
 }
 
-window_handle_t R_GetWindowHandle( void )
+qboolean R_GetWindowHandle( void **handle, int type )
 {
-	window_handle_t handle;
-	handle.type = REF_WINDOW_TYPE_NONE;
-	handle.handle = NULL;
-	return handle;
+	return FALSE;
 }
 
 #endif

--- a/engine/platform/platform.h
+++ b/engine/platform/platform.h
@@ -312,21 +312,6 @@ typedef enum
 	rserr_unknown
 } rserr_t;
 
-enum
-{
-	REF_WINDOW_TYPE_NONE = 0, // NULL
-	REF_WINDOW_TYPE_WIN32 = 1, // HWND
-	REF_WINDOW_TYPE_X11 = 2, // Display*
-	REF_WINDOW_TYPE_WAYLAND = 3, // wl_display*
-	REF_WINDOW_TYPE_MACOS = 4, // NSWindow*
-};
-
-typedef struct window_handle_s
-{
-	int type;
-	void* handle;
-} window_handle_t;
-
 struct vidmode_s;
 typedef enum window_mode_e window_mode_t;
 // Window
@@ -345,7 +330,7 @@ void *SW_LockBuffer( void );
 void SW_UnlockBuffer( void );
 qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *r, uint *g, uint *b );
 void Platform_Minimize_f( void );
-window_handle_t R_GetWindowHandle( void );
+qboolean R_GetWindowHandle( void **handle, int type );
 
 //
 // in_evdev.c

--- a/engine/platform/platform.h
+++ b/engine/platform/platform.h
@@ -312,6 +312,20 @@ typedef enum
 	rserr_unknown
 } rserr_t;
 
+enum
+{
+	REF_WINDOW_TYPE_WIN32 = 1, // HWND
+	REF_WINDOW_TYPE_X11 = 2, // Display*
+	REF_WINDOW_TYPE_WAYLAND = 3, // wl_display*
+	REF_WINDOW_TYPE_MACOS = 4, // NSWindow*
+};
+
+typedef struct window_handle_s
+{
+	int type;
+	void* handle;
+} window_handle_t;
+
 struct vidmode_s;
 typedef enum window_mode_e window_mode_t;
 // Window
@@ -330,6 +344,7 @@ void *SW_LockBuffer( void );
 void SW_UnlockBuffer( void );
 qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *r, uint *g, uint *b );
 void Platform_Minimize_f( void );
+window_handle_t *R_GetWindowHandle( void );
 
 //
 // in_evdev.c

--- a/engine/platform/platform.h
+++ b/engine/platform/platform.h
@@ -314,6 +314,7 @@ typedef enum
 
 enum
 {
+	REF_WINDOW_TYPE_NONE = 0, // NULL
 	REF_WINDOW_TYPE_WIN32 = 1, // HWND
 	REF_WINDOW_TYPE_X11 = 2, // Display*
 	REF_WINDOW_TYPE_WAYLAND = 3, // wl_display*
@@ -344,7 +345,7 @@ void *SW_LockBuffer( void );
 void SW_UnlockBuffer( void );
 qboolean SW_CreateBuffer( int width, int height, uint *stride, uint *bpp, uint *r, uint *g, uint *b );
 void Platform_Minimize_f( void );
-window_handle_t *R_GetWindowHandle( void );
+window_handle_t R_GetWindowHandle( void );
 
 //
 // in_evdev.c

--- a/engine/platform/sdl1/vid_sdl1.c
+++ b/engine/platform/sdl1/vid_sdl1.c
@@ -513,12 +513,9 @@ qboolean VID_SetMode( void )
 	return true;
 }
 
-window_handle_t R_GetWindowHandle( void )
+qboolean R_GetWindowHandle( void **handle, int type )
 {
-	window_handle_t handle;
-	handle.type = REF_WINDOW_TYPE_NONE;
-	handle.handle = NULL;
-	return handle;
+	return FALSE;
 }
 
 /*

--- a/engine/platform/sdl1/vid_sdl1.c
+++ b/engine/platform/sdl1/vid_sdl1.c
@@ -513,9 +513,12 @@ qboolean VID_SetMode( void )
 	return true;
 }
 
-window_handle_t *R_GetWindowHandle( void )
+window_handle_t R_GetWindowHandle( void )
 {
-	return NULL;
+	window_handle_t handle;
+	handle.type = REF_WINDOW_TYPE_NONE;
+	handle.handle = NULL;
+	return handle;
 }
 
 /*

--- a/engine/platform/sdl1/vid_sdl1.c
+++ b/engine/platform/sdl1/vid_sdl1.c
@@ -513,6 +513,11 @@ qboolean VID_SetMode( void )
 	return true;
 }
 
+window_handle_t *R_GetWindowHandle( void )
+{
+	return NULL;
+}
+
 /*
 ==================
 R_Free_Video

--- a/engine/platform/sdl2/vid_sdl2.c
+++ b/engine/platform/sdl2/vid_sdl2.c
@@ -1165,30 +1165,33 @@ qboolean VID_SetMode( void )
 	return true;
 }
 
-window_handle_t *R_GetWindowHandle( void )
+window_handle_t R_GetWindowHandle( void )
 {
+	window_handle_t handle;
+	handle.type = REF_WINDOW_TYPE_NONE;
+	handle.handle = NULL;
+
 	SDL_SysWMinfo wmInfo;
     SDL_VERSION(&wmInfo.version);
 
     if (SDL_GetWindowWMInfo(host.hWnd, &wmInfo) != SDL_TRUE) {
-        return NULL;
+        return handle;
     }
 
-	window_handle_t *handle = malloc( sizeof( window_handle_t ) );
     #if defined(SDL_VIDEO_DRIVER_WINDOWS)
-        handle->type = REF_WINDOW_TYPE_WIN32;
-        handle->handle = (void*)wmInfo.info.win.window; // HWND
+        handle.type = REF_WINDOW_TYPE_WIN32;
+        handle.handle = (void*)wmInfo.info.win.window; // HWND
     #elif defined(SDL_VIDEO_DRIVER_COCOA)
-        handle->type = REF_WINDOW_TYPE_MACOS;
-        handle->handle = (void*)wmInfo.info.cocoa.window; // NSWindow*
+        handle.type = REF_WINDOW_TYPE_MACOS;
+        handle.handle = (void*)wmInfo.info.cocoa.window; // NSWindow*
     #elif defined(SDL_VIDEO_DRIVER_X11)
-        handle->type = REF_WINDOW_TYPE_X11;
-        handle->handle = (void*)(uintptr_t)wmInfo.info.x11.window; // X11 Window
+        handle.type = REF_WINDOW_TYPE_X11;
+        handle.handle = (void*)(uintptr_t)wmInfo.info.x11.window; // X11 Window
     #elif defined(SDL_VIDEO_DRIVER_WAYLAND)
-        handle->type = REF_WINDOW_TYPE_WAYLAND;
-        handle->handle = (void*)wmInfo.info.wl.surface; // wl_surface*
+        handle.type = REF_WINDOW_TYPE_WAYLAND;
+        handle.handle = (void*)wmInfo.info.wl.surface; // wl_surface*
     #else
-        return NULL;
+        return handle;
     #endif
 
 	return handle;

--- a/engine/platform/sdl2/vid_sdl2.c
+++ b/engine/platform/sdl2/vid_sdl2.c
@@ -13,6 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 */
 #include <SDL.h>
+#include <SDL_config.h>
 #include "common.h"
 #include "client.h"
 #include "vid_common.h"
@@ -1162,6 +1163,35 @@ qboolean VID_SetMode( void )
 	}
 
 	return true;
+}
+
+window_handle_t *R_GetWindowHandle( void )
+{
+	SDL_SysWMinfo wmInfo;
+    SDL_VERSION(&wmInfo.version);
+
+    if (SDL_GetWindowWMInfo(host.hWnd, &wmInfo) != SDL_TRUE) {
+        return NULL;
+    }
+
+	window_handle_t *handle = malloc( sizeof( window_handle_t ) );
+    #if defined(SDL_VIDEO_DRIVER_WINDOWS)
+        handle->type = REF_WINDOW_TYPE_WIN32;
+        handle->handle = (void*)wmInfo.info.win.window; // HWND
+    #elif defined(SDL_VIDEO_DRIVER_COCOA)
+        handle->type = REF_WINDOW_TYPE_MACOS;
+        handle->handle = (void*)wmInfo.info.cocoa.window; // NSWindow*
+    #elif defined(SDL_VIDEO_DRIVER_X11)
+        handle->type = REF_WINDOW_TYPE_X11;
+        handle->handle = (void*)(uintptr_t)wmInfo.info.x11.window; // X11 Window
+    #elif defined(SDL_VIDEO_DRIVER_WAYLAND)
+        handle->type = REF_WINDOW_TYPE_WAYLAND;
+        handle->handle = (void*)wmInfo.info.wl.surface; // wl_surface*
+    #else
+        return NULL;
+    #endif
+
+	return handle;
 }
 
 /*

--- a/engine/platform/sdl2/vid_sdl2.c
+++ b/engine/platform/sdl2/vid_sdl2.c
@@ -1165,36 +1165,52 @@ qboolean VID_SetMode( void )
 	return true;
 }
 
-window_handle_t R_GetWindowHandle( void )
+qboolean R_GetWindowHandle( void **handle, int type )
 {
-	window_handle_t handle;
-	handle.type = REF_WINDOW_TYPE_NONE;
-	handle.handle = NULL;
-
 	SDL_SysWMinfo wmInfo;
-    SDL_VERSION(&wmInfo.version);
+	SDL_VERSION( &wmInfo.version );
 
-    if (SDL_GetWindowWMInfo(host.hWnd, &wmInfo) != SDL_TRUE) {
-        return handle;
-    }
+	if ( SDL_GetWindowWMInfo( host.hWnd, &wmInfo ) != SDL_TRUE )
+	{
+		return FALSE;
+	}
 
-    #if defined(SDL_VIDEO_DRIVER_WINDOWS)
-        handle.type = REF_WINDOW_TYPE_WIN32;
-        handle.handle = (void*)wmInfo.info.win.window; // HWND
-    #elif defined(SDL_VIDEO_DRIVER_COCOA)
-        handle.type = REF_WINDOW_TYPE_MACOS;
-        handle.handle = (void*)wmInfo.info.cocoa.window; // NSWindow*
-    #elif defined(SDL_VIDEO_DRIVER_X11)
-        handle.type = REF_WINDOW_TYPE_X11;
-        handle.handle = (void*)(uintptr_t)wmInfo.info.x11.window; // X11 Window
-    #elif defined(SDL_VIDEO_DRIVER_WAYLAND)
-        handle.type = REF_WINDOW_TYPE_WAYLAND;
-        handle.handle = (void*)wmInfo.info.wl.surface; // wl_surface*
-    #else
-        return handle;
-    #endif
+	switch( type )
+	{
+		case REF_WINDOW_TYPE_WIN32:
+#ifdef SDL_VIDEO_DRIVER_WINDOWS
+			*handle = (void*)wmInfo.info.win.window; // HWND
+			return TRUE;
+#else
+			return FALSE;
+#endif
+		case REF_WINDOW_TYPE_MACOS:
+#ifdef SDL_VIDEO_DRIVER_COCOA
+			*handle = (void*)wmInfo.info.cocoa.window; // NSWindow*
+			return TRUE;
+#else
+			return FALSE;
+#endif
+		case REF_WINDOW_TYPE_X11:
+#ifdef SDL_VIDEO_DRIVER_X11
+			*handle = (void*)(uintptr_t)wmInfo.info.x11.window; // X11 Window
+			return TRUE;
+#else
+			return FALSE;
+#endif
+		case REF_WINDOW_TYPE_WAYLAND:
+#ifdef SDL_VIDEO_DRIVER_WAYLAND
+			*handle = (void*)wmInfo.info.wl.surface; // wl_surface*
+			return TRUE;
+#else
+			return FALSE;
+#endif
+		case REF_WINDOW_TYPE_SDL:
+			*handle = (void*)host.hWnd; // SDL_Window*
+			return TRUE;
+	}
 
-	return handle;
+	return FALSE;
 }
 
 /*

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -470,7 +470,7 @@ typedef struct ref_api_s
 	fs_api_t	*fsapi;
 
 	// for abstracting the engine's rendering
-	struct window_handle_t *(*R_GetWindowHandle)( void );
+	struct window_handle_t (*R_GetWindowHandle)( void );
 } ref_api_t;
 
 struct mip_s;

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -58,7 +58,7 @@ GNU General Public License for more details.
 //    Removed R_DrawTileClear and Mod_LoadMapSprite, as they're implemented on engine side
 //    Removed FillRGBABlend. Now FillRGBA accepts rendermode parameter.
 // 10. Added R_GetWindowHandle.
-#define REF_API_VERSION 10
+#define REF_API_VERSION 9
 
 #define TF_SKY		(TF_SKYSIDE|TF_NOMIPMAP|TF_ALLOW_NEAREST)
 #define TF_FONT		(TF_NOMIPMAP|TF_CLAMP|TF_ALLOW_NEAREST)
@@ -103,6 +103,15 @@ typedef enum
 	DEMO_XASH3D,
 	DEMO_QUAKE1
 } demo_mode;
+
+enum
+{
+	REF_WINDOW_TYPE_WIN32 = 1, // HWND
+	REF_WINDOW_TYPE_X11 = 2, // Display*
+	REF_WINDOW_TYPE_WAYLAND = 3, // wl_display*
+	REF_WINDOW_TYPE_MACOS = 4, // NSWindow*
+	REF_WINDOW_TYPE_SDL = 5, // SDL_Window*
+};
 
 typedef struct
 {
@@ -470,7 +479,7 @@ typedef struct ref_api_s
 	fs_api_t	*fsapi;
 
 	// for abstracting the engine's rendering
-	struct window_handle_t (*R_GetWindowHandle)( void );
+	qboolean (*R_GetWindowHandle)( void **handle, int type );
 } ref_api_t;
 
 struct mip_s;

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -467,6 +467,9 @@ typedef struct ref_api_s
 
 	// filesystem exports
 	fs_api_t	*fsapi;
+
+	// for abstracting the engine's rendering
+	struct window_handle_t *(*R_GetWindowHandle)( void );
 } ref_api_t;
 
 struct mip_s;

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -57,7 +57,8 @@ GNU General Public License for more details.
 //    CL_RunLightStyles now accepts lightstyles array.
 //    Removed R_DrawTileClear and Mod_LoadMapSprite, as they're implemented on engine side
 //    Removed FillRGBABlend. Now FillRGBA accepts rendermode parameter.
-#define REF_API_VERSION 9
+// 10. Added R_GetWindowHandle.
+#define REF_API_VERSION 10
 
 #define TF_SKY		(TF_SKYSIDE|TF_NOMIPMAP|TF_ALLOW_NEAREST)
 #define TF_FONT		(TF_NOMIPMAP|TF_CLAMP|TF_ALLOW_NEAREST)


### PR DESCRIPTION
### **Added `R_GetWindowHandle` to `ref_api`**  
- **Purpose**: Allows renderers to fetch the native window handle for direct integration (e.g., Vulkan/D3D/Metal).  
- **Returns**: Opaque pointer to the platform-specific handle (`HWND`, `NSWindow*`, `X11 Window`, etc.).  
- **Unsupported platforms**: Returns `NULL`
- **Supported platforms**: SDL2 only now (WIN32, X11, WAYLAND, MACOS)

```c 
// Usage example (renderer-side):  
window_handle_t window_handle = ref_api->R_GetWindowHandle();  
if (window_handle.type == 0) {  
    Com_Error(ERR_FATAL, "Window handle not supported on this platform");  
}  
// ... create surface/swapchain with the handle  
```  
