### PR TITLE
crtlib: Force use xash strchrnul implementation on ios

### DIFF
--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -288,7 +288,7 @@ static inline char *Q_stristr( const char *s1, const char *s2 )
 char *Q_stristr( const char *s1, const char *s2 );
 #endif // !HAVE_STRCASESTR
 
-#if HAVE_STRCHRNUL
+#if HAVE_STRCHRNUL && !XASH_IOS
 #define Q_strchrnul strchrnul
 #else // !HAVE_STRCHRNUL
 static inline char *Q_strchrnul( const char *s, int c )


### PR DESCRIPTION
Apple added their own strchrnul implementation on iOS 18.4 and macOS 15.4, so if we build xash for iOS with an 18.4 SDK or later the generated ipa will not work on work on iOS versions below 18.4, this is a workaround for this issue