### PR TITLE
engine: common: set cmd_args to "" when tokenising, if we've no arguments

### DIFF
--- a/engine/common/cmd.c
+++ b/engine/common/cmd.c
@@ -615,8 +615,11 @@ void Cmd_TokenizeString( const char *text )
 		if( !*text )
 			return;
 
-		if( cmd_argc == 1 )
-			 cmd_args = text;
+		switch( cmd_argc )
+		{
+		case 0: cmd_args = "";   break;
+		case 1: cmd_args = text; break;
+		}
 
 		text = COM_ParseFileSafe( (char*)text, cmd_token, sizeof( cmd_token ), PFILE_IGNOREBRACKET, NULL, NULL );
 


### PR DESCRIPTION
When a client command is sent without any arguments, `Cmd_TokenizeString()` leaves `cmd_args` as NULL, which breaks [`metamod-fwgs`'s `ClientCommand` handler](https://github.com/FWGS/metamod-fwgs/blob/eedede40e806e7f3d1604de61ed43404928ea639/metamod/src/commands_meta.cpp#L63).

Set it to `""` in this case to avoid the crash. I'm unsure what the "correct" behaviour is here, it's quite possible this is a bug in metamod instead; if so, I'll post a fix there.

(Also, `STRING(pEntity->v.netname)` is pointing to garbage, which makes me think this is an engine bug).

<img width="1072" height="1114" alt="image" src="https://github.com/user-attachments/assets/b75e14c1-91e4-4ed8-83b3-0eff10013ff7" />

## The crash in question:

(Ignore the missing build info, my environment didn't have Git in it. it's from commit 84b7b5803bed19651d5fa8873225126ffd1ba9d1)
```
Ver: Xash3D FWGS 0.21 (build -1-[]-[], linux-amd64)
Crash: signal 11 errno 0 with code 1 at 0x7f50b0e14040 (nil)
Ver: Xash3D FWGS 0.21 (build -1-[]-[], linux-amd64)
Crash: signal 11 errno 0 with code 1 at 0x7f50b0e14040 (nil)
 0: <Sys_Crash+350> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
 0: <Sys_Crash+350> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
 1: 0x7f4fb24da78f (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 1: 0x7f4fb24da78f (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 2: <__strlen_evex+28> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 2: <__strlen_evex+28> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 3: <__printf_buffer+8031> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 3: <__printf_buffer+8031> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 4: <vsnprintf+107> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 4: <vsnprintf+107> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
 5: buffered_ALERT (log_meta.cpp:125) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 5: buffered_ALERT (log_meta.cpp:125) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 6: _Z8META_LOGPKcz (log_meta.cpp:76) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 6: _Z8META_LOGPKcz (log_meta.cpp:76) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 7: _Z11client_metaP7edict_s (commands_meta.cpp:74) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 7: _Z11client_metaP7edict_s (commands_meta.cpp:74) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 8: mm_ClientCommand (dllapi.cpp:36) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 8: mm_ClientCommand (dllapi.cpp:36) (/home/zane/Documents/Coding/metamod-fwgs/cmake-build-debug/metamod/metamod_amd64.so)
 9: <SV_ExecuteClientMessage+2146> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
 9: <SV_ExecuteClientMessage+2146> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
10: <Host_ServerFrame+1976> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
10: <Host_ServerFrame+1976> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
11: <Host_Frame+635> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
11: <Host_Frame+635> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
12: <COM_Frame+177> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
12: <COM_Frame+177> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
13: <Host_Main+2633> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
13: <Host_Main+2633> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
14: <__libc_start_call_main+116> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
14: <__libc_start_call_main+116> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
15: <__libc_start_main@GLIBC_2.2.5+135> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
15: <__libc_start_main@GLIBC_2.2.5+135> (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6)
16: <_start+36> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
16: <_start+36> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
17: 0xffffffffffffffff
17: 0xffffffffffffffff
======================================
Xash Error: Ver: Xash3D FWGS 0.21 (build -1-[]-[], linux-amd64)
Crash: signal 11 errno 0 with code 1 at 0x7f50b0e14040 (nil)
 0: <Sys_Crash+350> (/nix/store/9q17szs185f46d7yg0vf5psfw2gixp3d-xash3d-fwgs-unstable-2026-04-13-0/bin/xash)
======================================
[22:12:02] Note: Issuing host shutdown due to reason "crashed"
[22:12:02] Server shutdown
```