### PR TITLE
Fixed blueish outline on sprays converted to WAD3 for GoldSrc servers

### DIFF
--- a/engine/client/cl_spray.c
+++ b/engine/client/cl_spray.c
@@ -151,9 +151,11 @@ qboolean CL_ConvertImageToWAD3( const char *filename )
 			}
 		}
 
+		// make last palette color black to avoid blueish texture filtering artifacts
 		quant->palette[255 * 3 + 0] = 0;
 		quant->palette[255 * 3 + 1] = 0;
-		quant->palette[255 * 3 + 2] = 255;
+		quant->palette[255 * 3 + 2] = 0;
+
 		memcpy( palette, quant->palette, SPRAY_PALETTE_BYTES );
 		indexed = quant->buffer;
 	}


### PR DESCRIPTION
Before:
<img width="1280" height="736" alt="image" src="https://github.com/user-attachments/assets/d291c695-307d-4154-a794-20e00518dc96" />

After:
<img width="1280" height="736" alt="image" src="https://github.com/user-attachments/assets/0da124ea-495d-4529-81cb-e194d05eb1a6" />
