### PR TITLE
[emscripten] use for macro EXPORT __attribute__(( used ))

### DIFF
--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -12,6 +12,10 @@
 #include <wchar.h> // off_t
 #endif // _WIN32
 
+#if XASH_EMSCRIPTEN
+#include <emscripten.h>
+#endif
+
 #include <sys/types.h> // off_t
 #ifdef STDINT_H
 #include STDINT_H
@@ -73,6 +77,9 @@ typedef int qboolean;
 	#if defined( __i386__ )
 		#define EXPORT         __attribute__(( visibility( "default" ), force_align_arg_pointer ))
 		#define GAME_EXPORT    __attribute__(( force_align_arg_pointer ))
+	#elif defined(XASH_EMSCRIPTEN)
+		#define EXPORT EMSCRIPTEN_KEEPALIVE
+		#define GAME_EXPORT
 	#else
 		#define EXPORT         __attribute__(( visibility ( "default" )))
 		#define GAME_EXPORT

--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -12,10 +12,6 @@
 #include <wchar.h> // off_t
 #endif // _WIN32
 
-#if XASH_EMSCRIPTEN
-#include <emscripten.h>
-#endif
-
 #include <sys/types.h> // off_t
 #ifdef STDINT_H
 #include STDINT_H
@@ -78,7 +74,7 @@ typedef int qboolean;
 		#define EXPORT         __attribute__(( visibility( "default" ), force_align_arg_pointer ))
 		#define GAME_EXPORT    __attribute__(( force_align_arg_pointer ))
 	#elif defined(XASH_EMSCRIPTEN)
-		#define EXPORT EMSCRIPTEN_KEEPALIVE
+		#define                __attribute__((used)) //tell llvm to keep this export, see EMSCRIPTEN_KEEPALIVE
 		#define GAME_EXPORT
 	#else
 		#define EXPORT         __attribute__(( visibility ( "default" )))


### PR DESCRIPTION
In general it allows emscripten compiler to keep exports.