### PR TITLE
Better PSVita exit, fixing crash

### DIFF
--- a/engine/common/launcher.c
+++ b/engine/common/launcher.c
@@ -45,6 +45,17 @@ int main( int argc, char **argv )
 	szArgc = argc;
 	szArgv = argv;
 #endif // XASH_PSVITA
-	return Host_Main( szArgc, szArgv, XASH_GAMEDIR, 0, Sys_ChangeGame );
+
+	{
+		int ret = Host_Main( szArgc, szArgv, XASH_GAMEDIR, 0, Sys_ChangeGame );
+#if XASH_PSVITA
+		// Returning from main() on the Vita runs the C runtime's atexit chain
+		// (__call_exitprocs). By then the game libraries have been dlclose'd, so
+		// any atexit/static-destructor entry pointing into them dangles and
+		// crashes on Quit. Exit the process directly, skipping atexit.
+		PSVita_Exit( ret );
+#endif
+		return ret;
+	}
 }
 #endif // XASH_ENABLE_MAIN

--- a/engine/platform/platform.h
+++ b/engine/platform/platform.h
@@ -112,6 +112,7 @@ void PSVita_Shutdown( void );
 qboolean PSVita_GetBasePath( char *buf, const size_t buflen );
 int PSVita_GetArgv( int in_argc, char **in_argv, char ***out_argv );
 void PSVita_InputUpdate( void );
+void PSVita_Exit( int code ) __attribute__((noreturn));
 #endif
 
 #if XASH_DOS

--- a/engine/platform/psvita/sys_psvita.c
+++ b/engine/platform/psvita/sys_psvita.c
@@ -184,6 +184,27 @@ void PSVita_Shutdown( void )
 	vrtld_quit( );
 }
 
+/*
+===========
+PSVita_Exit
+
+Terminate the process directly instead of returning up through main() and the
+C runtime's exit sequence. Xash unloads the game libraries (client/menu/server)
+during shutdown, but any function-local static destructor they registered via
+atexit() cannot be removed on dlclose (it has no DSO handle), so it is left
+dangling in the newlib exit list. Returning normally would make __call_exitprocs
+call that pointer into now-unmapped memory -> prefetch abort on Quit.
+sceKernelExitProcess() skips the atexit chain entirely, which is the correct
+way to terminate a Vita application anyway.
+===========
+*/
+void PSVita_Exit( int code )
+{
+	sceKernelExitProcess( code );
+	// not reached
+	for( ;; );
+}
+
 qboolean PSVita_GetBasePath( char *buf, const size_t buflen )
 {
 	// check if a xash3d folder exists on one of these drives


### PR DESCRIPTION

## Title

PSVita: exit via sceKernelExitProcess to avoid crash on quit

## Description

### Problem

On the PS Vita, quitting the game (menu -> Quit) crashes with a prefetch abort.
Crash dump (symbolized against the eboot):

```
Stop reason: 0x30003 (Prefetch abort exception)
PC: 0x99a7ab74                         <- unmapped
LR: __call_exitprocs+0x4a (blx r2)     <- r2 = dangling function pointer
```

### Cause

`Sys_Quit()` -> `Host_ShutdownWithReason()` unloads the client/menu/server
libraries (`dlclose`), then `Host_ExitInMain()` longjmps back so `Host_Main()`
returns and `main()` returns. Returning from `main()` runs the C runtime's
`atexit` chain (`__call_exitprocs`). Because the Vita builds the game libs with
`-fno-use-cxa-atexit`, their function-local static destructors are registered
with plain `atexit()` (no DSO handle), so they cannot be removed on `dlclose`.
After the module is unmapped those entries dangle, and `__call_exitprocs` jumps
into freed memory.

### Fix

On the Vita, terminate the process with `sceKernelExitProcess()` after
`Host_Main()` returns, instead of falling back through the C runtime. This skips
the `atexit` chain entirely, which is the correct way to end a Vita application
anyway — the config is already written during shutdown, and the OS reclaims all
process resources.

### Testing

On device (PS Vita Slim, PCH-2000): selecting Quit now returns to the LiveArea
with no crash. "Change game" and normal gameplay are unaffected (that path
relaunches via `sceAppMgrLoadExec()` and never returns through `main()`).
