### PR TITLE
Fix hlsdk-xash3d references where applicable.

### DIFF
--- a/Documentation/development/engine-porting-guide.md
+++ b/Documentation/development/engine-porting-guide.md
@@ -22,7 +22,7 @@ The other yet unsupported configuration is the big endian.
 
 2) Open `public/build.h` file. Add appropriate checks for your operating system and/or CPU architecture. It shouldn't be hard.
 
-Also, you'll need to build [Half-Life SDK](https://github.com/FWGS/hlsdk-xash3d/). It has same `public/build.h` so reflect changes into it. Note that to be compatible with HLSDK proprietary license, it's relicensed as public domain under [Unlicense](https://unlicense.org).
+Also, you'll need to build [Half-Life SDK](https://github.com/FWGS/hlsdk-portable/). It has same `public/build.h` so reflect changes into it. Note that to be compatible with HLSDK proprietary license, it's relicensed as public domain under [Unlicense](https://unlicense.org).
 
 We have a library naming scheme that allows us and game creators to distribute binaries for different platforms in one archive. Read `Documentation/extensions/library-naming.md` for more information.
 

--- a/Documentation/not-supported-mod-list-and-reasons-why.md
+++ b/Documentation/not-supported-mod-list-and-reasons-why.md
@@ -4,7 +4,7 @@
 |----							|-------			|---------------						|----------------------
 |Area 51						|Update 1			|Uses outdated BSP31 map format and custom HLFX SDK libraries.	|You can try [this tool](https://hlfx.ru/forum/showthread.php?threadid=5250) to convert maps but there no warranty if it works.
 |Arrange Mod: Rebirth					|v150				|No idea yet.							|
-|Blue Shift						|The latest steam release	|Uses vgui2 library which xash3d does not support.		|Recreated source code here: https://github.com/FWGS/hlsdk-xash3d/tree/bshift.
+|Blue Shift						|The latest steam release	|Uses vgui2 library which xash3d does not support.		|Recreated source code here: https://github.com/FWGS/hlsdk-portable/tree/bshift.
 |Counter Strike						|Beta 6.5-			|Uses an old WON HL 1.0.0.16- interface.			|
 |							|1.4				|Has encrypted blob instead of normal client.dll.		|You can try [this tool](https://aluigi.altervista.org/papers/hldlldec.zip) to decrypt client.dll but there no warranty if it works.
 |							|1.5				|Has encrypted blob instead of normal client.dll.		|Decrypted blob here: https://csm.dev/threads/cs-1-5-client-dll-decrypted-patched-for-usage.38845.
@@ -15,6 +15,6 @@
 |Half-Life: Extended					|Day One demo			|Uses many hooks to GoldSource engine and version check.	|Just wait new version or use more old version.
 |Icon of Hell						|Beta 0.99			|Uses outdated BSP31 map format and paranoia 2 libraries.	|You can try [this tool](https://hlfx.ru/forum/showthread.php?threadid=5250) to convert maps and use Paranoia 2: The Savior 1.51 libraries but there no warranty if it works.
 |Paranoia 2: The Savior					|All builds older 1.51		|Uses an old renderer interface and engine features.		|
-|Rebellion						|1.0				|Uses an old WON HL 1.0.0.16- interface.			|Recreated source code here: https://github.com/FWGS/hlsdk-xash3d/tree/rebellion.
+|Rebellion						|1.0				|Uses an old WON HL 1.0.0.16- interface.			|Recreated source code here: https://github.com/FWGS/hlsdk-portable/tree/rebellion.
 |Sven-Coop						|5.0+				|Uses custom GoldSrc engine.					|
 |Time Shadows						|Beta 0.1			|Uses Direct3D renderer.					|

--- a/scripts/gha/deps_motomagx.sh
+++ b/scripts/gha/deps_motomagx.sh
@@ -12,4 +12,4 @@ pushd /opt/toolchains/ || exit 1
 sudo git clone https://github.com/a1batross/motomagx_toolchain motomagx --depth=1
 popd || exit 1
 
-git clone https://github.com/FWGS/hlsdk-xash3d hlsdk -b mobile_hacks --depth=1
+git clone https://github.com/FWGS/hlsdk-portable hlsdk -b mobile_hacks --depth=1


### PR DESCRIPTION
This changes references of hlsdk-xash3d (previous name) to hlsdk-portable (current name) where applicable.

The other occurrences were left as is:

https://github.com/FWGS/xash3d-fwgs/blob/7d87d65a3fc5c4b5b6241c352d82102032d8a2e7/Documentation/opensource-mods.md?plain=1#L307

https://github.com/FWGS/xash3d-fwgs/blob/7d87d65a3fc5c4b5b6241c352d82102032d8a2e7/scripts/gha/deps_nswitch.sh#L16

https://github.com/FWGS/xash3d-fwgs/blob/7d87d65a3fc5c4b5b6241c352d82102032d8a2e7/scripts/gha/deps_psvita.sh#L50

