### PR TITLE
Unaligned access handler for MIPS-IRIX

### DIFF
--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -273,4 +273,11 @@ typedef int qboolean;
 	#define HostFourCC( a, b, c, d ) LittleFourCC( a, b, c, d )
 #endif
 
+static inline short UnalignedShort( short *x )
+{
+	short y;
+	memcpy( &y, x, sizeof( y ) );
+	return y;
+}
+
 #endif // XASH_TYPES_H

--- a/public/xash3d_mathlib.c
+++ b/public/xash3d_mathlib.c
@@ -470,23 +470,23 @@ void R_StudioCalcBones( int frame, float s, const mstudiobone_t *pbone, const ms
 
 		if( panimvalue->num.valid > j )
 		{
-			v1[i] = panimvalue[j + 1].value;
+			v1[i] = UnalignedShort( &( panimvalue[j + 1].value ) );
 
 			if( panimvalue->num.valid > j + 1 )
-				v2[i] = panimvalue[j + 2].value;
+				v2[i] = UnalignedShort( &( panimvalue[j + 2].value ) );
 			else if( panimvalue->num.total > j + 1 )
 				v2[i] = v1[i];
 			else
-				v2[i] = panimvalue[panimvalue->num.valid + 2].value;
+				v2[i] = UnalignedShort( &( panimvalue[panimvalue->num.valid + 2].value ) );
 		}
 		else
 		{
-			v1[i] = panimvalue[panimvalue->num.valid].value;
+			v1[i] = UnalignedShort( &( panimvalue[panimvalue->num.valid].value ) );
 
 			if( panimvalue->num.total > j + 1 )
 				v2[i] = v1[i];
 			else
-				v2[i] = panimvalue[panimvalue->num.valid + 2].value;
+				v2[i] = UnalignedShort( &(  panimvalue[panimvalue->num.valid + 2].value ) );
 		}
 
 		v1[i] = pbone->value[i] + v1[i] * pbone->scale[i] + fadj;


### PR DESCRIPTION
More of the unaligned access handlers needed on MIPS `mstudioanimvalue_t` data is commonly allocated at unaligned positions.

Because this is in C code we can't use the C++ template-based method we used in hlsdk. (You could do something similar with a number of various macros and compiler extensions, but I can't think of one that would be well supported across all compilers on all platforms. So it's probably best to just leave it at having to manually specify the type you're accessing for now.)