### PR TITLE
Add 'retry' command for quick retry connect to servers (including if disconnected)

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -1859,6 +1859,45 @@ static void CL_Reconnect_f( void )
 
 /*
 =================
+CL_Retry_f
+
+retry connection to last server
+=================
+*/
+static void CL_Retry_f( void )
+{
+	if( !COM_CheckString( cls.servername ))
+	{
+		Con_Printf( "Can't retry, no previous connection.\n" );
+		return;
+	}
+
+	// can't retry when running a server
+	if( SV_Active( ))
+	{
+		Con_Printf( "Can't retry when running a server.\n" );
+		return;
+	}
+
+	NET_Config( true, !cl_nat.value ); // allow remote
+
+	Con_Printf( "Commencing connection retry to %s\n", cls.servername );
+	CL_Disconnect();
+
+	UI_SetActiveMenu( false );
+	Key_SetKeyDest( key_console );
+
+	cls.state = ca_connecting;
+	cls.connect_time = MAX_HEARTBEAT; // CL_CheckForResend() will fire immediately
+	cls.max_fragment_size = FRAGMENT_MAX_SIZE;
+	cls.connect_retry = 0;
+	memset( &cls.bandwidth_test, 0, sizeof( cls.bandwidth_test ));
+	cls.spectator = false;
+	cls.signon = 0;
+}
+
+/*
+=================
 CL_FixupColorStringsForInfoString
 
 all the keys and values must be ends with ^7
@@ -3427,6 +3466,7 @@ static void CL_InitLocal( void )
 
 	Cmd_AddCommand ("connect", CL_Connect_f, "connect to a server by hostname" );
 	Cmd_AddCommand ("reconnect", CL_Reconnect_f, "reconnect to current level" );
+	Cmd_AddCommand ("retry", CL_Retry_f, "retry connection to last server" );
 
 	Cmd_AddCommand ("rcon", CL_Rcon_f, "sends a command to the server console (rcon_password and rcon_address required)" );
 


### PR DESCRIPTION
Added a `retry` command that reconnects to previous server if available.

We may want to replace the current `reconnect` command, though. Some differences:

|                                             | reconnect             | retry                   |
|-------------------------------------|-------------------------|-------------------------|
| When disconnected         | Does nothing      | Works (main use case)   |
| Purpose                             | "The server is changing levels" (Line 1827) | Retry failed connection |
| Resets retry counter        | No                         | Yes                     |
| Resets fragment size       | No                         | Yes                     |
| Opens network sockets  | No                         | Yes                     |
| Blocks on local server     | No                         | Yes                     |

It appears from the comment I mentioned that this was for level changing, so the purpose is potentially different. It's been missing for me as I shut down, restart servers for testing all the time. It's also useful for plugin development where you need to restart the server or map.