### PR TITLE
engine: add clc_bad log packet cmd value

### DIFF
--- a/engine/server/sv_client.c
+++ b/engine/server/sv_client.c
@@ -3663,7 +3663,7 @@ void SV_ExecuteClientMessage( sv_client_t *cl, sizebuf_t *msg )
 			SV_ParseCvarValue2( cl, msg );
 			break;
 		default:
-			Con_DPrintf( S_ERROR "%s: clc_bad\n", cl->name );
+			Con_DPrintf( S_ERROR "%s: clc_bad (%d)\n", cl->name, c );
 			SV_DropClient( cl, false );
 			return;
 		}


### PR DESCRIPTION
A minor improvement outputs the value of the packet, which is defined as clc_bad