### PR TITLE
net_chan: fix fragment size validation crashes

### DIFF
--- a/engine/common/net_chan.c
+++ b/engine/common/net_chan.c
@@ -1089,6 +1089,23 @@ qboolean Netchan_CopyNormalFragments( netchan_t *chan, sizebuf_t *msg, size_t *l
 
 	MSG_Init( msg, "NetMessage", net_message_buffer, sizeof( net_message_buffer ));
 
+	{
+		size_t totalSize = 0;
+		fragbuf_t *check = p;
+		while( check )
+		{
+			totalSize += MSG_GetNumBytesWritten( &check->frag_message );
+			if( totalSize > sizeof( net_message_buffer ))
+			{
+				Con_Printf( S_ERROR "Netchan_CopyNormalFragments: assembled fragments exceed buffer (%zu bytes) from %s, dropping\n",
+					totalSize, NET_AdrToString( chan->remote_address ));
+				Netchan_FlushIncoming( chan, FRAG_NORMAL_STREAM );
+				return false;
+			}
+			check = check->next;
+		}
+	}
+
 	while( p )
 	{
 		fragbuf_t *n = p->next;
@@ -1904,6 +1921,22 @@ qboolean Netchan_Process( netchan_t *chan, sizebuf_t *msg )
 
 					int size = MSG_GetNumBitsRead( msg ) + frag_offset[i];
 					int bits = frag_length[i];
+
+					if( bits <= 0 || bits > (int)( NET_MAX_FRAGMENT << 3 ))
+					{
+						Con_Printf( S_ERROR "Netchan_Process: invalid fragment size %d bits from %s, dropping\n",
+							bits, NET_AdrToString( chan->remote_address ));
+						Netchan_FlushIncoming( chan, i );
+						return false;
+					}
+
+					if( size < 0 || ( size + bits ) > (int)( MSG_GetMaxBytes( msg ) << 3 ))
+					{
+						Con_Printf( S_ERROR "Netchan_Process: fragment read out of bounds from %s, dropping\n",
+							NET_AdrToString( chan->remote_address ));
+						Netchan_FlushIncoming( chan, i );
+						return false;
+					}
 
 					// copy in data
 					MSG_Clear( &pbuf->frag_message );


### PR DESCRIPTION
Another engine vulnerability that is used by some malicious clients to crash the server. Added bounds checks in Netchan_Process and Netchan_CopyNormalFragments to validate fragment length and buffer limits before processing.

Tested and confirmed working.
[log.txt](https://github.com/user-attachments/files/28129383/log.txt)
