### PR TITLE
engine: common: mod_studio: fix model traversal and crash in Mod_StudioComputeBounds

### DIFF
--- a/engine/common/mod_studio.c
+++ b/engine/common/mod_studio.c
@@ -690,7 +690,6 @@ static void Mod_StudioComputeBounds( void *buffer, vec3_t mins, vec3_t maxs, qbo
 	vec3_t		bone_mins, bone_maxs;
 	vec3_t		vert_mins, vert_maxs;
 	int		vert_count, bone_count;
-	int		bodyCount = 0;
 	vec3_t		pos, *pverts;
 
 	vert_count = bone_count = 0;
@@ -706,18 +705,16 @@ static void Mod_StudioComputeBounds( void *buffer, vec3_t mins, vec3_t maxs, qbo
 	// each body part has nummodels variations so there are as many total variations as there
 	// are in a matrix of each part by each other part
 	for( i = 0; i < pstudiohdr->numbodyparts; i++ )
-		bodyCount += pbodypart[i].nummodels;
-
-	// The studio models we want are vec3_t mins, vec3_t maxsight after the bodyparts (still need to
-	// find a detailed breakdown of the mdl format).  Move pointer there.
-	m_pSubModel = (mstudiomodel_t *)(&pbodypart[pstudiohdr->numbodyparts]);
-
-	for( i = 0; i < bodyCount; i++ )
 	{
-		pverts = (vec3_t *)((byte *)pstudiohdr + m_pSubModel[i].vertindex);
+		m_pSubModel = (mstudiomodel_t *)((byte *)pstudiohdr + pbodypart[i].modelindex);
 
-		for( j = 0; j < m_pSubModel[i].numverts; j++ )
-			Mod_StudioBoundVertex( bone_mins, bone_maxs, &vert_count, pverts[j] );
+		for( j = 0; j < pbodypart[i].nummodels; j++ )
+		{
+			pverts = (vec3_t *)((byte *)pstudiohdr + m_pSubModel[j].vertindex);
+
+			for( k = 0; k < m_pSubModel[j].numverts; k++ )
+				Mod_StudioBoundVertex( bone_mins, bone_maxs, &vert_count, pverts[k] );
+		}
 	}
 
 	pbones = (mstudiobone_t *)((byte *)pstudiohdr + pstudiohdr->boneindex);


### PR DESCRIPTION
Fixes: https://github.com/FWGS/xash3d-fwgs/issues/2561

### Correct Model Traversal
The GoldSrc StudioMDL format (as defined in [studio.h](https://github.com/ValveSoftware/halflife/blob/master/engine/studio.h)) explicitly uses offsets to link different data chunks. Specifically, ``mstudiobodyparts_t`` points to its models via an offset, and ``mstudiomodel_t`` points to its vertices:

From [mstudiobodyparts_t](https://github.com/ValveSoftware/halflife/blob/b1b5cf5892918535619b2937bb927e46cb097ba1/engine/studio.h#L256-L263) definition:
```
typedef struct
{
	char				name[64];
	int					nummodels;
	int					base;
	int					modelindex; // <--- index into models array
} mstudiobodyparts_t;

```

From [mstudiomodel_t](https://github.com/ValveSoftware/halflife/blob/b1b5cf5892918535619b2937bb927e46cb097ba1/engine/studio.h#L281-L302) definition:
```
typedef struct
{
	char				name[64];
	// ...
	int					numverts;		// number of unique vertices
	int					vertinfoindex;	// vertex bone info
	int					vertindex;		// <--- vertex vec3_t offset
	// ...
} mstudiomodel_t;

```

As the specification shows, it is mandatory to use these ``modelindex`` and ``vertindex`` offsets from the model header base pointer to safely access the data. The old code ignored the ``modelindex`` and assumed a contiguous memory layout, which is not guaranteed by the StudioMDL compiler.

### Correct Bone Animation Access
Also in the original Half-Life SDK, the function responsible for bone transformations (``CalcRotations``) iterates through bones and animation data simultaneously. You can see the ``panim`` pointer being incremented for each bone:

From [studio_render.cpp](https://github.com/ValveSoftware/halflife/blob/b1b5cf5892918535619b2937bb927e46cb097ba1/utils/mdlviewer/studio_render.cpp#L233-L259) (MDLViewer from Valve HLSDK):
```
void StudioModel::CalcRotations ( vec3_t *pos, vec4_t *q, mstudioseqdesc_t *pseqdesc, mstudioanim_t *panim, float f )
{
    // ...
    pbone = (mstudiobone_t *)((byte *)m_pstudiohdr + m_pstudiohdr->boneindex);
    for (i = 0; i < m_pstudiohdr->numbones; i++, pbone++, panim++) // <--- panim is incremented here!
    {
        CalcBoneQuaternion( frame, s, pbone, panim, q[i] );
        CalcBonePosition( frame, s, pbone, panim, pos[i] );
    }
    // ...
}
```

This confirms that each bone ``i`` requires its corresponding animation data structure ``panim[i]``. The old code in ``Mod_StudioComputeBounds`` was passing a static pointer to the first bone's animation data for all bones in the model, resulting in incorrect bounding box calculations.