### PR TITLE
Warning for accessing non-existent CVARs from client or server

### DIFF
--- a/engine/client/dll_int/cl_game.c
+++ b/engine/client/dll_int/cl_game.c
@@ -3568,6 +3568,16 @@ static void GAME_EXPORT VGui_ViewportPaintBackground( int extents[4] )
 	// stub
 }
 
+static cvar_t* GAME_EXPORT CL_CvarGetPointer( const char *szVarName )
+{
+	cvar_t *result = (cvar_t *)Cvar_FindVar( szVarName );
+
+	if( !result )
+		Con_DPrintf( S_WARN "%s: client tried to get non-existent cvar \"%s\"\n", __func__, szVarName );
+	
+	return result;
+}
+
 // shared between client and server
 triangleapi_t gTriApi;
 
@@ -3790,7 +3800,7 @@ static cl_enginefunc_t gEngfuncs =
 	pfnHookEvent,
 	Con_Visible,
 	pfnGetGameDirectory,
-	pfnCVarGetPointer,
+	CL_CvarGetPointer,
 	Key_LookupBinding,
 	pfnGetLevelName,
 	pfnGetScreenFade,
@@ -3924,7 +3934,7 @@ static engine_studio_api_t gStudioAPI =
 	.Mod_ForName             = pfnStudio_Mod_ForName,
 	.Mod_Extradata           = pfnStudio_Mod_Extradata,
 	.GetModelByIndex         = CL_ModelHandle,
-	.GetCvar                 = pfnCVarGetPointer,
+	.GetCvar                 = CL_CvarGetPointer,
 	.GetChromeSprite         = pfnStudio_GetChromeSprite,
 	.GetAliasScale           = pfnStudio_GetAliasScale,
 	.StudioGetAliasTransform = pfnStudio_GetAliasTransform,

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -687,18 +687,6 @@ void GAME_EXPORT pfnGetModelBounds( model_t *mod, float *mins, float *maxs )
 
 /*
 =============
-pfnCVarGetPointer
-
-can return NULL
-=============
-*/
-cvar_t *GAME_EXPORT pfnCVarGetPointer( const char *szVarName )
-{
-	return (cvar_t *)Cvar_FindVar( szVarName );
-}
-
-/*
-=============
 pfnCompareFileTime
 
 =============

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -634,7 +634,6 @@ byte COM_Nibble( char c );
 int COM_SaveFile( const char *filename, const void *data, int len );
 byte *COM_LoadFileForMe( const char *filename, int *pLength ) MALLOC_LIKE( free, 1 );
 qboolean COM_IsSafeFileToDownload( const char *filename );
-cvar_t *pfnCVarGetPointer( const char *szVarName );
 int pfnDrawConsoleString( int x, int y, char *string );
 void pfnDrawSetTextColor( float r, float g, float b );
 void pfnDrawConsoleStringLen( const char *pText, int *length, int *height );

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -4680,6 +4680,16 @@ static void GAME_EXPORT pfnGetGameDir( char *out )
 	}
 }
 
+static cvar_t* GAME_EXPORT SV_CvarGetPointer( const char *szVarName )
+{
+	cvar_t *result = (cvar_t *)Cvar_FindVar( szVarName );
+
+	if( !result )
+		Con_DPrintf( S_WARN "%s: server tried to get non-existent cvar \"%s\"\n", __func__, szVarName );
+	
+	return result;
+}
+
 // engine callbacks
 static enginefuncs_t gEngfuncs =
 {
@@ -4799,7 +4809,7 @@ static enginefuncs_t gEngfuncs =
 	pfnGetPlayerUserId,
 	pfnBuildSoundMsg,
 	pfnIsDedicatedServer,
-	pfnCVarGetPointer,
+	SV_CvarGetPointer,
 	pfnGetPlayerWONId,
 	(void*)Info_RemoveKey,
 	pfnGetPhysicsKeyValue,


### PR DESCRIPTION
Would help with investigating compatibility bugs (with bugs like from Sven Co-op 4.8). In case of enormous spamming, we could add another CVAR which will control this feature. For now messages will be printed only in developer mode.