### PR TITLE
Fix SV_ProcessFile crash from short malformed filename

### DIFF
--- a/engine/server/sv_main.c
+++ b/engine/server/sv_main.c
@@ -312,6 +312,12 @@ static void SV_ProcessFile( sv_client_t *cl, const char *filename )
 		return;
 	}
 
+	if( Q_strlen( filename ) < 36 )
+	{
+		Con_Printf( "%s: Malformed customization filename from %s (too short)\n", __func__, cl->name );
+		return;
+	}
+
 	COM_HexConvert( filename + 4, 32, md5 );
 
 	for( resource = cl->resourcesneeded.pNext; resource != &cl->resourcesneeded; resource = next )


### PR DESCRIPTION
A client can crash the server by sending a file upload with a filename too short to contain a valid MD5 hash (e.g. just "!"). This causes COM_HexConvert to read out of bounds. Added a length check before processing. Not tested yet. Based on GDB analysis of the crash. May not fully address the issue.

```
0xf6b34504 in SV_ProcessFile (cl=0xf219f398, filename=0xf21ff81c "!") at ../engine/server/sv_main.c:325
#0  0xf6b34504 in SV_ProcessFile (cl=0xf219f398, filename=0xf21ff81c "!") at ../engine/server/sv_main.c:325
        pList = 0x3
        resource = 0x0
        next = 0xffffcbc8
        md5 = '0' <repeats 16 times>
        bFound = -151994344
        bError = 16
        __func__ = "SV_ProcessFile"
#1  0xf6b34ab5 in SV_ReadPackets () at ../engine/server/sv_main.c:453
        cl = 0xf219f398
        i = 1
        qport = 35453
        curSize = 30
#2  0xf6b352b4 in Host_ServerFrame () at ../engine/server/sv_main.c:699
No locals.
#3  0xf6acac65 in Host_Frame (time=2.0999999605919584e-07) at ../engine/common/host.c:673
        t1 = 38.951061281000001
#4  0xf6accbee in Host_RunFrame (time=2.0999999605919584e-07) at ../engine/common/host_state.c:159
No locals.
#5  0xf6accd76 in COM_Frame (time=2.0999999605919584e-07) at ../engine/common/host_state.c:221
        oldState = 0
        loopCount = 0
#6  0xf6acc5a0 in Host_Main (argc=16, argv=0xffffd004, progname=0x804a073 "valve", bChangeGame=0, pChangeGame=0x8049313 <Sys_ChangeGame(char const*)>) at ../engine/common/host.c:1314
        newtime = 38.951061029999998
        oldtime = 38.951060820000002
        demoname = "\000\000\000\000\001\001\276\207\270\222\004\b\004\320\377\377H\320\377\377p\b\324\367\204z\251\366(\037\332\3674\216\276\367\334\316\377\377\347Ŭ\366\256\205\235\367m\203\004\b\030\240\004\b\002\000\000\2006\222\004\b\000.'\262\020\000\000\000\350\317\377\367H\320\377\377\334\316\377\377\274\377\377\377@i\233\367`\313\377\367\331\002\244\367\000\000\000\000\002\000\000\000\270\222\004\b\001\000\000\000\234\257\234\367.\t\000\0004\216\276\367-\245\374\367\334\316\377\377\000\000\000\000<\363\234\367p\035\374\367\304\315\377\377\006\000\000\000\350\317\377\367\000\000\000\000\350\317\377\367<\363\234\367\035\203\004\bD\316\377\377x\315\377\3774\216\276\367\274\377\377\377@i\233\367`\313\377\367P"...
        exename = "xash3d\000\377\3367\375\367P\202\004\bD\316\377\377\214\333\377\367\004\000\000\0000!\374\367\001\000\000\000\000\000\000\000\001\000\000\000 \332\377\367\001\000\000\000\000\000\000\000p\035\374\367\274\034\234\367<\006\234\367\350\317\377\367\030\000\000\000\000\000\000\000\001\000\000\000<\231\234\367\310\a\000\0004\216\276\367Y\246\374\367D\316\377\377\300\002\244\367\334\316\377\377\000.'\262\377\377\377\377", '\000' <repeats 12 times>, "\350\317\377\367<\363\234\367\374\202\004\bJ\374\243\367\224\316\377\377\230\316\377\377\223\316\377\377\300\002\244\367\334\316\377\377Ɗ\375\367\035\203\004\b \332\377\367\300\316\377\377\000\000\000\0000!\374\367\001\000\000\000\001\000\000\001\347"...
#7  0x08049348 in Sys_Start () at ../game_launch/game.cpp:175
        ret = -140549319
#8  0x08049373 in main (argc=16, argv=0xffffd004) at ../game_launch/game.cpp:187
```