### PR TITLE
engine: fix black fullscreen flash on startup in windowed mode

### DIFF
--- a/engine/platform/sdl2/host_sdl2.c
+++ b/engine/platform/sdl2/host_sdl2.c
@@ -387,11 +387,22 @@ static void SDLash_EventHandler( SDL_Event *event )
 		case SDL_WINDOWEVENT_MOVED:
 		{
 			char val[32];
+			int top, left;
+			int x = event->window.data1;
+			int y = event->window.data2;
 
-			Q_snprintf( val, sizeof( val ), "%d", event->window.data1 );
+			// adjust for window decorations - SDL reports client area position,
+			// but SDL_CreateWindow positions the frame
+			if( SDL_GetWindowBordersSize( host.hWnd, &top, &left, NULL, NULL ) == 0 )
+			{
+				x -= left;
+				y -= top;
+			}
+
+			Q_snprintf( val, sizeof( val ), "%d", x );
 			Cvar_DirectSet( &window_xpos, val );
 
-			Q_snprintf( val, sizeof( val ), "%d", event->window.data2 );
+			Q_snprintf( val, sizeof( val ), "%d", y );
 			Cvar_DirectSet( &window_ypos, val );
 
 			if ( vid_fullscreen.value == WINDOW_MODE_WINDOWED )

--- a/engine/platform/sdl2/vid_sdl2.c
+++ b/engine/platform/sdl2/vid_sdl2.c
@@ -856,9 +856,24 @@ static qboolean VID_CreateWindow( const int input_width, const int input_height,
 	SDL_GetWindowSize( host.hWnd, &rect.w, &rect.h );
 	VID_SaveWindowSize( rect.w, rect.h );
 
-	SDL_GetWindowPosition( host.hWnd, &rect.x, &rect.y );
-	Cvar_DirectSetValue( &window_xpos, rect.x );
-	Cvar_DirectSetValue( &window_ypos, rect.y );
+	// save position if it was undefined (first launch)
+	if( position_undefined )
+	{
+		int top, left;
+
+		SDL_GetWindowPosition( host.hWnd, &rect.x, &rect.y );
+
+		// adjust for window decorations - SDL reports client area position,
+		// but SDL_CreateWindow positions the frame
+		if( SDL_GetWindowBordersSize( host.hWnd, &top, &left, NULL, NULL ) == 0 )
+		{
+			rect.x -= left;
+			rect.y -= top;
+		}
+
+		Cvar_DirectSetValue( &window_xpos, rect.x );
+		Cvar_DirectSetValue( &window_ypos, rect.y );
+	}
 
 	return true;
 }


### PR DESCRIPTION
... and fix saved window position drift.

Changes:

- Set SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR to "0" to prevent a brief fullscreen black flash when launching in windowed mode on X11 with compositing enabled.

- Fix saved window position drifting downward on each launch. SDL reports client area position via SDL_GetWindowPosition and SDL_WINDOWEVENT_MOVED, but SDL_CreateWindow positions the window frame. This mismatch caused the position to drift by the title bar height on each launch. **Fixed by subtracting the window decoration offset (via SDL_GetWindowBordersSize) before saving, so coordinates represent the frame position that SDL_CreateWindow expects.**
