### PR TITLE
engine: client: avi: remove XASH_FFMPEG_DLOPEN

### DIFF
--- a/engine/client/avi/avi_ffmpeg.c
+++ b/engine/client/avi/avi_ffmpeg.c
@@ -23,7 +23,6 @@ static qboolean avi_initialized;
 static poolhandle_t avi_mempool;
 
 #if XASH_AVI == AVI_FFMPEG
-#define XASH_FFMPEG_DLOPEN 1
 #include "avi_ffmpeg.h"
 
 struct movie_state_s


### PR DESCRIPTION
Is this a mistake? This define effectively forces `--enable-ffmpeg-dlopen` at all times ignoring configuration (which in turn makes build to fail with ffmpeg 8.1).