### PR TITLE
ref: gl: always use RGTC internal format for ATI2 textures

### DIFF
--- a/ref/gl/gl_image.c
+++ b/ref/gl/gl_image.c
@@ -613,11 +613,7 @@ static void GL_SetTextureFormat( gl_texture_t *tex, pixformat_t format, int chan
 		case PF_BC6H_UNSIGNED: tex->format = GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB; break;
 		case PF_BC7_SRGB:
 		case PF_BC7_UNORM: tex->format = GL_COMPRESSED_RGBA_BPTC_UNORM_ARB; break;
-		case PF_ATI2:
-			if( glConfig.hardware_type == GLHW_RADEON )
-				tex->format = GL_COMPRESSED_LUMINANCE_ALPHA_3DC_ATI;
-			else tex->format = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
-			break;
+		case PF_ATI2: tex->format = GL_COMPRESSED_RED_GREEN_RGTC2_EXT; break;
 		}
 		return;
 	}


### PR DESCRIPTION
AMD убрала в новых драйверах поддержку расширения GL_ATI_texture_compression_3dc, из-за чего сломалась загрузка ATI2 текстур. Формат RGTC включен в стандарт OpenGL 3.0, а единственные видеокарты с поддержкой 3DC, но без RGTC - это серия Radeon X1000 (2005г.). Можно было бы только ради Х1000 проверять поддерживаемые расширения и переключаться на 3DC, но без явной необходимости этого делать не хочется.