### PR TITLE
engine: zone: free poolchain on every iteration of Memory_Init

### DIFF
--- a/engine/common/zone.c
+++ b/engine/common/zone.c
@@ -517,6 +517,10 @@ Memory_Init
 */
 void Memory_Init( void )
 {
+	if( poolchain )
+	{
+		Q_free( poolchain );
+	}
 	poolchain = NULL; // init mem chain
 	poolcount = 0;
 }


### PR DESCRIPTION
previously when fuzzing using the built in fuzzing tool, a memory leak would occur with 
```
=4704==ERROR: AddressSanitizer: out of memory: allocator is trying to allocate 0x58 bytes
    #0 0x566de3e9 in realloc (/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x1863e9) (BuildId: 60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #1 0xedcae1ee in _Mem_AllocPool /home/veygax/research/halflife/xash3d-fwgs/build/../engine/common/zone.c:347:22
    #2 0xedac563d in Image_Init /home/veygax/research/halflife/xash3d-fwgs/build/../engine/common/imagelib/img_utils.c:146:19
    #3 0xedaa24ab in Fuzz_Image_LoadBMP /home/veygax/research/halflife/xash3d-fwgs/build/../engine/common/imagelib/img_main.c:727:1
    #4 0x5673d625 in LLVMFuzzerTestOneInput /home/veygax/research/halflife/xash3d-fwgs/build/../utils/run-fuzzer/run-fuzzer.c:26:11
    #5 0x565adb05 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned int)
(/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x55b05) (BuildId: 60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #6 0x565ae17e in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned int, bool, fuzzer::InputInfo*, bool, bool*)
(/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x5617e) (BuildId: 60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #7 0x565afbb5 in fuzzer::Fuzzer::MutateAndTestOne() (/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x57bb5) (BuildId:
60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #8 0x565b0fc8 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&)
(/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x58fc8) (BuildId: 60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #9 0x56592764 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned int))
(/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x3a764) (BuildId: 60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #10 0x5657a2bf in main (/home/veygax/research/halflife/xash3d-fwgs/build/utils/run-fuzzer/run-fuzzer-Image_LoadBMP+0x222bf) (BuildId: 60a81d9932b82c5d76e7816ef82d2ef049490e6e)
    #11 0xf79b8534  (/usr/lib32/libc.so.6+0x22534) (BuildId: 2c2530b7da8a12b4294d7edeedc8c7e87dbc5de3
 
```
this was due to the fuzzer calling [Memory_Init](https://github.com/FWGS/xash3d-fwgs/blob/49b0619c9a5405137eeecfb061c1e50e43686087/engine/common/zone.c#L520) on every iteration, which would set poolchain = NULL without properly freeing it.

this PR adds a check to Memory_Init if poolchain exists, and frees it with Q_free if it does, resolving the memory leak.
