### PR TITLE
Fix mouse input not working in main menu at 640x480

### DIFF
--- a/engine/client/vid_common.c
+++ b/engine/client/vid_common.c
@@ -69,11 +69,11 @@ void R_SaveVideoMode( int w, int h, int render_w, int render_h, qboolean maximiz
 	// video subsystem to reapply settings
 	host.renderinfo_changed = false;
 
-	if( refState.width == render_w && refState.height == render_h )
-		return;
-
 	refState.scale_x = (float)render_w / w;
 	refState.scale_y = (float)render_h / h;
+
+	if( refState.width == render_w && refState.height == render_h )
+		return;
 
 	refState.width = render_w;
 	refState.height = render_h;


### PR DESCRIPTION
Default width and height for `refState` is 640x480, so running at that resolution hits the early exit in `R_SaveVideoMode`, causing the scaling factors to never be set, which results in the SDL2 implementation of `Platform_GetMousePos` outputting `0, 0`.

I've moved the early exit to after the scaling factors are set, which fixes this.