### PR TITLE
Fix README for Fedora/RedHat Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ This repository contains our fork of HLSDK and restored source code for Half-Lif
 
 ##### RedHat/Fedora
 * Only for 32-bit engine on 64-bit x86 operating system:
-  * Install development tools: `$ sudo dnf install git gcc gcc-c++ glibc-devel.i686 SDL2-devel.i686 opus-devel.i686 freetype-devel.i686 bzip2-devel.i686 libvorbis-devel.i686 opusfile-devel.i686 libogg-devel.i686`.
+  * Install development tools: `$ sudo dnf install git gcc gcc-c++ glibc-devel.i686 SDL3-devel.i686 sdl2-compat-devel.i686 opus-devel.i686 freetype-devel.i686 bzip2-devel.i686 libvorbis-devel.i686 opusfile-devel.i686 libogg-devel.i686`.
   * Set PKG_CONFIG_PATH environment variable to point at 32-bit libraries: `$ export PKG_CONFIG_PATH=/usr/lib/pkgconfig`.
 
 * For 64-bit engine on 64-bit x86 and other non-x86 systems:
-  * Install development tools: `$ sudo dnf install git gcc gcc-c++ SDL2-devel opus-devel freetype-devel bzip2-devel libvorbis-devel opusfile-devel libogg-devel`.
+  * Install development tools: `$ sudo dnf install git gcc gcc-c++ SDL3-devel sdl2-compat-devel opus-devel freetype-devel bzip2-devel libvorbis-devel opusfile-devel libogg-devel`.
 
 * Clone this repostory: `$ git clone --recursive https://github.com/FWGS/xash3d-fwgs`.
 


### PR DESCRIPTION
## Description

SDL2 is no longer available directly on Fedora as of Fedora 42. I believe this should also be true on RedHat EL but I'd like other user feedback there.

There are other minor problems, like manually needing to install libGL.i686 but we probably shouldn't have to explain all of that as it will be system dependent for the time being. Most people will probably want to build straight into the 64bit version which doesn't have this problem. 

### Testing

Using either a Fedora system or a Fedora pet container (distrobox or docker), run the command to install dependencies and then proceed with the rest of the build instructions. The old instructions would fail in the installation process, and careless setup (only installing the `sdl2-compat-devel`, for example) could result in cryptic build failures. You would think `sdl2-compat-devel` would install `SDL3-devel` if it's a compatibility layer, but that's an issue for upstream. :upside_down_face: 