### PR TITLE
engine: add MenuFactory native object

### DIFF
--- a/Documentation/extensions/native-object.md
+++ b/Documentation/extensions/native-object.md
@@ -16,6 +16,7 @@ Only these objects are guaranteed to be available on all targets.
 |-------------|-----------|
 | `VFileSystem009` | Provides C++ interface to filesystem, binary-compatible with Valve's VFileSystem009. |
 | `XashFileSystemXXX` | Provides C interface to filesystem. This interface is unstable and not recommended for generic use, outside of engine internals. For more info about current version look into `filesystem.h`. |
+| `MenuFactory` | Returns a `CreateInterface` function pointer (`pfnCreateInterface_t`) for the currently loaded menu library. |
 
 #### Android-specific objects
 

--- a/engine/client/dll_int/cl_gameui.c
+++ b/engine/client/dll_int/cl_gameui.c
@@ -1335,6 +1335,14 @@ void UI_UnloadProgs( void )
 	memset( &gameui, 0, sizeof( gameui ));
 }
 
+void *UI_GetMenuFactory( void )
+{
+	if( !gameui.hInstance )
+		return NULL;
+
+	return COM_GetProcAddress( gameui.hInstance, "CreateInterface" );
+}
+
 qboolean UI_LoadProgs( void )
 {
 	static ui_enginefuncs_t	gpEngfuncs;

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -745,6 +745,7 @@ qboolean CL_DisableVisibility( void );
 qboolean CL_IsRecordDemo( void );
 qboolean CL_IsPlaybackDemo( void );
 qboolean UI_CreditsActive( void );
+void *UI_GetMenuFactory( void );
 int CL_GetMaxClients( void );
 #else
 static inline qboolean CL_Initialized( void ) { return false; }
@@ -755,6 +756,7 @@ static inline qboolean CL_DisableVisibility( void ) { return false; }
 static inline qboolean CL_IsRecordDemo( void ) { return false; }
 static inline qboolean CL_IsPlaybackDemo( void ) { return false; }
 static inline qboolean UI_CreditsActive( void ) { return false; }
+static inline void *UI_GetMenuFactory( void ) { return NULL; }
 static inline int CL_GetMaxClients( void ) { return SV_GetMaxClients(); }
 #endif
 

--- a/engine/common/system.c
+++ b/engine/common/system.c
@@ -666,6 +666,9 @@ void *Sys_GetNativeObject( const char *obj )
 	if( COM_StringEmptyOrNULL( obj ))
 		return NULL;
 
+	if( !Q_strcmp( obj, "MenuFactory" ))
+		return UI_GetMenuFactory();
+
 	ptr = FS_GetNativeObject( obj );
 
 	if( ptr )


### PR DESCRIPTION
Needed for integration support of MainUI-based menus in CS16Client.
See also: https://github.com/Velaron/cs16-client/pull/342 and https://github.com/Velaron/cs16-client/pull/342