### PR TITLE
Big endian support (now with client)

### DIFF
--- a/3rdparty/libbacktrace/wscript
+++ b/3rdparty/libbacktrace/wscript
@@ -20,10 +20,10 @@ int main (void) {
 }'''
 
 FRAGMENT_GETPAGESIZE='''#include <unistd.h>
-int main(void) { return getpagesize() }'''
+int main(void) { return getpagesize(); }'''
 
 FRAGMENT_GETEXECNAME='''#include <stdlib.h>
-int main(void) { return getexecname() != 0 }'''
+int main(void) { return getexecname() != 0; }'''
 
 FRAGMENT_STRNLEN='''#include <string.h>
 int main(int argc, char **argv) { return (int)strnlen(argv[0], 10); }'''
@@ -120,8 +120,8 @@ def configure(conf):
 		check_frag(FRAGMENT_SYNC, ' __sync extensions', 'HAVE_SYNC_FUNCTIONS'),
 		check_frag(FRAGMENT_GETPAGESIZE, ' getpagesize function', 'HAVE_DECL_GETPAGESIZE'),
 		check_frag(FRAGMENT_STRNLEN, ' strnlen function', 'HAVE_DECL_STRNLEN'),
-		check_frag(FRAGMENT_DL_ITERATE_PHDR % 'link.h', ' dl_iterate_phdr function in link.h', 'HAVE_DL_ITERATE_PHDR', after_tests=['link.h']),
-		check_frag(FRAGMENT_DL_ITERATE_PHDR % 'sys/link.h', ' dl_iterate_phdr function in sys/link.h', 'HAVE_DL_ITERATE_PHDR', after_tests=['sys/link.h']),
+		check_frag(FRAGMENT_DL_ITERATE_PHDR % 'link.h', ' dl_iterate_phdr function in link.h', 'HAVE_DL_ITERATE_PHDR_LINK_H', after_tests=['link.h']),
+		check_frag(FRAGMENT_DL_ITERATE_PHDR % 'sys/link.h', ' dl_iterate_phdr function in sys/link.h', 'HAVE_DL_ITERATE_PHDR_SYS_LINK_H', after_tests=['sys/link.h']),
 		check_frag(FRAGMENT_FCNTL, 'fnctl function', 'HAVE_FCNTL'),
 		check_frag(FRAGMENT_GETEXECNAME, 'getexecname function','HAVE_GETEXECNAME'),
 		check_frag(FRAGMENT_GETIPINFO, '_Unwind_GetIPInfo function', 'HAVE_GETIPINFO'),
@@ -136,6 +136,9 @@ def configure(conf):
 #		{'lib':'zstd', 'define_name':'HAVE_ZSTD', 'uselib_store':'zstd', 'msg':'... zstd library', 'mandatory':False},
 		msg='Checking for in parallel'
 	)
+
+	if conf.is_defined('HAVE_DL_ITERATE_PHDR_LINK_H') or conf.is_defined('HAVE_DL_ITERATE_PHDR_SYS_LINK_H'):
+		conf.define('HAVE_DL_ITERATE_PHDR', 1)
 
 	conf.env[DEFKEYS].sort()
 
@@ -181,7 +184,8 @@ def build(bld):
 
 	task = bld.stlib(
 		source = ['libbacktrace/' + i for i in sources],
-		target = 'backtrace',
+		# while we're using upstream libbacktrace, sometimes compiler picks up it's own version that isn't built with required options
+		target = 'backtrace_custom',
 		features = 'frandomseed' if bld.env.HAVE_FRANDOM_SEED else '',
 		use = 'EXTRAFLAGS lzma z zstd',
 		includes = '. libbacktrace/',

--- a/common/com_image.h
+++ b/common/com_image.h
@@ -87,6 +87,7 @@ typedef enum
 	IL_LOAD_PLAYER_DECAL = BIT(7), // special mode for player decals
 	IL_KTX2_RAW = BIT(8), // renderer can consume raw KTX2 files (e.g. ref_vk)
 	IL_ALLOW_WAD3_LUMA = BIT(9), // allow usage of luma textures in wad3 (tilde textures)
+	IL_HOST_ENDIAN = BIT(10), // buffer is already in host endian, skip byte-swapping
 } ilFlags_t;
 
 // goes into rgbdata_t->encode

--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -243,6 +243,9 @@ typedef int qboolean;
 #define Swap32Store( x ) ( x = Swap32( x ))
 #define Swap16Store( x ) ( x = Swap16( x ))
 
+#define LittleFourCC( a, b, c, d ) (((uint32_t)( d ) << 24 ) | ((uint32_t)( c ) << 16 ) | ((uint32_t)( b ) << 8 ) | (uint32_t)( a ))
+#define BigFourCC( a, b, c, d )    (((uint32_t)( a ) << 24 ) | ((uint32_t)( b ) << 16 ) | ((uint32_t)( c ) << 8 ) | (uint32_t)( d ))
+
 #if XASH_BIG_ENDIAN
 	#define LittleLong( x )    Swap32( x )
 	#define LittleShort( x )   Swap16( x )
@@ -252,6 +255,7 @@ typedef int qboolean;
 	#define BigLong( x )  ( x )
 	#define BigShort( x ) ( x )
 	#define BigFloat( x ) ( x )
+	#define HostFourCC( a, b, c, d ) BigFourCC( a, b, c, d )
 #else
 	#define LittleLong( x )  ( x )
 	#define LittleShort( x )  ( x )
@@ -261,6 +265,7 @@ typedef int qboolean;
 	#define BigLong( x )  Swap32( x )
 	#define BigShort( x ) Swap16( x )
 	#define BigFloat( x ) SwapFloat( x )
+	#define HostFourCC( a, b, c, d ) LittleFourCC( a, b, c, d )
 #endif
 
 #endif // XASH_TYPES_H

--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -243,7 +243,7 @@ typedef int qboolean;
 #define Swap32Store( x ) ( x = Swap32( x ))
 #define Swap16Store( x ) ( x = Swap16( x ))
 
-#ifdef XASH_BIG_ENDIAN
+#if XASH_BIG_ENDIAN
 	#define LittleLong( x )    Swap32( x )
 	#define LittleShort( x )   Swap16( x )
 	#define LittleLongSW( x )  Swap32Store( x )

--- a/engine/client/cl_font.c
+++ b/engine/client/cl_font.c
@@ -17,6 +17,20 @@ GNU General Public License for more details.
 #include "filesystem.h"
 #include "client.h"
 #include "qfont.h"
+#include "swaplib.h"
+
+le_struct_begin( charinfo_swap )
+	le_struct_field( charinfo, startoffset )
+	le_struct_field( charinfo, charwidth )
+le_struct_end();
+
+le_struct_begin( qfont_swap )
+	le_struct_field( qfont_t, width )
+	le_struct_field( qfont_t, height )
+	le_struct_field( qfont_t, rowcount )
+	le_struct_field( qfont_t, rowheight )
+	le_struct_array_child( qfont_t, fontinfo, charinfo_swap, NUM_GLYPHS )
+le_struct_end();
 
 qboolean CL_FixedFont( cl_font_t *font )
 {
@@ -130,6 +144,7 @@ qboolean Con_LoadVariableWidthFont( const char *fontname, cl_font_t *font, float
 	}
 
 	memcpy( &src, pfile, sizeof( src ));
+	le_struct_swap( qfont_swap, &src );
 	Mem_Free( pfile );
 
 	font->hFontTexture = CL_LoadFontTexture( fontname, texFlags, &font_width );

--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -2583,7 +2583,7 @@ static void CL_ServerList( netadr_t from, sizebuf_t *msg )
 			MSG_ReadBytes( msg, servadr.ip, sizeof( servadr.ip ));	// 4 bytes for IP
 			NET_NetadrSetType( &servadr, NA_IP );
 		}
-		servadr.port = MSG_ReadShort( msg );			// 2 bytes for Port
+		MSG_ReadBytes( msg, &servadr.port, sizeof( servadr.port ));	// 2 bytes for Port, in network byte order
 
 		// list is ends here
 		if( !servadr.port )

--- a/engine/client/dll_int/ref_common.c
+++ b/engine/client/dll_int/ref_common.c
@@ -505,9 +505,9 @@ static void R_CreateBuiltinTextures( void )
 		for( int x = 0; x < 16; x++ )
 		{
 			if(( y < 8 ) ^ ( x < 8 ))
-				data16x16[y * 16 + x] = 0xFFFF00FF;
+				data16x16[y * 16 + x] = HostFourCC( 255, 0, 255, 255 );
 			else
-				data16x16[y * 16 + x] = 0xFF000000;
+				data16x16[y * 16 + x] = HostFourCC( 0, 0, 0, 255 );
 		}
 	}
 	ref.dllFuncs.GL_CreateTexture( REF_DEFAULT_TEXTURE, 16, 16, data16x16, 0 );
@@ -517,7 +517,7 @@ static void R_CreateBuiltinTextures( void )
 	for( int y = 0; y < 8; y++ )
 	{
 		for( int x = 0; x < 8; x++ )
-			particle[y * 8 + x] = 0x00FFFFFF; // fill it with invisible white
+			particle[y * 8 + x] = HostFourCC( 255, 255, 255, 0 ); // fill it with invisible white
 	}
 
 	// a1ba: moved one pixel down and to the right to make it look better with linear interpolation
@@ -530,7 +530,7 @@ static void R_CreateBuiltinTextures( void )
 			if(( x == corner || x == 3 + corner ) && ( y == corner || y == 3 + corner ))
 				continue;
 
-			particle[y * 8 + x] = 0xFFFFFFFF;
+			particle[y * 8 + x] = HostFourCC( 255, 255, 255, 255 );
 		}
 	}
 	ref.dllFuncs.GL_CreateTexture( REF_PARTICLE_TEXTURE, 8, 8, particle, TF_CLAMP|TF_HAS_ALPHA );
@@ -541,11 +541,11 @@ static void R_CreateBuiltinTextures( void )
 	ref.dllFuncs.GL_CreateTexture( REF_WHITE_TEXTURE, 4, 4, data4x4, 0 );
 
 	for( int x = 0; x < 16; x++ )
-		data4x4[x] = 0xFF7F7F7F;
+		data4x4[x] = HostFourCC( 127, 127, 127, 255 );
 	ref.dllFuncs.GL_CreateTexture( REF_GRAY_TEXTURE, 4, 4, data4x4, 0 );
 
 	for( int x = 0; x < 16; x++ )
-		data4x4[x] = 0xFF000000;
+		data4x4[x] = HostFourCC( 0, 0, 0, 255 );
 	ref.dllFuncs.GL_CreateTexture( REF_BLACK_TEXTURE, 4, 4, data4x4, 0 );
 }
 

--- a/engine/client/soundlib/snd_ogg_vorbis.c
+++ b/engine/client/soundlib/snd_ogg_vorbis.c
@@ -157,7 +157,7 @@ qboolean Sound_LoadOggVorbis( const char *name, const byte *buffer, fs_offset_t 
 	SetBits( sound.flags, SOUND_RESAMPLE );
 	Sound_ScanVorbisComments( &vorbisFile );
 
-	while(( ret = ov_read( &vorbisFile, (char *)sound.wav + written, sound.size - written, 0, sound.width, 1, &section )) != 0 )
+	while(( ret = ov_read( &vorbisFile, (char *)sound.wav + written, sound.size - written, XASH_BIG_ENDIAN, sound.width, 1, &section )) != 0 )
 	{
 		if( ret < 0 )
 		{
@@ -232,7 +232,7 @@ int Stream_ReadOggVorbis( stream_t *stream, int needBytes, void *buffer )
 
 		if( !stream->buffsize )
 		{
-			stream->pos = ov_read( &ctx->vf, (char *)stream->temp, OUTBUF_SIZE, 0, stream->width, 1, &section );
+			stream->pos = ov_read( &ctx->vf, (char *)stream->temp, OUTBUF_SIZE, XASH_BIG_ENDIAN, stream->width, 1, &section );
 			if( stream->pos == 0 )
 			{
 				break; // end of file

--- a/engine/client/soundlib/snd_wav.c
+++ b/engine/client/soundlib/snd_wav.c
@@ -152,6 +152,8 @@ static qboolean StreamFindNextChunk( file_t *file, const char *name, int *last_c
 		if( FS_Read( file, &iff_chunk_len, sizeof( iff_chunk_len )) != sizeof( iff_chunk_len ))
 			return false;
 
+		iff_chunk_len = LittleLong( iff_chunk_len );
+
 		if( iff_chunk_len < 0 )
 			return false;	// didn't find the chunk
 
@@ -394,6 +396,7 @@ stream_t *Stream_OpenWAV( const char *filename )
 	FS_Read( file, chunkName, 4 );
 
 	FS_Read( file, &t, sizeof( t ));
+	t = LittleShort( t );
 	if( t != 1 )
 	{
 		Con_DPrintf( S_ERROR "%s: %s not a microsoft PCM format\n", __func__, filename );
@@ -402,14 +405,15 @@ stream_t *Stream_OpenWAV( const char *filename )
 	}
 
 	FS_Read( file, &t, sizeof( t ));
-	sound.channels = t;
+	sound.channels = LittleShort( t );
 
 	FS_Read( file, &sound.rate, sizeof( int ));
+	sound.rate = LittleLong( sound.rate );
 
 	FS_Seek( file, 6, SEEK_CUR );
 
 	FS_Read( file, &t, sizeof( t ));
-	sound.width = t / 8;
+	sound.width = LittleShort( t ) / 8;
 
 	sound.loopstart = 0;
 
@@ -423,7 +427,7 @@ stream_t *Stream_OpenWAV( const char *filename )
 	}
 
 	FS_Read( file, &sound.samples, sizeof( int ));
-	sound.samples = ( sound.samples / sound.width ) / sound.channels;
+	sound.samples = ( LittleLong( sound.samples ) / sound.width ) / sound.channels;
 
 	// at this point we have valid stream
 	stream = Mem_Calloc( host.soundpool, sizeof( stream_t ));

--- a/engine/client/soundlib/snd_wav.c
+++ b/engine/client/soundlib/snd_wav.c
@@ -319,6 +319,15 @@ qboolean Sound_LoadWAV( const char *name, const byte *buffer, fs_offset_t filesi
 
 	memcpy( sound.wav, buffer + (iff_dataPtr - buffer), sound.size );
 
+	// swap 16-bit samples from little endian to native
+	if( sound.width == 2 )
+	{
+		short *p = (short *)sound.wav;
+		int count = sound.size / 2;
+		for( int i = 0; i < count; i++ )
+			p[i] = LittleShort( p[i] );
+	}
+
 	// now convert 8-bit sounds to signed
 	if( sound.width == 1 )
 	{
@@ -461,6 +470,14 @@ int Stream_ReadWAV( stream_t *stream, int bytes, void *buffer )
 
 	stream->pos += bytes;
 	FS_Read( stream->file, buffer, bytes );
+
+	if( stream->width == 2 )
+	{
+		short *p = (short *)buffer;
+		int count = bytes / 2;
+		for( int i = 0; i < count; i++ )
+			p[i] = LittleShort( p[i] );
+	}
 
 	return bytes;
 }

--- a/engine/common/imagelib/img_bmp.c
+++ b/engine/common/imagelib/img_bmp.c
@@ -16,6 +16,24 @@ GNU General Public License for more details.
 #include "imagelib.h"
 #include "xash3d_mathlib.h"
 #include "img_bmp.h"
+#include "swaplib.h"
+
+le_struct_begin( bmp_swap )
+	le_struct_field( bmp_t, fileSize )
+	le_struct_field( bmp_t, reserved0 )
+	le_struct_field( bmp_t, bitmapDataOffset )
+	le_struct_field( bmp_t, bitmapHeaderSize )
+	le_struct_field( bmp_t, width )
+	le_struct_field( bmp_t, height )
+	le_struct_field( bmp_t, planes )
+	le_struct_field( bmp_t, bitsPerPixel )
+	le_struct_field( bmp_t, compression )
+	le_struct_field( bmp_t, bitmapDataSize )
+	le_struct_field( bmp_t, hRes )
+	le_struct_field( bmp_t, vRes )
+	le_struct_field( bmp_t, colors )
+	le_struct_field( bmp_t, importantColors )
+le_struct_end();
 
 /*
 =============
@@ -41,6 +59,7 @@ qboolean Image_LoadBMP( const char *name, const byte *buffer, fs_offset_t filesi
 
 	buf_p = (byte *)buffer;
 	memcpy( &bhdr, buf_p, sizeof( bmp_t ));
+	le_struct_swap( bmp_swap, &bhdr );
 	buf_p += BI_FILE_HEADER_SIZE + bhdr.bitmapHeaderSize;
 
 	// bogus file header check
@@ -282,7 +301,8 @@ qboolean Image_LoadBMP( const char *name, const byte *buffer, fs_offset_t filesi
 				}
 				break;
 			case 16:
-				shortPixel = *(word *)buf_p, buf_p += 2;
+				shortPixel = buf_p[0] | (buf_p[1] << 8);
+				buf_p += 2;
 				*pixbuf++ = blue = (shortPixel & ( 31 << 10 )) >> 7;
 				*pixbuf++ = green = (shortPixel & ( 31 << 5 )) >> 2;
 				*pixbuf++ = red = (shortPixel & ( 31 )) << 3;
@@ -396,7 +416,9 @@ qboolean Image_SaveBMP( const char *name, rgbdata_t *pix )
 	hdr.colors = ( pixel_size == 1 ) ? 256 : 0;
 	hdr.importantColors = 0;
 
+	le_struct_swap( bmp_swap, &hdr );
 	FS_Write( pfile, &hdr, sizeof( bmp_t ));
+	le_struct_swap( bmp_swap, &hdr );
 
 	pbBmpBits = Mem_Malloc( host.imagepool, cbBmpBits );
 

--- a/engine/common/imagelib/img_dds.c
+++ b/engine/common/imagelib/img_dds.c
@@ -16,6 +16,49 @@ GNU General Public License for more details.
 #include "imagelib.h"
 #include "xash3d_mathlib.h"
 #include "img_dds.h"
+#include "swaplib.h"
+
+le_struct_begin( dds_pixf_swap )
+	le_struct_field( dds_pixf_t, dwSize )
+	le_struct_field( dds_pixf_t, dwFlags )
+	le_struct_field( dds_pixf_t, dwFourCC )
+	le_struct_field( dds_pixf_t, dwRGBBitCount )
+	le_struct_field( dds_pixf_t, dwRBitMask )
+	le_struct_field( dds_pixf_t, dwGBitMask )
+	le_struct_field( dds_pixf_t, dwBBitMask )
+	le_struct_field( dds_pixf_t, dwABitMask )
+le_struct_end();
+
+le_struct_begin( dds_caps_swap )
+	le_struct_field( dds_caps_t, dwCaps1 )
+	le_struct_field( dds_caps_t, dwCaps2 )
+	le_struct_field( dds_caps_t, dwCaps3 )
+	le_struct_field( dds_caps_t, dwCaps4 )
+le_struct_end();
+
+le_struct_begin( dds_swap )
+	le_struct_field( dds_t, dwIdent )
+	le_struct_field( dds_t, dwSize )
+	le_struct_field( dds_t, dwFlags )
+	le_struct_field( dds_t, dwHeight )
+	le_struct_field( dds_t, dwWidth )
+	le_struct_field( dds_t, dwLinearSize )
+	le_struct_field( dds_t, dwDepth )
+	le_struct_field( dds_t, dwMipMapCount )
+	le_struct_field( dds_t, dwAlphaBitDepth )
+	le_struct_array( dds_t, dwReserved1, 10 )
+	le_struct_child( dds_t, dsPixelFormat, dds_pixf_swap )
+	le_struct_child( dds_t, dsCaps, dds_caps_swap )
+	le_struct_field( dds_t, dwTextureStage )
+le_struct_end();
+
+le_struct_begin( dds_dxt10_swap )
+	le_struct_field( dds_header_dxt10_t, dxgiFormat )
+	le_struct_field( dds_header_dxt10_t, resourceDimension )
+	le_struct_field( dds_header_dxt10_t, miscFlag )
+	le_struct_field( dds_header_dxt10_t, arraySize )
+	le_struct_field( dds_header_dxt10_t, miscFlags2 )
+le_struct_end();
 
 static qboolean Image_CheckDXT3Alpha( dds_t *hdr, byte *fin )
 {
@@ -295,6 +338,7 @@ qboolean Image_LoadDDS( const char *name, const byte *buffer, fs_offset_t filesi
 		return false;
 
 	memcpy( &header, buffer, sizeof( header ));
+	le_struct_swap( dds_swap, &header );
 
 	if( header.dwIdent != DDSHEADER )
 		return false; // it's not a dds file, just skip it
@@ -315,6 +359,7 @@ qboolean Image_LoadDDS( const char *name, const byte *buffer, fs_offset_t filesi
 	if( header.dsPixelFormat.dwFourCC == TYPE_DX10 )
 	{
 		memcpy( &header2, buffer + sizeof( header ), sizeof( header2 ));
+		le_struct_swap( dds_dxt10_swap, &header2 );
 		headersOffset += sizeof( header2 );
 	}
 

--- a/engine/common/imagelib/img_ktx2.c
+++ b/engine/common/imagelib/img_ktx2.c
@@ -16,6 +16,34 @@ GNU General Public License for more details.
 #include "imagelib.h"
 #include "xash3d_mathlib.h"
 #include "img_ktx2.h"
+#include "swaplib.h"
+
+le_struct_begin( ktx2_header_swap )
+	le_struct_field( ktx2_header_t, vkFormat )
+	le_struct_field( ktx2_header_t, typeSize )
+	le_struct_field( ktx2_header_t, pixelWidth )
+	le_struct_field( ktx2_header_t, pixelHeight )
+	le_struct_field( ktx2_header_t, pixelDepth )
+	le_struct_field( ktx2_header_t, layerCount )
+	le_struct_field( ktx2_header_t, faceCount )
+	le_struct_field( ktx2_header_t, levelCount )
+	le_struct_field( ktx2_header_t, supercompressionScheme )
+le_struct_end();
+
+le_struct_begin( ktx2_index_swap )
+	le_struct_field( ktx2_index_t, dfdByteOffset )
+	le_struct_field( ktx2_index_t, dfdByteLength )
+	le_struct_field( ktx2_index_t, kvdByteOffset )
+	le_struct_field( ktx2_index_t, kvdByteLength )
+	le_struct_field( ktx2_index_t, sgdByteOffset )
+	le_struct_field( ktx2_index_t, sgdByteLength )
+le_struct_end();
+
+le_struct_begin( ktx2_level_swap )
+	le_struct_field( ktx2_level_t, byteOffset )
+	le_struct_field( ktx2_level_t, byteLength )
+	le_struct_field( ktx2_level_t, uncompressedByteLength )
+le_struct_end();
 
 static void Image_KTX2Format( uint32_t ktx2_format )
 {
@@ -125,6 +153,7 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 	}
 
 	memcpy( &index, buffer + KTX2_IDENTIFIER_SIZE + sizeof( ktx2_header_t ), sizeof( index ));
+	le_struct_swap( ktx2_index_swap, &index );
 
 	for( mip = 0; mip < header->levelCount; ++mip )
 	{
@@ -134,6 +163,7 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 
 		ktx2_level_t level;
 		memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
+		le_struct_swap( ktx2_level_swap, &level );
 
 		if( mip_size != level.byteLength )
 		{
@@ -159,6 +189,7 @@ static qboolean Image_KTX2Parse( const ktx2_header_t *header, const byte *buffer
 	{
 		ktx2_level_t level;
 		memcpy( &level, levels_begin + mip * sizeof( level ), sizeof( level ));
+		le_struct_swap( ktx2_level_swap, &level );
 		memcpy( image.rgba + cursor, buffer + level.byteOffset, level.byteLength );
 		cursor += level.byteLength;
 	}
@@ -180,6 +211,7 @@ qboolean Image_LoadKTX2( const char *name, const byte *buffer, fs_offset_t files
 	}
 
 	memcpy( &header, buffer + KTX2_IDENTIFIER_SIZE, sizeof( header ));
+	le_struct_swap( ktx2_header_swap, &header );
 
 	image.width = header.pixelWidth;
 	image.height = header.pixelHeight;

--- a/engine/common/imagelib/img_tga.c
+++ b/engine/common/imagelib/img_tga.c
@@ -16,6 +16,16 @@ GNU General Public License for more details.
 #include "imagelib.h"
 #include "xash3d_mathlib.h"
 #include "img_tga.h"
+#include "swaplib.h"
+
+le_struct_begin( tga_swap )
+	le_struct_field( tga_t, colormap_index )
+	le_struct_field( tga_t, colormap_length )
+	le_struct_field( tga_t, x_origin )
+	le_struct_field( tga_t, y_origin )
+	le_struct_field( tga_t, width )
+	le_struct_field( tga_t, height )
+le_struct_end();
 
 /*
 =============
@@ -44,10 +54,10 @@ qboolean Image_LoadTGA( const char *name, const byte *buffer, fs_offset_t filesi
 	targa_header.colormap_index = buf_p[0] + buf_p[1] * 256;		buf_p += 2;
 	targa_header.colormap_length = buf_p[0] + buf_p[1] * 256;		buf_p += 2;
 	targa_header.colormap_size = *buf_p;				buf_p += 1;
-	targa_header.x_origin = *(short *)buf_p;			buf_p += 2;
-	targa_header.y_origin = *(short *)buf_p;			buf_p += 2;
-	targa_header.width = image.width = *(short *)buf_p;		buf_p += 2;
-	targa_header.height = image.height = *(short *)buf_p;		buf_p += 2;
+	targa_header.x_origin = buf_p[0] + buf_p[1] * 256;		buf_p += 2;
+	targa_header.y_origin = buf_p[0] + buf_p[1] * 256;		buf_p += 2;
+	targa_header.width = image.width = buf_p[0] + buf_p[1] * 256;	buf_p += 2;
+	targa_header.height = image.height = buf_p[0] + buf_p[1] * 256;	buf_p += 2;
 	targa_header.pixel_size = *buf_p++;
 	targa_header.attributes = *buf_p++;
 	if( targa_header.id_length != 0 ) buf_p += targa_header.id_length;	// skip TARGA image comment
@@ -284,6 +294,7 @@ qboolean Image_SaveTGA( const char *name, rgbdata_t *pix )
 
 	out = buffer;
 
+	le_struct_swap( tga_swap, &targa_header );
 	memcpy( out, &targa_header, sizeof( tga_t ) );
 	out += sizeof( tga_t );
 

--- a/engine/common/imagelib/img_utils.c
+++ b/engine/common/imagelib/img_utils.c
@@ -285,66 +285,34 @@ int Image_ComparePalette( const byte *pal )
 
 static void Image_SetPalette( const byte *pal, uint *d_table )
 {
-	byte	rgba[4];
-	uint uirgba; // TODO: palette looks byte-swapped on big-endian
-	int	i;
-
-	// setup palette
 	switch( image.d_rendermode )
 	{
 	case LUMP_NORMAL:
-		for( i = 0; i < 256; i++ )
-		{
-			memcpy( rgba, &pal[i * 3], 3 );
-			rgba[3] = 0xFF;
-			memcpy( &uirgba, rgba, sizeof( uirgba ));
-			d_table[i] = uirgba;
-		}
+		for( int i = 0; i < 256; i++ )
+			d_table[i] = HostFourCC( pal[i * 3 + 0], pal[i * 3 + 1], pal[i * 3 + 2], 0xFF );
 		break;
 	case LUMP_TEXGAMMA:
-		for( i = 0; i < 256; i++ )
+		for( int i = 0; i < 256; i++ )
 		{
-			rgba[0] = TextureToGamma( pal[i * 3 + 0] );
-			rgba[1] = TextureToGamma( pal[i * 3 + 1] );
-			rgba[2] = TextureToGamma( pal[i * 3 + 2] );
-			rgba[3] = 0xFF;
-			memcpy( &uirgba, rgba, sizeof( uirgba ));
-			d_table[i] = uirgba;
+			d_table[i] = HostFourCC(
+				TextureToGamma( pal[i * 3 + 0] ),
+				TextureToGamma( pal[i * 3 + 1] ),
+				TextureToGamma( pal[i * 3 + 2] ),
+				0xFF );
 		}
 		break;
 	case LUMP_GRADIENT:
-		for( i = 0; i < 256; i++ )
-		{
-			rgba[0] = pal[765];
-			rgba[1] = pal[766];
-			rgba[2] = pal[767];
-			rgba[3] = i;
-			memcpy( &uirgba, rgba, sizeof( uirgba ));
-			d_table[i] = uirgba;
-		}
+		for( int i = 0; i < 256; i++ )
+			d_table[i] = HostFourCC( pal[765], pal[766], pal[767], i );
 		break;
 	case LUMP_MASKED:
-		for( i = 0; i < 255; i++ )
-		{
-			rgba[0] = pal[i*3+0];
-			rgba[1] = pal[i*3+1];
-			rgba[2] = pal[i*3+2];
-			rgba[3] = 0xFF;
-			memcpy( &uirgba, rgba, sizeof( uirgba ));
-			d_table[i] = uirgba;
-		}
+		for( int i = 0; i < 255; i++ )
+			d_table[i] = HostFourCC( pal[i * 3 + 0], pal[i * 3 + 1], pal[i * 3 + 2], 0xFF );
 		d_table[255] = 0;
 		break;
 	case LUMP_EXTENDED:
-		for( i = 0; i < 256; i++ )
-		{
-			rgba[0] = pal[i*4+0];
-			rgba[1] = pal[i*4+1];
-			rgba[2] = pal[i*4+2];
-			rgba[3] = pal[i*4+3];
-			memcpy( &uirgba, rgba, sizeof( uirgba ));
-			d_table[i] = uirgba;
-		}
+		for( int i = 0; i < 256; i++ )
+			d_table[i] = HostFourCC( pal[i * 4 + 0], pal[i * 4 + 1], pal[i * 4 + 2], pal[i * 4 + 3] );
 		break;
 	}
 }

--- a/engine/common/imagelib/img_wad.c
+++ b/engine/common/imagelib/img_wad.c
@@ -19,6 +19,43 @@ GNU General Public License for more details.
 #include "studio.h"
 #include "sprite.h"
 #include "qfont.h"
+#include "swaplib.h"
+
+le_struct_begin( charinfo_swap )
+	le_struct_field( charinfo, startoffset )
+	le_struct_field( charinfo, charwidth )
+le_struct_end();
+
+le_struct_begin( qfont_swap )
+	le_struct_field( qfont_t, width )
+	le_struct_field( qfont_t, height )
+	le_struct_field( qfont_t, rowcount )
+	le_struct_field( qfont_t, rowheight )
+	le_struct_array_child( qfont_t, fontinfo, charinfo_swap, NUM_GLYPHS )
+le_struct_end();
+
+le_struct_begin( lmp_swap )
+	le_struct_field( lmp_t, width )
+	le_struct_field( lmp_t, height )
+le_struct_end();
+
+le_struct_begin( mip_swap )
+	le_struct_field( mip_t, width )
+	le_struct_field( mip_t, height )
+	le_struct_array( mip_t, offsets, 4 )
+le_struct_end();
+
+le_struct_begin( dwadinfo_swap )
+	le_struct_field( dwadinfo_t, ident )
+	le_struct_field( dwadinfo_t, numlumps )
+	le_struct_field( dwadinfo_t, infotableofs )
+le_struct_end();
+
+le_struct_begin( dlumpinfo_swap )
+	le_struct_field( dlumpinfo_t, filepos )
+	le_struct_field( dlumpinfo_t, disksize )
+	le_struct_field( dlumpinfo_t, size )
+le_struct_end();
 
 /*
 ============
@@ -98,6 +135,7 @@ qboolean Image_LoadFNT( const char *name, const byte *buffer, fs_offset_t filesi
 		return false;
 
 	memcpy( &font, buffer, sizeof( font ));
+	le_struct_swap( qfont_swap, &font );
 
 	// last sixty four bytes - what the hell ????
 	size = sizeof( qfont_t ) - 4 + ( font.height * font.width * QCHAR_WIDTH ) + sizeof( short ) + 768 + 64;
@@ -120,7 +158,8 @@ qboolean Image_LoadFNT( const char *name, const byte *buffer, fs_offset_t filesi
 
 	fin = buffer + sizeof( font ) - 4;
 	pal = fin + (image.width * image.height);
-	numcolors = *(short *)pal, pal += sizeof( short );
+	numcolors = pal[0] | (pal[1] << 8);
+	pal += sizeof( short );
 
 	if( numcolors == 768 || numcolors == 256 )
 	{
@@ -305,6 +344,7 @@ qboolean Image_LoadLMP( const char *name, const byte *buffer, fs_offset_t filesi
 	{
 		fin = (byte *)buffer;
 		memcpy( &lmp, fin, sizeof( lmp ));
+		le_struct_swap( lmp_swap, &lmp );
 		image.width = lmp.width;
 		image.height = lmp.height;
 		rendermode = LUMP_NORMAL;
@@ -337,7 +377,7 @@ qboolean Image_LoadLMP( const char *name, const byte *buffer, fs_offset_t filesi
 			}
 		}
 		pal = fin + pixels;
-		numcolors = *(short *)pal;
+		numcolors = pal[0] | (pal[1] << 8);
 		if( numcolors != 256 ) pal = NULL; // corrupted lump ?
 		else pal += sizeof( short );
 	}
@@ -397,6 +437,7 @@ qboolean Image_LoadMIP( const char *name, const byte *buffer, fs_offset_t filesi
 		return false;
 
 	memcpy( &mip, buffer, sizeof( mip ));
+	le_struct_swap( mip_swap, &mip );
 	image.width = mip.width;
 	image.height = mip.height;
 
@@ -411,7 +452,7 @@ qboolean Image_LoadMIP( const char *name, const byte *buffer, fs_offset_t filesi
 		// half-life 1.0.0.1 mip version with palette
 		fin = (byte *)buffer + mip.offsets[0];
 		pal = (byte *)buffer + mip.offsets[0] + (((image.width * image.height) * 85)>>6);
-		numcolors = *(short *)pal;
+		numcolors = pal[0] | (pal[1] << 8);
 		if( numcolors != 256 ) pal = NULL; // corrupted mip ?
 		else pal += sizeof( short ); // skip colorsize
 
@@ -596,24 +637,23 @@ Image_LoadWAD
 */
 qboolean Image_LoadWAD( const char *name, const byte *buffer, fs_offset_t filesize )
 {
-	const dwadinfo_t    *header;
-	const dlumpinfo_t   *lumps;
+	dwadinfo_t whdr;
 	const unsigned char *mipdata;
 	int i, j;
 
 	if( !buffer || filesize < sizeof( dwadinfo_t ))
 		return false;
 
-	header = (const dwadinfo_t *)buffer;
-	if( header->numlumps <= 0 || header->infotableofs <= 0 || header->infotableofs >= (int)filesize )
+	memcpy( &whdr, buffer, sizeof( whdr ));
+	le_struct_swap( dwadinfo_swap, &whdr );
+	if( whdr.numlumps <= 0 || whdr.infotableofs <= 0 || whdr.infotableofs >= (int)filesize )
 		return false;
 
-	lumps = (const dlumpinfo_t *)((const unsigned char *)buffer + header->infotableofs );
-
-	for( i = 0; i < header->numlumps; ++i )
+	for( i = 0; i < whdr.numlumps; ++i )
 	{
 		const unsigned char *pixels, *palette, *use_palette;
 		unsigned char grad_palette[256 * 3];
+		dlumpinfo_t lump;
 		int mip_size;
 		mip_t mip;
 		uint32_t      width, height, offset0;
@@ -623,16 +663,20 @@ qboolean Image_LoadWAD( const char *name, const byte *buffer, fs_offset_t filesi
 		float t;
 		byte  idx;
 
-		if( lumps[i].type != TYP_MIPTEX && lumps[i].type != TYP_PALETTE )
+		memcpy( &lump, buffer + whdr.infotableofs + i * sizeof( dlumpinfo_t ), sizeof( lump ));
+		le_struct_swap( dlumpinfo_swap, &lump );
+
+		if( lump.type != TYP_MIPTEX && lump.type != TYP_PALETTE )
 			continue;
 
 		// get lump data and validate
-		mipdata = (const unsigned char *)buffer + lumps[i].filepos;
-		mip_size = lumps[i].disksize;
-		if( lumps[i].filepos < 0 || lumps[i].filepos + mip_size > (int)filesize )
+		mipdata = (const unsigned char *)buffer + lump.filepos;
+		mip_size = lump.disksize;
+		if( lump.filepos < 0 || lump.filepos + mip_size > (int)filesize )
 			continue;
 
 		memcpy( &mip, mipdata, sizeof( mip ));
+		le_struct_swap( mip_swap, &mip );
 		width = mip.width;
 		height = mip.height;
 
@@ -652,7 +696,7 @@ qboolean Image_LoadWAD( const char *name, const byte *buffer, fs_offset_t filesi
 		use_palette = palette;
 
 		// handle gradient palette
-		if( lumps[i].type == TYP_PALETTE )
+		if( lump.type == TYP_PALETTE )
 		{
 			// gradient palette
 			const unsigned char *frontColorPtr = palette + 255 * 3;
@@ -755,12 +799,16 @@ qboolean Image_SaveWAD( const char *name, rgbdata_t *pix )
 	header.ident = IDWAD3HEADER;
 	header.numlumps = 1;
 
+	le_struct_swap( dwadinfo_swap, &header );
 	FS_Write( f, &header, sizeof( header ));
+	le_struct_swap( mip_swap, &miptex );
 	FS_Write( f, &miptex, sizeof( mip_t ));
+	le_struct_swap( mip_swap, &miptex );
 	FS_Write( f, pix->buffer, m0size );
 	FS_Write( f, mip1_data, m1size );
 	FS_Write( f, mip2_data, m2size );
 	FS_Write( f, mip3_data, m3size );
+	palette_size = LittleShort( palette_size );
 	FS_Write( f, &palette_size, sizeof( short ));
 
 	if( lump_type == TYP_PALETTE )
@@ -793,10 +841,11 @@ qboolean Image_SaveWAD( const char *name, rgbdata_t *pix )
 	lump.type = (char)lump_type;
 	lump.attribs = 0;
 	Q_strncpy( lump.name, "tempdecal", sizeof( lump.name ));
+	le_struct_swap( dlumpinfo_swap, &lump );
 	FS_Write( f, &lump, sizeof( lump ));
 
 	FS_Seek( f, offsetof( dwadinfo_t, infotableofs ), SEEK_SET );
-	infotableofs32 = (int)infotableofs;
+	infotableofs32 = LittleLong((int)infotableofs );
 	FS_Write( f, &infotableofs32, sizeof( int ));
 
 	FS_Close( f );

--- a/engine/common/imagelib/img_wad.c
+++ b/engine/common/imagelib/img_wad.c
@@ -437,7 +437,8 @@ qboolean Image_LoadMIP( const char *name, const byte *buffer, fs_offset_t filesi
 		return false;
 
 	memcpy( &mip, buffer, sizeof( mip ));
-	le_struct_swap( mip_swap, &mip );
+	if( !Image_CheckFlag( IL_HOST_ENDIAN ))
+		le_struct_swap( mip_swap, &mip );
 	image.width = mip.width;
 	image.height = mip.height;
 

--- a/engine/common/mod_bmodel.c
+++ b/engine/common/mod_bmodel.c
@@ -2723,6 +2723,7 @@ static void Mod_InitSkyClouds( model_t *mod, const mip_t *mt, texture_t *tx, qbo
 		if( custom_palette )
 			size += sizeof( short ) + 768;
 
+		Image_SetForceFlags( IL_HOST_ENDIAN );
 		r_sky = FS_LoadImage( texname, (byte *)mt, size );
 	}
 	else
@@ -2905,7 +2906,7 @@ static void Mod_LoadTextureData( model_t *mod, dbspmodel_t *bmod, int textureInd
 		const size_t size = Mod_CalculateMipTexSize( mipTex, usesCustomPalette );
 
 		Q_snprintf( texName, sizeof( texName ), "#%s:%s.mip", loadstat.name, mipTex->name );
-		Image_SetForceFlags( texture_force_flags );
+		Image_SetForceFlags( texture_force_flags | IL_HOST_ENDIAN );
 		texture->gl_texturenum = ref.dllFuncs.GL_LoadTexture( texName, (byte *)mipTex, size, txFlags );
 	}
 
@@ -2938,7 +2939,7 @@ static void Mod_LoadTextureData( model_t *mod, dbspmodel_t *bmod, int textureInd
 
 		Q_snprintf( texName, sizeof( texName ), "#%s:%s_luma.mip", loadstat.name, mipTex->name );
 
-		Image_SetForceFlags( texture_force_flags );
+		Image_SetForceFlags( texture_force_flags | IL_HOST_ENDIAN );
 
 		if( mipTex->offsets[0] > 0 )
 		{

--- a/engine/common/mod_local.h
+++ b/engine/common/mod_local.h
@@ -191,6 +191,7 @@ void Mod_StudioGetAttachment( const edict_t *e, int iAttachment, float *org, flo
 void Mod_GetBonePosition( const edict_t *e, int iBone, float *org, float *ang );
 hull_t *Mod_HullForStudio( model_t *m, float frame, int seq, vec3_t ang, vec3_t org, vec3_t size, byte *pcnt, byte *pbl, int *hitboxes, edict_t *ed );
 void *R_StudioGetAnim( studiohdr_t *m_pStudioHeader, model_t *m_pSubModel, mstudioseqdesc_t *pseqdesc );
+void Mod_SwapStudioSeqGroupAnims( studiohdr_t *phdr, mstudioseqdesc_t *pseq, byte *buf );
 int Mod_HitgroupForStudioHull( int index );
 void Mod_ClearStudioCache( void );
 

--- a/engine/common/mod_studio.c
+++ b/engine/common/mod_studio.c
@@ -162,7 +162,6 @@ le_struct_begin( mstudioattachment_swap )
 	le_struct_field( mstudioattachment_t, flags )
 	le_struct_field( mstudioattachment_t, bone )
 	le_struct_array( mstudioattachment_t, org, 3 )
-	le_struct_array( mstudioattachment_t, vectors, 3 * 3 )
 le_struct_end();
 
 le_struct_begin( mstudiobodyparts_swap )
@@ -977,6 +976,9 @@ static qboolean Mod_SwapStudioModel( const char *name, void *buffer, size_t buff
 	if( phdr->ident != IDSTUDIOHEADER || phdr->version != STUDIO_VERSION )
 		return false;
 
+
+
+
 #if XASH_BIG_ENDIAN
 	if( phdr->studiohdr2index > 0 && phdr->studiohdr2index < phdr->length )
 	{
@@ -998,7 +1000,11 @@ static qboolean Mod_SwapStudioModel( const char *name, void *buffer, size_t buff
 		le_struct_swap( mstudioseqgroup_swap, (mstudioseqgroup_t *)( mod_base + phdr->seqgroupindex ) + i );
 
 	for( int i = 0; i < phdr->numattachments; i++ )
-		le_struct_swap( mstudioattachment_swap, (mstudioattachment_t *)( mod_base + phdr->attachmentindex ) + i );
+	{
+		mstudioattachment_t *pattach = (mstudioattachment_t *)( mod_base + phdr->attachmentindex ) + i;
+		le_struct_swap( mstudioattachment_swap, pattach );
+		le_array_swap((float *)pattach->vectors, 3 * 3 );
+	}
 
 	for( int i = 0; i < phdr->numtextures; i++ )
 		le_struct_swap( mstudiotexture_swap, (mstudiotexture_t *)( mod_base + phdr->textureindex ) + i );
@@ -1013,6 +1019,38 @@ static qboolean Mod_SwapStudioModel( const char *name, void *buffer, size_t buff
 
 		for( int j = 0; j < pseq->numevents; j++ )
 			le_struct_swap( mstudioevent_swap, (mstudioevent_t *)( mod_base + pseq->eventindex ) + j );
+
+		if( pseq->seqgroup != 0 )
+			continue;
+
+		mstudioanim_t *panim = (mstudioanim_t *)( mod_base + pseq->animindex );
+		int numanims = pseq->numblends * phdr->numbones;
+
+		for( int j = 0; j < numanims; j++, panim++ )
+		{
+			le_struct_swap( mstudioanim_swap, panim );
+
+			for( int k = 0; k < 6; k++ )
+			{
+				if( panim->offset[k] == 0 )
+					continue;
+
+				mstudioanimvalue_t *panimvalue = (mstudioanimvalue_t *)((byte *)panim + panim->offset[k] );
+
+				int frames = pseq->numframes;
+				while( frames > 0 )
+				{
+					int valid = panimvalue->num.valid;
+					int total = panimvalue->num.total;
+
+					for( int l = 1; l <= valid; l++ )
+						panimvalue[l].value = LittleShort( panimvalue[l].value );
+
+					panimvalue += valid + 1;
+					frames -= total;
+				}
+			}
+		}
 	}
 
 	for( int i = 0; i < phdr->numbodyparts; i++ )
@@ -1024,8 +1062,25 @@ static qboolean Mod_SwapStudioModel( const char *name, void *buffer, size_t buff
 			mstudiomodel_t *pmodel = (mstudiomodel_t *)( mod_base + pbodypart->modelindex ) + j;
 			le_struct_swap( mstudiomodel_swap, pmodel );
 
+			le_array_swap((float *)( mod_base + pmodel->vertindex ), pmodel->numverts * 3 );
+			le_array_swap((float *)( mod_base + pmodel->normindex ), pmodel->numnorms * 3 );
+
 			for( int k = 0; k < pmodel->nummesh; k++ )
-				le_struct_swap( mstudiomesh_swap, (mstudiomesh_t *)( mod_base + pmodel->meshindex ) + k );
+			{
+				mstudiomesh_t *pmesh = (mstudiomesh_t *)( mod_base + pmodel->meshindex ) + k;
+				le_struct_swap( mstudiomesh_swap, pmesh );
+
+				short *ptricmds = (short *)( mod_base + pmesh->triindex );
+				short n;
+				while(( n = LittleShort( *ptricmds )))
+				{
+					*ptricmds++ = n;
+					int count = abs( n ) * 4;
+					for( int l = 0; l < count; l++, ptricmds++ )
+						*ptricmds = LittleShort( *ptricmds );
+				}
+				*ptricmds = 0;
+			}
 		}
 	}
 

--- a/engine/common/mod_studio.c
+++ b/engine/common/mod_studio.c
@@ -550,6 +550,38 @@ static void Mod_StudioCalcRotations( int boneused[], int numbones, const byte *p
 }
 
 
+static void Mod_SwapStudioSeqGroupAnims( studiohdr_t *phdr, mstudioseqdesc_t *pseq, byte *buf )
+{
+	mstudioanim_t *panim = (mstudioanim_t *)( buf + pseq->animindex );
+	int numanims = pseq->numblends * phdr->numbones;
+
+	for( int j = 0; j < numanims; j++, panim++ )
+	{
+		le_struct_swap( mstudioanim_swap, panim );
+
+		for( int k = 0; k < 6; k++ )
+		{
+			if( panim->offset[k] == 0 )
+				continue;
+
+			mstudioanimvalue_t *panimvalue = (mstudioanimvalue_t *)((byte *)panim + panim->offset[k] );
+
+			int frames = pseq->numframes;
+			while( frames > 0 )
+			{
+				int valid = panimvalue->num.valid;
+				int total = panimvalue->num.total;
+
+				for( int l = 1; l <= valid; l++ )
+					panimvalue[l].value = LittleShort( panimvalue[l].value );
+
+				panimvalue += valid + 1;
+				frames -= total;
+			}
+		}
+	}
+}
+
 /*
 ====================
 StudioGetAnim
@@ -558,17 +590,10 @@ StudioGetAnim
 */
 void *R_StudioGetAnim( studiohdr_t *m_pStudioHeader, model_t *m_pSubModel, mstudioseqdesc_t *pseqdesc )
 {
-	mstudioseqgroup_t	*pseqgroup;
-	cache_user_t	*paSequences;
-	fs_offset_t	filesize;
-	byte		*buf;
-
-	pseqgroup = (mstudioseqgroup_t *)((byte *)m_pStudioHeader + m_pStudioHeader->seqgroupindex) + pseqdesc->seqgroup;
 	if( pseqdesc->seqgroup == 0 )
 		return ((byte *)m_pStudioHeader + pseqdesc->animindex);
 
-	paSequences = (cache_user_t *)m_pSubModel->submodels;
-
+	cache_user_t *paSequences = (cache_user_t *)m_pSubModel->submodels;
 	if( paSequences == NULL )
 	{
 		paSequences = (cache_user_t *)Mem_Calloc( com_studiocache, MAXSTUDIOGROUPS * sizeof( cache_user_t ));
@@ -578,23 +603,31 @@ void *R_StudioGetAnim( studiohdr_t *m_pStudioHeader, model_t *m_pSubModel, mstud
 	// check for already loaded
 	if( !Mod_CacheCheck(( cache_user_t *)&( paSequences[pseqdesc->seqgroup] )))
 	{
-		string	filepath, modelname, modelpath;
-
+		string modelname;
 		COM_FileBase( m_pSubModel->name, modelname, sizeof( modelname ));
+
+		string modelpath;
 		COM_ExtractFilePath( m_pSubModel->name, modelpath );
 
 		// NOTE: here we build real sub-animation filename because stupid user may rename model without recompile
+		string filepath;
 		Q_snprintf( filepath, sizeof( filepath ), "%s/%s%i%i.mdl", modelpath, modelname, pseqdesc->seqgroup / 10, pseqdesc->seqgroup % 10 );
 
-		buf = FS_LoadFile( filepath, &filesize, false );
-		if( !buf || !filesize ) Host_Error( "%s: can't load %s\n", __func__, filepath );
-		if( IDSEQGRPHEADER != *(uint *)buf ) Host_Error( "%s: %s is corrupted\n", __func__, filepath );
+		fs_offset_t filesize;
+		byte *buf = FS_LoadFile( filepath, &filesize, false );
+		if( !buf || !filesize )
+			Host_Error( "%s: can't load %s\n", __func__, filepath );
+		if( LittleLong( IDSEQGRPHEADER ) != *(uint *)buf )
+			Host_Error( "%s: %s is corrupted\n", __func__, filepath );
 
 		Con_Printf( "loading: %s\n", filepath );
 
 		paSequences[pseqdesc->seqgroup].data = Mem_Calloc( com_studiocache, filesize );
 		memcpy( paSequences[pseqdesc->seqgroup].data, buf, filesize );
 		Mem_Free( buf );
+
+		Mod_SwapStudioSeqGroupAnims( m_pStudioHeader, pseqdesc,
+			(byte *)paSequences[pseqdesc->seqgroup].data );
 	}
 
 	return ((byte *)paSequences[pseqdesc->seqgroup].data + pseqdesc->animindex);
@@ -1023,34 +1056,7 @@ static qboolean Mod_SwapStudioModel( const char *name, void *buffer, size_t buff
 		if( pseq->seqgroup != 0 )
 			continue;
 
-		mstudioanim_t *panim = (mstudioanim_t *)( mod_base + pseq->animindex );
-		int numanims = pseq->numblends * phdr->numbones;
-
-		for( int j = 0; j < numanims; j++, panim++ )
-		{
-			le_struct_swap( mstudioanim_swap, panim );
-
-			for( int k = 0; k < 6; k++ )
-			{
-				if( panim->offset[k] == 0 )
-					continue;
-
-				mstudioanimvalue_t *panimvalue = (mstudioanimvalue_t *)((byte *)panim + panim->offset[k] );
-
-				int frames = pseq->numframes;
-				while( frames > 0 )
-				{
-					int valid = panimvalue->num.valid;
-					int total = panimvalue->num.total;
-
-					for( int l = 1; l <= valid; l++ )
-						panimvalue[l].value = LittleShort( panimvalue[l].value );
-
-					panimvalue += valid + 1;
-					frames -= total;
-				}
-			}
-		}
+		Mod_SwapStudioSeqGroupAnims( phdr, pseq, mod_base );
 	}
 
 	for( int i = 0; i < phdr->numbodyparts; i++ )

--- a/engine/common/mod_studio.c
+++ b/engine/common/mod_studio.c
@@ -550,7 +550,7 @@ static void Mod_StudioCalcRotations( int boneused[], int numbones, const byte *p
 }
 
 
-static void Mod_SwapStudioSeqGroupAnims( studiohdr_t *phdr, mstudioseqdesc_t *pseq, byte *buf )
+void Mod_SwapStudioSeqGroupAnims( studiohdr_t *phdr, mstudioseqdesc_t *pseq, byte *buf )
 {
 	mstudioanim_t *panim = (mstudioanim_t *)( buf + pseq->animindex );
 	int numanims = pseq->numblends * phdr->numbones;

--- a/engine/common/model.c
+++ b/engine/common/model.c
@@ -614,7 +614,7 @@ void GAME_EXPORT Mod_LoadCacheFile( const char *filename, cache_user_t *cu )
 #if XASH_BIG_ENDIAN
 	if( size >= sizeof( int ) && LittleLong( IDSEQGRPHEADER ) == *(uint *)cu->data )
 	{
-		studiohdr_t *phdr = (studiohdr_t *)(intptr_t)REF_GET_PARM( PARM_GET_STUDIO_HDR, 0 );
+		studiohdr_t *phdr = (studiohdr_t *)REF_GET_PARM( PARM_GET_STUDIO_HDR, 0 );
 		if( !phdr )
 			return;
 

--- a/engine/common/model.c
+++ b/engine/common/model.c
@@ -608,6 +608,31 @@ void GAME_EXPORT Mod_LoadCacheFile( const char *filename, cache_user_t *cu )
 	cu->data = Mem_Malloc( com_studiocache, size );
 	memcpy( cu->data, buf, size );
 	Mem_Free( buf );
+
+	// this handles when studio model renderer tries to load sequence files on it's own
+	// which is what they always do in HLSDK
+#if XASH_BIG_ENDIAN
+	if( size >= sizeof( int ) && LittleLong( IDSEQGRPHEADER ) == *(uint *)cu->data )
+	{
+		studiohdr_t *phdr = (studiohdr_t *)(intptr_t)REF_GET_PARM( PARM_GET_STUDIO_HDR, 0 );
+		if( !phdr )
+			return;
+
+		mstudioseqdesc_t *pseq = (mstudioseqdesc_t *)((byte *)phdr + phdr->seqindex );
+
+		for( int i = 0; i < phdr->numseq; i++ )
+		{
+			if( pseq[i].seqgroup == 0 )
+				continue;
+
+			mstudioseqgroup_t *pgrp = (mstudioseqgroup_t *)((byte *)phdr + phdr->seqgroupindex ) + pseq[i].seqgroup;
+
+			// assuming filename passes seqgroup's name
+			if( !Q_stricmp( pgrp->name, filename ))
+				Mod_SwapStudioSeqGroupAnims( phdr, &pseq[i], (byte *)cu->data );
+		}
+	}
+#endif
 }
 
 /*

--- a/engine/common/soundlib/snd_utils.c
+++ b/engine/common/soundlib/snd_utils.c
@@ -84,37 +84,37 @@ void Sound_Shutdown( void )
 
 uint GAME_EXPORT Sound_GetApproxWavePlayLen( const char *filepath )
 {
-	string    name;
-	file_t    *f;
-	wavehdr_t wav;
-	size_t    filesize;
-	uint      msecs;
-
+	string name;
 	Q_strncpy( name, filepath, sizeof( name ));
 	COM_FixSlashes( name );
 
-	f = FS_Open( name, "rb", false );
+	file_t *f = FS_Open( name, "rb", false );
 	if( !f )
 		return 0;
 
+	wavehdr_t wav;
 	if( FS_Read( f, &wav, sizeof( wav )) != sizeof( wav ))
 	{
 		FS_Close( f );
 		return 0;
 	}
 
-	filesize = FS_FileLength( f );
-	filesize -= 128; // magic number from GoldSrc, seems to be header size
+	// magic number from GoldSrc, seems to be header size
+	size_t filesize = FS_FileLength( f ) - 128;
 
 	FS_Close( f );
 
 	// is real wav file ?
-	if( wav.riff_id != RIFFHEADER || wav.wave_id != WAVEHEADER || wav.fmt_id != FORMHEADER )
+	if( wav.riff_id != LittleLong( RIFFHEADER ) || wav.wave_id != LittleLong( WAVEHEADER ) || wav.fmt_id != LittleLong( FORMHEADER ))
 		return 0;
 
-	if( wav.nAvgBytesPerSec >= 1000 )
-		msecs = (uint)((float)filesize / ((float)wav.nAvgBytesPerSec / 1000.0f));
-	else msecs = (uint)(((float)filesize / (float)wav.nAvgBytesPerSec) * 1000.0f);
+	int avgBytes = LittleLong( wav.nAvgBytesPerSec );
+	uint msecs;
+
+	if( avgBytes >= 1000 )
+		msecs = (uint)((float)filesize / ((float)avgBytes / 1000.0f));
+	else
+		msecs = (uint)(((float)filesize / (float)avgBytes) * 1000.0f);
 
 	return msecs;
 }

--- a/engine/common/sys_con.c
+++ b/engine/common/sys_con.c
@@ -61,6 +61,8 @@ SYSTEM LOG
 */
 int Sys_LogFileNo( void )
 {
+	if( !s_ld.logfile )
+		return -1;
 	return s_ld.logfileno;
 }
 

--- a/engine/platform/posix/crash_libbacktrace.c
+++ b/engine/platform/posix/crash_libbacktrace.c
@@ -53,16 +53,10 @@ static void Sys_AppendPrint( struct print_data *pd, const char *fmt, ... )
 
 	if( len > 0 )
 	{
-		char ch = '\n';
-
 		if( pd->logfd >= 0 )
-		{
 			write( pd->logfd, pd->message, len );
-			write( pd->logfd, &ch, 1 );
-		}
 
 		write( STDERR_FILENO, pd->message, len );
-		write( STDERR_FILENO, &ch, 1 );
 
 		pd->message += len;
 		pd->len += len;

--- a/engine/platform/posix/crash_libbacktrace.c
+++ b/engine/platform/posix/crash_libbacktrace.c
@@ -55,8 +55,11 @@ static void Sys_AppendPrint( struct print_data *pd, const char *fmt, ... )
 	{
 		char ch = '\n';
 
-		write( pd->logfd, pd->message, len );
-		write( pd->logfd, &ch, 1 );
+		if( pd->logfd >= 0 )
+		{
+			write( pd->logfd, pd->message, len );
+			write( pd->logfd, &ch, 1 );
+		}
 
 		write( STDERR_FILENO, pd->message, len );
 		write( STDERR_FILENO, &ch, 1 );

--- a/engine/platform/posix/crash_libbacktrace.c
+++ b/engine/platform/posix/crash_libbacktrace.c
@@ -27,15 +27,10 @@ static qboolean enable_libbacktrace;
 
 static void Sys_BacktraceError( void *data, const char *msg, int errnum )
 {
-	if( errnum < 0 )
-	{
-		Con_Printf( S_ERROR "no symbol info, no libbacktrace\n" );
-		return;
-	}
+	Con_Printf( S_ERROR "libbacktrace: %s (%d)\n", msg, errnum );
 
-	Con_Printf( S_ERROR "libbacktrace error: %s (%d)\n", msg, errnum );
-
-	enable_libbacktrace = false;
+	if( errnum > 0 )
+		enable_libbacktrace = false;
 }
 
 struct print_data
@@ -136,7 +131,7 @@ int Sys_CrashDetailsLibbacktrace( int logfd, char *message, int len, size_t max_
 	struct print_data pd =
 	{
 		.message = message + len,
-		.message_size = sizeof( message ) - len,
+		.message_size = max_len - len,
 		.logfd = logfd,
 		.len = len,
 	};

--- a/engine/platform/posix/crash_libbacktrace.c
+++ b/engine/platform/posix/crash_libbacktrace.c
@@ -40,7 +40,15 @@ struct print_data
 	int len;
 	int idx;
 	int logfd;
+	qboolean skip_wrappers;
 };
+
+static qboolean Sys_IsCrashHandlerFrame( const char *name )
+{
+	if( !name )
+		return false;
+	return !Q_strcmp( name, "Sys_Crash" ) || !Q_strcmp( name, "Sys_CrashDetailsLibbacktrace" );
+}
 
 static void Sys_AppendPrint( struct print_data *pd, const char *fmt, ... )
 {
@@ -76,6 +84,13 @@ static void Sys_BacktracePrintSyminfo( void *data, uintptr_t pc, const char *sym
 	Dl_info dlinfo = { 0 };
 	const char *module_name;
 
+	if( pd->skip_wrappers )
+	{
+		if( Sys_IsCrashHandlerFrame( symname ))
+			return;
+		pd->skip_wrappers = false;
+	}
+
 	if( dladdr((void *)pc, &dlinfo ))
 		module_name = dlinfo.dli_fname;
 	else module_name = NULL;
@@ -101,6 +116,13 @@ static int Sys_BacktracePrintFull( void *data, uintptr_t pc, const char *filenam
 	struct print_data *pd = data;
 	Dl_info dlinfo = { 0 };
 	const char *module_name;
+
+	if( pd->skip_wrappers )
+	{
+		if( Sys_IsCrashHandlerFrame( function ))
+			return 0;
+		pd->skip_wrappers = false;
+	}
 
 	if( dladdr((void *)pc, &dlinfo ))
 		module_name = dlinfo.dli_fname;
@@ -131,9 +153,10 @@ int Sys_CrashDetailsLibbacktrace( int logfd, char *message, int len, size_t max_
 		.message_size = max_len - len,
 		.logfd = logfd,
 		.len = len,
+		.skip_wrappers = true,
 	};
 
-	backtrace_full( g_bt_state, 1, Sys_BacktracePrintFull, Sys_BacktracePrintError, &pd );
+	backtrace_full( g_bt_state, 0, Sys_BacktracePrintFull, Sys_BacktracePrintError, &pd );
 
 	return pd.len;
 }

--- a/engine/platform/posix/crash_posix.c
+++ b/engine/platform/posix/crash_posix.c
@@ -44,7 +44,8 @@ static void Sys_Crash( int signal, siginfo_t *si, void *context )
 
 	// now get log fd and write trace directly to log
 	logfd = Sys_LogFileNo();
-	write( logfd, message, len );
+	if( logfd >= 0 )
+		write( logfd, message, len );
 
 #if HAVE_LIBBACKTRACE
 	if( have_libbacktrace && !detailed_message )

--- a/engine/platform/sdl1/s_sdl1.c
+++ b/engine/platform/sdl1/s_sdl1.c
@@ -106,7 +106,7 @@ qboolean SNDDMA_Init( void )
 
 	memset( &desired, 0, sizeof( desired ) );
 	desired.freq     = SOUND_DMA_SPEED;
-	desired.format   = AUDIO_S16LSB;
+	desired.format   = AUDIO_S16SYS;
 	desired.samples  = 1024;
 	desired.channels = 2;
 	desired.callback = SDL_SoundCallback;
@@ -119,7 +119,7 @@ qboolean SNDDMA_Init( void )
 		return false;
 	}
 
-	if( obtained.format != AUDIO_S16LSB )
+	if( obtained.format != AUDIO_S16SYS )
 	{
 		Con_Printf( "SDL audio format %d unsupported.\n", obtained.format );
 		goto fail;

--- a/engine/platform/sdl2/s_sdl2.c
+++ b/engine/platform/sdl2/s_sdl2.c
@@ -123,7 +123,7 @@ qboolean SNDDMA_Init( void )
 
 	memset( &desired, 0, sizeof( desired ) );
 	desired.freq     = SOUND_DMA_SPEED;
-	desired.format   = AUDIO_S16LSB;
+	desired.format   = AUDIO_S16SYS;
 	desired.samples  = 1024;
 	desired.channels = 2;
 	desired.callback = SDL_SoundCallback;
@@ -136,7 +136,7 @@ qboolean SNDDMA_Init( void )
 		return false;
 	}
 
-	if( obtained.format != AUDIO_S16LSB )
+	if( obtained.format != AUDIO_S16SYS )
 	{
 		Con_Printf( "SDL audio format %d unsupported.\n", obtained.format );
 		goto fail;
@@ -277,7 +277,7 @@ qboolean VoiceCapture_Init( void )
 
 	SDL_zero( wanted );
 	wanted.freq = voice.samplerate;
-	wanted.format = AUDIO_S16LSB;
+	wanted.format = AUDIO_S16SYS;
 	wanted.channels = VOICE_PCM_CHANNELS;
 	wanted.samples = voice.frame_size;
 	wanted.callback = SDL_SoundInputCallback;

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -72,7 +72,8 @@ GNU General Public License for more details.
 //     Moved RenderAPI and TriAPI filling to renderer via R_FillRenderAPI and R_FillTriAPI
 //     Moved detail textures parsing and cinematic texture management to engine
 //     Moved creation of default textures to the engine
-#define REF_API_VERSION 15
+// 16. RefGetParm return type changed from int to intptr_t.
+#define REF_API_VERSION 16
 
 #define TF_SKY		(TF_SKYSIDE|TF_NOMIPMAP|TF_ALLOW_NEAREST)
 #define TF_FONT		(TF_NOMIPMAP|TF_CLAMP|TF_ALLOW_NEAREST)
@@ -599,7 +600,7 @@ typedef struct ref_interface_s
 	void (*CL_DrawBeams)( int fTrans , BEAM *beams );
 
 	// Xash3D Render Interface
-	int			(*RefGetParm)( int parm, int arg );	// generic
+	intptr_t		(*RefGetParm)( int parm, int arg );	// generic
 
 	// detail texture scale
 	void	(*R_GetDetailScaleForTexture)( int texture, float *xScale, float *yScale );

--- a/engine/ref_api.h
+++ b/engine/ref_api.h
@@ -342,6 +342,7 @@ typedef enum
 	PARM_GET_LIGHTSTYLES_PTR = -20,
 	PARM_GET_DLIGHTS_PTR = -21,
 	PARM_GET_ELIGHTS_PTR = -22,
+	PARM_GET_STUDIO_HDR = -23, // current m_pStudioHeader in renderer
 
 	// implemented by ref_dll
 

--- a/engine/wscript
+++ b/engine/wscript
@@ -186,7 +186,7 @@ def build(bld):
 	# public includes for renderers and utils use
 	bld(name = 'engine_includes', export_includes = '. common common/imagelib', use = 'filesystem_includes')
 
-	libs = ['engine_includes', 'public', 'werror', 'backtrace', 'library_suffix', 'build_vcs']
+	libs = ['engine_includes', 'public', 'werror', 'backtrace_custom', 'library_suffix', 'build_vcs']
 	includes = ['server', 'client', 'client/vgui', 'common/soundlib', 'platform']
 
 	# basic build: dedicated only

--- a/public/swaplib.h
+++ b/public/swaplib.h
@@ -82,9 +82,16 @@ static inline void swap_struct_( const swap_struct_def_t *def, size_t len, byte 
 	}
 }
 
+static inline void swap_array_( byte *data, int32_t elem_size, uint32_t count )
+{
+	for( uint32_t i = 0; i < count; i++ )
+		swap_field_( &data[i * elem_size], elem_size );
+}
+
 // do not use these macros, they will swap structs unconditionally
 // you might want to use le_/be_ macros instead
 #define swap_struct( swapdef, ptr ) swap_struct_(( swapdef ), sizeof( swapdef ) / sizeof( swapdef[0] ), (byte *)( ptr ))
+#define swap_array( ptr, count ) swap_array_((byte *)( ptr ), sizeof( *( ptr )), ( count ))
 
 #define swap_struct_begin( swapdef ) static swap_struct_def_t swapdef[] = {
 #define swap_struct_end() }
@@ -112,6 +119,7 @@ static inline void swap_struct_( const swap_struct_def_t *def, size_t len, byte 
 	#define be_struct_array_child( x, y, z, w ) swap_struct_array_child( x, y, z, w )
 	#define be_struct_end()                   swap_struct_end()
 	#define be_struct_swap( x, y )            swap_struct( x, y )
+	#define be_array_swap( x, y )             swap_array( x, y )
 	#define le_struct_begin( x )
 	#define le_struct_field( x, y )
 	#define le_struct_child( x, y, z )
@@ -119,6 +127,7 @@ static inline void swap_struct_( const swap_struct_def_t *def, size_t len, byte 
 	#define le_struct_array_child( x, y, z, w )
 	#define le_struct_end()                   extern int _le_struct_end_dummy // define as extern variable, to let end() end with ;
 	#define le_struct_swap( x, y )            (void)(y)
+	#define le_array_swap( x, y )             (void)(x)
 #else
 	#define be_struct_begin( x )
 	#define be_struct_field( x, y )
@@ -127,6 +136,7 @@ static inline void swap_struct_( const swap_struct_def_t *def, size_t len, byte 
 	#define be_struct_array_child( x, y, z, w )
 	#define be_struct_end()                   extern int _le_struct_end_dummy
 	#define be_struct_swap( x, y )            (void)(y)
+	#define be_array_swap( x, y )             (void)(x)
 	#define le_struct_begin( x )              swap_struct_begin( x )
 	#define le_struct_field( x, y )           swap_struct_field( x, y )
 	#define le_struct_child( x, y, z )        swap_struct_child( x, y, z )
@@ -134,6 +144,7 @@ static inline void swap_struct_( const swap_struct_def_t *def, size_t len, byte 
 	#define le_struct_array_child( x, y, z, w ) swap_struct_array_child( x, y, z, w )
 	#define le_struct_end()                   swap_struct_end()
 	#define le_struct_swap( x, y )            swap_struct( x, y )
+	#define le_array_swap( x, y )             swap_array( x, y )
 #endif
 
 

--- a/public/swaplib.h
+++ b/public/swaplib.h
@@ -111,7 +111,7 @@ static inline void swap_array_( byte *data, int32_t elem_size, uint32_t count )
 
 // this is done in macros so we can completely avoid defining this
 // in little endian targets
-#ifdef XASH_LITTLE_ENDIAN
+#if XASH_LITTLE_ENDIAN
 	#define be_struct_begin( x )              swap_struct_begin( x )
 	#define be_struct_field( x, y )           swap_struct_field( x, y )
 	#define be_struct_child( x, y, z )        swap_struct_child( x, y, z )

--- a/ref/gl/gl_context.c
+++ b/ref/gl/gl_context.c
@@ -161,7 +161,7 @@ static qboolean Mod_ProcessRenderData( model_t *mod, qboolean create, const byte
 	return loaded;
 }
 
-static int GL_RefGetParm( int parm, int arg )
+static intptr_t GL_RefGetParm( int parm, int arg )
 {
 	gl_texture_t *glt;
 

--- a/ref/gl/gl_context.c
+++ b/ref/gl/gl_context.c
@@ -230,6 +230,8 @@ static int GL_RefGetParm( int parm, int arg )
 			return gl_texture_nearest.value == 0.0f;
 
 		return GL_TextureFilteringEnabled( R_GetTexture( arg ));
+	case PARM_GET_STUDIO_HDR:
+		return (intptr_t)R_StudioGetHeader();
 	default:
 		return ENGINE_GET_PARM_( parm, arg );
 	}

--- a/ref/gl/gl_local.h
+++ b/ref/gl/gl_local.h
@@ -403,6 +403,7 @@ void R_DrawSpriteModel( cl_entity_t *e );
 // gl_studio.c
 //
 void R_StudioInit( void );
+studiohdr_t *R_StudioGetHeader( void );
 void R_StudioLerpMovement( cl_entity_t *e, double time, vec3_t origin, vec3_t angles );
 struct mstudiotex_s *R_StudioGetTexture( cl_entity_t *e );
 int R_GetEntityRenderMode( cl_entity_t *ent );

--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -962,8 +962,17 @@ static void GL_InitExtensionsBigGL( void )
 		pglGetIntegerv( GL_MAX_VERTEX_UNIFORM_COMPONENTS_ARB, &glConfig.max_vertex_uniforms );
 		pglGetIntegerv( GL_MAX_VERTEX_ATTRIBS_ARB, &glConfig.max_vertex_attribs );
 
+		// GLSL sanity check
+		if( glConfig.max_vertex_uniforms <= 0 || glConfig.max_texture_coords < glConfig.max_texture_units || glConfig.max_teximage_units < glConfig.max_texture_units )
+		{
+			gEngfuncs.Con_Reportf( S_NOTE "driver supports GL_ARB_shading_language_100 but has bogus limits, ignoring\n" );
+			GL_SetExtension( GL_SHADER_GLSL100_EXT, false );
+			glConfig.max_texture_coords = glConfig.max_teximage_units = glConfig.max_texture_units;
+			glConfig.max_vertex_uniforms = 0;
+			glConfig.max_vertex_attribs = 0;
+		}
 #if XASH_WIN32 // Win32 only drivers?
-		if( glConfig.hardware_type == GLHW_RADEON && glConfig.max_vertex_uniforms > 512 )
+		else if( glConfig.hardware_type == GLHW_RADEON && glConfig.max_vertex_uniforms > 512 )
 			glConfig.max_vertex_uniforms /= 4; // radeon returns not correct info
 #endif
 	}

--- a/ref/gl/gl_opengl.c
+++ b/ref/gl/gl_opengl.c
@@ -1405,6 +1405,12 @@ void GL_SetupAttributes( int safegl )
 		glw_state.extended = true;
 	}
 
+	if( gEngfuncs.Sys_CheckParm( "-glnoerr" ))
+	{
+		gEngfuncs.Con_Reportf( "Creating a no-error GL context...\n" );
+		gEngfuncs.GL_SetAttribute( REF_GL_CONTEXT_NO_ERROR, 1 );
+	}
+
 	if( safegl > SAFE_DONTCARE )
 	{
 		safegl = -1; // can't retry anymore, can only shutdown engine

--- a/ref/gl/gl_studio.c
+++ b/ref/gl/gl_studio.c
@@ -2602,6 +2602,11 @@ static void R_StudioSetHeader( studiohdr_t *pheader )
 	m_fDoRemap = false;
 }
 
+studiohdr_t *R_StudioGetHeader( void )
+{
+	return m_pStudioHeader;
+}
+
 /*
 ===============
 R_StudioSetRenderModel

--- a/ref/null/r_context.c
+++ b/ref/null/r_context.c
@@ -224,7 +224,7 @@ static void CL_DrawBeams( int fTrans, BEAM *beams )
 	;
 }
 
-static int RefGetParm( int parm, int arg )
+static intptr_t RefGetParm( int parm, int arg )
 {
 	return 0;
 }

--- a/ref/soft/r_context.c
+++ b/ref/soft/r_context.c
@@ -120,7 +120,7 @@ static qboolean GAME_EXPORT Mod_ProcessRenderData( model_t *mod, qboolean create
 	return loaded;
 }
 
-static int GL_RefGetParm( int parm, int arg )
+static intptr_t GL_RefGetParm( int parm, int arg )
 {
 	image_t *glt;
 

--- a/ref/soft/r_context.c
+++ b/ref/soft/r_context.c
@@ -188,6 +188,8 @@ static int GL_RefGetParm( int parm, int arg )
 		return 0; // ref_soft doesn't support sky sphere
 	case PARM_TEX_FILTERING:
 		return 0; // ref_soft doesn't do filtering in general
+	case PARM_GET_STUDIO_HDR:
+		return (intptr_t)R_StudioGetHeader();
 	default:
 		return ENGINE_GET_PARM_( parm, arg );
 	}

--- a/ref/soft/r_local.h
+++ b/ref/soft/r_local.h
@@ -392,6 +392,7 @@ void R_DrawSpriteModel( cl_entity_t *e );
 // gl_studio.c
 //
 void R_StudioInit( void );
+studiohdr_t *R_StudioGetHeader( void );
 void Mod_LoadStudioModel( model_t *mod, const void *buffer, qboolean *loaded );
 void R_StudioLerpMovement( cl_entity_t *e, double time, vec3_t origin, vec3_t angles );
 struct mstudiotex_s *R_StudioGetTexture( cl_entity_t *e );

--- a/ref/soft/r_studio.c
+++ b/ref/soft/r_studio.c
@@ -2267,6 +2267,11 @@ static void R_StudioSetHeader( studiohdr_t *pheader )
 	m_fDoRemap = false;
 }
 
+studiohdr_t *R_StudioGetHeader( void )
+{
+	return m_pStudioHeader;
+}
+
 /*
 ===============
 R_StudioSetRenderModel


### PR DESCRIPTION
Does a lot of stuff here and there, as while porting the client I found out about broken libbacktrace that was only caused by incorrect configure script running sequentially. (heh, reverse race condition)

Almost everything works as intended, except for a few known issues:
- sometimes animations get corrupted, but I wasn't been able to consistently reproduce that, so it's a known bug
- already pushed patch to hlsdk-portable that reverts byte swapping in studio model renderer previously added by @IntriguingTiles, as it's now completely handled by the engine.
- voice chat is probably broken

