### PR TITLE
contributing: add a note about usage of LLM-based tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,8 @@
   Tags can be any: subsystem, simple feature name or even just a filename, without extension.
   Just keep them always same, it helps keep history clean and commit messages short.
 
+## LLM-based tools usage.
+
+While we wouldn't recommend using any LLM-based (also misleadingly called AI) tools, we understand that they are here to stay.
+
+Whether you're reporting bug or contributing the code, you take complete authorship and responsibility over provided content and the same rules will apply to you as for everybody else, so validate the bug report or the patch before sending it.


### PR DESCRIPTION
Now that Microsoft GitHub joined to shove LLM down our throats, I think it's time to make a note about it's usage.

So far, there is absolutely zero AI generated issues or PRs, so it seems declaring that responsibility lies on the contributor is the most safe option, i.e. sending hallucinated patches or reports might get contributor banned but if it's verified by them it's shouldn't a big difference from normal human-made contributions.