### PR TITLE
ref: gl: fix opacity of additive sprites and textures in fog

### DIFF
--- a/ref/gl/gl_backend.c
+++ b/ref/gl/gl_backend.c
@@ -438,26 +438,31 @@ void GL_SetRenderMode( int mode )
 	{
 	case kRenderNormal:
 	default:
+		R_AllowFog( true );
 		pglDisable( GL_BLEND );
 		pglDisable( GL_ALPHA_TEST );
 		break;
 	case kRenderTransColor:
 	case kRenderTransTexture:
+		R_AllowFog( true );
 		pglEnable( GL_BLEND );
 		pglDisable( GL_ALPHA_TEST );
 		pglBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 		break;
 	case kRenderTransAlpha:
+		R_AllowFog( true );
 		pglDisable( GL_BLEND );
 		pglEnable( GL_ALPHA_TEST );
 		break;
 	case kRenderGlow:
 	case kRenderTransAdd:
+		R_AllowFog( false );
 		pglEnable( GL_BLEND );
 		pglDisable( GL_ALPHA_TEST );
 		pglBlendFunc( GL_SRC_ALPHA, GL_ONE );
 		break;
 	case kRenderScreenFadeModulate:
+		R_AllowFog( true );
 		pglEnable( GL_BLEND );
 		pglDisable( GL_ALPHA_TEST );
 		pglBlendFunc( GL_ZERO, GL_SRC_COLOR );

--- a/ref/gl/gl_rpart.c
+++ b/ref/gl/gl_rpart.c
@@ -181,6 +181,7 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 	if( !TriSpriteTexture( gEngfuncs.GetDefaultSprite( REF_DOT_SPRITE ), 0 ))
 		return;
 
+	R_AllowFog( false );
 	pglEnable( GL_BLEND );
 	pglBlendFunc( GL_SRC_ALPHA, GL_ONE );
 	pglDisable( GL_ALPHA_TEST );
@@ -267,6 +268,7 @@ void CL_DrawTracers( double frametime, particle_t *cl_active_tracers )
 	pglEnd();
 
 	pglDepthMask( GL_TRUE );
+	R_AllowFog( true );
 }
 
 /*

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -2866,6 +2866,9 @@ static void R_StudioSetupRenderer( int rendermode )
 	if( rendermode > kRenderTransAdd ) rendermode = 0;
 	g_studio.rendermode = bound( 0, rendermode, kRenderTransAdd );
 
+	if( g_studio.rendermode == kRenderTransAdd || g_studio.rendermode == kRenderGlow )
+		R_AllowFog( false );
+
 	pglTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
 	pglDisable( GL_ALPHA_TEST );
 	pglShadeModel( GL_SMOOTH );
@@ -2891,6 +2894,9 @@ static void R_StudioRestoreRenderer( void )
 {
 	if( g_studio.rendermode != kRenderNormal )
 		pglDisable( GL_BLEND );
+
+	if( g_studio.rendermode == kRenderTransAdd || g_studio.rendermode == kRenderGlow )
+		R_AllowFog( true );
 
 	pglTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE );
 	pglShadeModel( GL_FLAT );

--- a/ref/gl/gl_triapi.c
+++ b/ref/gl/gl_triapi.c
@@ -45,21 +45,25 @@ void TriRenderMode( int mode )
 	switch( mode )
 	{
 	case kRenderNormal:
+		R_AllowFog( true );
 		pglDisable( GL_BLEND );
 		pglDepthMask( GL_TRUE );
 		break;
 	case kRenderTransAlpha:
+		R_AllowFog( true );
 		pglEnable( GL_BLEND );
 		pglBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 		pglDepthMask( GL_FALSE );
 		break;
 	case kRenderTransColor:
 	case kRenderTransTexture:
+		R_AllowFog( true );
 		pglEnable( GL_BLEND );
 		pglBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 		break;
 	case kRenderGlow:
 	case kRenderTransAdd:
+		R_AllowFog( false );
 		pglBlendFunc( GL_SRC_ALPHA, GL_ONE );
 		pglEnable( GL_BLEND );
 		pglDepthMask( GL_FALSE );


### PR DESCRIPTION
The ``cl_fog_density`` cvar was set to ``0.003`` to increase fog density during weather sprites testing.

## Before
<img width="1920" height="1080" alt="ka_risingsun_0002" src="https://github.com/user-attachments/assets/081cb476-ace9-48ea-bc9b-900e1e363106" />
<img width="1920" height="1080" alt="ka_risingsun_0005" src="https://github.com/user-attachments/assets/722a41c5-dd7b-49ba-a8fa-513e9bf3761d" />

## After
<img width="1920" height="1080" alt="ka_risingsun_0000" src="https://github.com/user-attachments/assets/b9e33d01-f1fa-4c55-a5bc-f62b1d08015e" />
<img width="1920" height="1080" alt="ka_risingsun_0001" src="https://github.com/user-attachments/assets/8f464803-099d-419d-bf3b-836070f79052" />
