### PR TITLE
engine: client: allow console toggle from menu via keybind

### DIFF
--- a/engine/client/cl_gameui.c
+++ b/engine/client/cl_gameui.c
@@ -37,6 +37,9 @@ void UI_UpdateMenu( float realtime )
 {
 	if( !gameui.hInstance ) return;
 
+	// don't draw menu over console
+	if( cls.key_dest == key_console ) return;
+
 	// if some deferred cmds is waiting
 	if( UI_IsVisible() && COM_CheckString( host.deferred_cmd ))
 	{

--- a/engine/client/console.c
+++ b/engine/client/console.c
@@ -263,8 +263,8 @@ void Con_ToggleConsole_f( void )
 
 	SCR_EndLoadingPlaque();
 
-	// show console only in game or by special call from menu
-	if( cls.state != ca_active || cls.key_dest == key_menu )
+	// show console only in game, from menu, or to close console
+	if( cls.state != ca_active && cls.key_dest != key_menu && cls.key_dest != key_console )
 		return;
 
 	Con_ClearTyping();
@@ -272,13 +272,23 @@ void Con_ToggleConsole_f( void )
 
 	if( cls.key_dest == key_console )
 	{
-		if( Cvar_VariableInteger( "sv_background" ) || Cvar_VariableInteger( "cl_background" ))
+		// closing console
+		if( cls.state != ca_active || Cvar_VariableInteger( "sv_background" ) || Cvar_VariableInteger( "cl_background" ))
+		{
+			// not in game or in background mode - return to menu
+			// UI_SetActiveMenu(true) reactivates menu without resetting history
 			UI_SetActiveMenu( true );
-		else UI_SetActiveMenu( false );
+		}
+		else
+		{
+			// in game - return to game
+			UI_SetActiveMenu( false );
+		}
 	}
 	else
 	{
-		UI_SetActiveMenu( false );
+		// opening console - just switch key_dest, don't call UI_SetActiveMenu
+		// which would reset menu state via on_menu_hide()
 		Key_SetKeyDest( key_console );
 	}
 }


### PR DESCRIPTION
Changes:
 - Allows opening/closing the console from the main menu using the console keybind (default `)
 - Console toggle now returns to the **same menu screen** instead of resetting to main menu
 - Works consistently whether console is opened via keybind or via menu's Console button
 
Previously, pressing the console key while in the menu was blocked by the condition:
```c++
  if( cls.state != ca_active || cls.key_dest == key_menu )
      return;
```

It appears this was intentional, but it's unclear **why** it was intentional. I use the console constantly, so having that shortcut immediately upon game launch is extremely valuable for executing saved history (e.g. uparrow, `connect 127.0.0.1`, enter)