### PR TITLE
engine: client: block player input during intermission

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -686,6 +686,10 @@ static void CL_CreateCmd( void )
 	clgame.dllFuncs.CL_CreateMove( host.frametime, cmd, active );
 	IN_EngineAppendMove( host.frametime, cmd, active );
 
+	// clear all input during intermission regardless of how it was set
+	if( cl.intermission )
+		cmd->buttons = 0;
+
 	CL_PopPMStates();
 
 	if( !cls.demoplayback )

--- a/engine/client/keys.c
+++ b/engine/client/keys.c
@@ -766,7 +766,7 @@ void GAME_EXPORT Key_Event( int key, int down )
 	}
 
 	// distribute the key down event to the apropriate handler
-	if( cls.key_dest == key_game && !cl.intermission )
+	if( cls.key_dest == key_game )
 	{
 		Key_AddKeyCommands( key, kb, down );
 	}


### PR DESCRIPTION
During SVC_INTERMISSION, the server blocks movement and actions, but the client was still allowing players to move and shoot visually.

Changes:
- cl_main.c: Add !cl.intermission to the 'active' flag passed to CL_CreateMove(). This tells the client DLL not to process movement input and handles keys that were already held before intermission. Then we clear cmd->buttons after all input processing completes to prevent all inputs regardless of where it was initiated from.

Closes #2409