### PR TITLE
engine: add support for legacy 'm' query responses

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -2074,7 +2074,7 @@ static void CL_ParseStatusMessage( netadr_t from, sizebuf_t *msg )
 	UI_AddServerToList( from, infostring );
 }
 
-static void CL_ParseGoldSrcStatusMessage( netadr_t from, sizebuf_t *msg )
+static void CL_ParseGoldSrcStatusMessage( netadr_t from, sizebuf_t *msg, qboolean legacy_format )
 {
 	static char	s[512+8];
 	int p, numcl, maxcl, password, remaining, bots;
@@ -2084,19 +2084,58 @@ static void CL_ParseGoldSrcStatusMessage( netadr_t from, sizebuf_t *msg )
 	// set to beginning but skip header
 	MSG_SeekToBit( msg, (sizeof( uint32_t ) + sizeof( uint8_t )) << 3, SEEK_SET );
 
-	p = MSG_ReadByte( msg );
-	Q_strncpy( host, MSG_ReadString( msg ), sizeof( host ));
-	Q_strncpy( map, MSG_ReadString( msg ), sizeof( map ));
-	Q_strncpy( gamedir, MSG_ReadString( msg ), sizeof( gamedir ));
-	MSG_ReadString( msg ); // game description
-	MSG_ReadShort( msg ); // app id
-	numcl = MSG_ReadByte( msg );
-	maxcl = MSG_ReadByte( msg );
-	bots = MSG_ReadByte( msg ); // bots count
-	MSG_ReadByte( msg ); // dedicated
-	MSG_ReadByte( msg ); // operating system
-	password = MSG_ReadByte( msg );
-	Q_strncpy( version, MSG_ReadString( msg ), sizeof( version ));
+	if( legacy_format )
+	{
+		string address;
+		int mod;
+
+		p = MSG_ReadByte( msg );
+		Q_strncpy( address, MSG_ReadString( msg ), sizeof( address ));
+		Q_strncpy( host, MSG_ReadString( msg ), sizeof( host ));
+		Q_strncpy( map, MSG_ReadString( msg ), sizeof( map ));
+		Q_strncpy( gamedir, MSG_ReadString( msg ), sizeof( gamedir ));
+		MSG_ReadString( msg ); // game description
+		numcl = MSG_ReadByte( msg );
+		maxcl = MSG_ReadByte( msg );
+		MSG_ReadByte( msg ); // protocol version
+		MSG_ReadByte( msg ); // server type
+		MSG_ReadByte( msg ); // operating system
+		password = MSG_ReadByte( msg );
+		mod = MSG_ReadByte( msg ); // mod flag
+
+		if( mod == 1 )
+		{
+			MSG_ReadString( msg ); // mod URL
+			MSG_ReadString( msg ); // mod download URL
+			MSG_ReadLong( msg );   // mod version
+			MSG_ReadLong( msg );   // mod size
+			MSG_ReadByte( msg );   // mod type (SP/MP)
+			MSG_ReadByte( msg );   // custom DLL flag
+			Q_strncpy( version, MSG_ReadString( msg ), sizeof( version ));
+			bots = MSG_ReadByte( msg ); // bots count
+		}
+		else
+		{
+			Q_strncpy( version, MSG_ReadString( msg ), sizeof( version ));
+			bots = MSG_ReadByte( msg ); // bots count
+		}
+	}
+	else
+	{
+		p = MSG_ReadByte( msg );
+		Q_strncpy( host, MSG_ReadString( msg ), sizeof( host ));
+		Q_strncpy( map, MSG_ReadString( msg ), sizeof( map ));
+		Q_strncpy( gamedir, MSG_ReadString( msg ), sizeof( gamedir ));
+		MSG_ReadString( msg ); // game description
+		MSG_ReadShort( msg ); // app id
+		numcl = MSG_ReadByte( msg );
+		maxcl = MSG_ReadByte( msg );
+		bots = MSG_ReadByte( msg ); // bots count
+		MSG_ReadByte( msg ); // server type
+		MSG_ReadByte( msg ); // operating system
+		password = MSG_ReadByte( msg );
+		Q_strncpy( version, MSG_ReadString( msg ), sizeof( version ));
+	}
 
 	// sanity check
 	if( maxcl > MAX_CLIENTS || numcl > MAX_CLIENTS || bots > MAX_CLIENTS || numcl > maxcl || bots > maxcl )
@@ -2657,7 +2696,11 @@ static void CL_ConnectionlessPacket( netadr_t from, sizebuf_t *msg )
 	}
 	else if( c[0] == S2A_GOLDSRC_INFO )
 	{
-		CL_ParseGoldSrcStatusMessage( from, msg );
+		CL_ParseGoldSrcStatusMessage( from, msg, false );
+	}
+	else if( c[0] == S2A_GOLDSRC_LEGACY_INFO )
+	{
+		CL_ParseGoldSrcStatusMessage( from, msg, true );
 	}
 	else if( !Q_strcmp( c, A2A_NETINFO ))
 	{

--- a/engine/common/protocol.h
+++ b/engine/common/protocol.h
@@ -333,6 +333,7 @@ extern const char *const svc_goldsrc_strings[svc_lastmsg+1];
 
 // from server to any
 #define S2A_GOLDSRC_INFO    'I'
+#define S2A_GOLDSRC_LEGACY_INFO 'm'
 #define S2A_GOLDSRC_RULES   'E'
 #define S2A_GOLDSRC_PLAYERS 'D'
 


### PR DESCRIPTION
This should resolve the issue with retrieving the server status (hostname, map, numcl/maxcl) for ``srv.tsmod.net:27015``.

I referred to the obsolete GoldSource response documentation:
https://developer.valvesoftware.com/wiki/Server_queries#Obsolete_GoldSource_Response