### PR TITLE
engine: net_ws: round-robin IPv4/IPv6 reads

### DIFF
--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -1358,53 +1358,51 @@ static qboolean NET_QueuePacket( int net_socket, netsrc_t sock, netadr_t *from, 
 
 	*length = 0;
 
+	if( !NET_IsSocketValid( net_socket ))
+		return NET_LagPacket( false, sock, from, length, data );
+
+	addr_len = sizeof( addr );
+	ret = recvfrom( net_socket, buf, sizeof( buf ), 0, (struct sockaddr *)&addr, &addr_len );
+
+	NET_SockadrToNetadr( &addr, from );
+
+	if( !NET_IsSocketError( ret ))
 	{
-		if( !NET_IsSocketValid( net_socket ))
-			return NET_LagPacket( false, sock, from, length, data );
-
-		addr_len = sizeof( addr );
-		ret = recvfrom( net_socket, buf, sizeof( buf ), 0, (struct sockaddr *)&addr, &addr_len );
-
-		NET_SockadrToNetadr( &addr, from );
-
-		if( !NET_IsSocketError( ret ))
+		if( ret < NET_MAX_FRAGMENT )
 		{
-			if( ret < NET_MAX_FRAGMENT )
-			{
-				// Transfer data
-				memcpy( data, buf, ret );
-				*length = ret;
+			// Transfer data
+			memcpy( data, buf, ret );
+			*length = ret;
 
 #if !XASH_DEDICATED
-				// check for split message
-				if( sock == NS_CLIENT && *(int *)data == NET_HEADER_SPLITPACKET )
-					return NET_GetLong( data, ret, length, CL_GetSplitSize( ), CL_Protocol( ));
+			// check for split message
+			if( sock == NS_CLIENT && *(int *)data == NET_HEADER_SPLITPACKET )
+				return NET_GetLong( data, ret, length, CL_GetSplitSize( ), CL_Protocol( ));
 #endif
 
-				// lag the packet, if needed
-				return NET_LagPacket( true, sock, from, length, data );
-			}
-			else
-			{
-				Con_Reportf( "%s: oversize packet from %s\n", __func__, NET_AdrToString( *from ));
-			}
+			// lag the packet, if needed
+			return NET_LagPacket( true, sock, from, length, data );
 		}
 		else
 		{
-			int	err = WSAGetLastError();
+			Con_Reportf( "%s: oversize packet from %s\n", __func__, NET_AdrToString( *from ));
+		}
+	}
+	else
+	{
+		int	err = WSAGetLastError();
 
-			switch( err )
-			{
-			case WSAEWOULDBLOCK:
-			case WSAECONNRESET:
-			case WSAECONNREFUSED:
-			case WSAEMSGSIZE:
-			case WSAETIMEDOUT:
-				break;
-			default:	// let's continue even after errors
-				Con_DPrintf( S_ERROR "%s: %s from %s\n", __func__, NET_ErrorString(), NET_AdrToString( *from ));
-				break;
-			}
+		switch( err )
+		{
+		case WSAEWOULDBLOCK:
+		case WSAECONNRESET:
+		case WSAECONNREFUSED:
+		case WSAEMSGSIZE:
+		case WSAETIMEDOUT:
+			break;
+		default:	// let's continue even after errors
+			Con_DPrintf( S_ERROR "%s: %s from %s\n", __func__, NET_ErrorString(), NET_AdrToString( *from ));
+			break;
 		}
 	}
 

--- a/engine/common/net_ws.c
+++ b/engine/common/net_ws.c
@@ -99,6 +99,7 @@ typedef struct
 	int		sequence_number;
 	int		ip_sockets[NS_COUNT];
 	int		ip6_sockets[NS_COUNT];
+	qboolean		rr_state[NS_COUNT];
 	qboolean		initialized;
 	qboolean		threads_initialized;
 	qboolean		configured;
@@ -1348,26 +1349,18 @@ NET_QueuePacket
 queue normal and lagged packets
 ==================
 */
-static qboolean NET_QueuePacket( netsrc_t sock, netadr_t *from, byte *data, size_t *length )
+static qboolean NET_QueuePacket( int net_socket, netsrc_t sock, netadr_t *from, byte *data, size_t *length )
 {
 	byte		buf[NET_MAX_FRAGMENT];
-	int		ret, protocol;
-	int		net_socket;
+	int		ret;
 	WSAsize_t	addr_len;
 	struct sockaddr_storage	addr = { 0 };
 
 	*length = 0;
 
-	for( protocol = 0; protocol < 2; protocol++ )
 	{
-		switch( protocol )
-		{
-		case 0: net_socket = net.ip_sockets[sock]; break;
-		case 1: net_socket = net.ip6_sockets[sock]; break;
-		}
-
 		if( !NET_IsSocketValid( net_socket ))
-			continue;
+			return NET_LagPacket( false, sock, from, length, data );
 
 		addr_len = sizeof( addr );
 		ret = recvfrom( net_socket, buf, sizeof( buf ), 0, (struct sockaddr *)&addr, &addr_len );
@@ -1438,7 +1431,20 @@ qboolean NET_GetPacket( netsrc_t sock, netadr_t *from, byte *data, size_t *lengt
 	}
 	else
 	{
-		return NET_QueuePacket( sock, from, data, length );
+		// Round-robin the socket to prevent constant activity on one starving the other.
+		int i = net.rr_state[sock];
+		int net_socket = i ? net.ip_sockets[sock] : net.ip6_sockets[sock];
+
+		if( NET_QueuePacket( net_socket, sock, from, data, length ))
+		{
+			net.rr_state[sock] = !i;
+			return true;
+		}
+
+		// try the other one before giving up
+		net_socket = i ? net.ip6_sockets[sock] : net.ip_sockets[sock];
+		net.rr_state[sock] = !i;
+		return NET_QueuePacket( net_socket, sock, from, data, length );
 	}
 }
 
@@ -2012,6 +2018,7 @@ void NET_Init( void )
 		net.lagdata[i].next = &net.lagdata[i];
 		net.ip_sockets[i]  = INVALID_SOCKET;
 		net.ip6_sockets[i] = INVALID_SOCKET;
+		net.rr_state[i] = false;
 	}
 
 #if XASH_WIN32


### PR DESCRIPTION
Previously, it would always return on the first one that had activity.
This meant that if IPv4 starts getting slammed, IPv6 reads wouldn't happen.

First commit implements the logic, second applies the indentation changes for easy diff'ing.

I've been running this on my server with both v4/v6 for a week, and have thrown all sorts of 
`socat -u /dev/urandom UDP6:` and `socat  -u /dev/urandom UDP:` variants at it with no issue.