### PR TITLE
Prepare support for direct SCR writing

### DIFF
--- a/engine/common/cfgscript.c
+++ b/engine/common/cfgscript.c
@@ -264,32 +264,6 @@ finish:
 	return count;
 }
 
-static void CSCR_WriteVariableToFile( scrvardef_t *var, void *file )
-{
-	file_t   *cfg  = (file_t*)file;
-	convar_t *cvar = Cvar_FindVar( var->name );
-
-	if( cvar && !FBitSet( cvar->flags, FCVAR_SERVER|FCVAR_ARCHIVE ))
-	{
-		// cvars will be placed in game.cfg and restored on map start
-		if( var->flags & FCVAR_USERINFO )
-			FS_Printf( cfg, "setinfo %s \"%s\"\n", var->name, cvar->string );
-		else FS_Printf( cfg, "%s \"%s\"\n", var->name, cvar->string );
-	}
-}
-
-/*
-======================
-CSCR_WriteGameCVars
-
-Print all cvars declared in script to game.cfg file
-======================
-*/
-int CSCR_WriteGameCVars( file_t *cfg, const char *scriptfilename )
-{
-	return CSCR_ParseFile( scriptfilename, CSCR_WriteVariableToFile, cfg );
-}
-
 static void CSCR_RegisterVariable( scrvardef_t *var, void *unused )
 {
 	if( !Cvar_FindVar( var->name ))

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -696,7 +696,6 @@ int COM_SizeofResourceList( resource_t *pList, resourceinfo_t *ri );
 // cfgscript.c
 //
 int CSCR_LoadDefaultCVars( const char *scriptfilename );
-int CSCR_WriteGameCVars( file_t *cfg, const char *scriptfilename );
 
 //
 // hpak.c

--- a/engine/common/con_utils.c
+++ b/engine/common/con_utils.c
@@ -1522,15 +1522,11 @@ void GAME_EXPORT Host_WriteServerConfig( const char *name )
 
 	Q_snprintf( newconfigfile, MAX_STRING, "%s.new", name );
 
-	// FIXME: move this out until menu parser is done
-	CSCR_LoadDefaultCVars( "settings.scr" );
-
 	if(( f = FS_Open( newconfigfile, "w", false )) != NULL )
 	{
 		Host_InitializeConfig( f, "game.cfg", "multiplayer server temporary config" );
 
 		Cvar_WriteVariables( f, FCVAR_SERVER );
-		CSCR_WriteGameCVars( f, "settings.scr" );
 
 		Host_FinalizeConfig( f, name );
 	}


### PR DESCRIPTION
This removes the old logic that wrote variables from ``settings.scr`` into **cfg** files.

In https://github.com/FWGS/mainui_cpp/pull/138 variables are now written directly into ``settings.scr`` when creating a server.