### PR TITLE
Made sprites rendering more compliant to GoldSrc

### DIFF
--- a/ref/gl/gl_sprite.c
+++ b/ref/gl/gl_sprite.c
@@ -748,6 +748,8 @@ void R_DrawSpriteModel( cl_entity_t *e )
 	{
 	case kRenderTransAlpha:
 		pglDepthMask( GL_FALSE );
+		pglEnable( GL_BLEND );
+		pglBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 		// fallthrough
 	case kRenderTransColor:
 	case kRenderTransTexture:
@@ -756,6 +758,9 @@ void R_DrawSpriteModel( cl_entity_t *e )
 		break;
 	case kRenderGlow:
 		pglDisable( GL_DEPTH_TEST );
+		pglDepthMask( GL_FALSE );
+		pglBlendFunc( GL_ONE, GL_ONE );
+		pglEnable( GL_BLEND );
 		// fallthrough
 	case kRenderTransAdd:
 		pglEnable( GL_BLEND );
@@ -768,8 +773,11 @@ void R_DrawSpriteModel( cl_entity_t *e )
 		break;
 	}
 
-	// all sprites can have color
-	pglTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
+	if( e->curstate.rendermode == kRenderTransColor ) 
+		pglTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ALPHA );
+	else
+		pglTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
+
 	pglEnable( GL_ALPHA_TEST );
 
 	// NOTE: never pass sprites with rendercolor '0 0 0' it's a stupid Valve Hammer Editor bug


### PR DESCRIPTION
I did not tested it and cannot be sure that it doesn't conflicts with some Xash-specific features related to sprites. So I'll summon testers to do it.