### PR TITLE
engine: client: deliver keys in Key_Event's handled-in-client case

### DIFF
--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -722,6 +722,7 @@ void GAME_EXPORT Key_Event( int key, int down )
 				keys[key].gamedown = false;
 				keys[key].repeats = 0;
 			}
+			VGui_KeyEvent( key, down ); // resolves issue #1923
 			return; // handled in client.dll
 		}
 	}

--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -722,8 +722,12 @@ void GAME_EXPORT Key_Event( int key, int down )
 				keys[key].gamedown = false;
 				keys[key].repeats = 0;
 			}
-			VGui_KeyEvent( key, down ); // resolves issue #1923
-			return; // handled in client.dll
+
+			// deliver keys regardless of whether the client.dll handled them or not
+			// reproduces GoldSrc behavior, where keys are passed even if the client.dll claims to have handled them
+			// this is needed for Cry of fear's Computer interface input, for more context, see https://github.com/FWGS/xash3d-fwgs/issues/1923
+			VGui_KeyEvent( key, down );
+			return;
 		}
 	}
 


### PR DESCRIPTION
Resolves #1923 

Below is an summary of the bug and my findings (essentially repeating what has been brought up in the issue):
---

The bug: The very first puzzle in Cry of fear is a computer screen with two input fields: a username and a password. The bug is that in FWGS the only keys that work are the TAB (alternates fields) and the ENTER button (does the comparison). None of the other keys work. This is cruicial to the gameplay as the computer puzzle reveals a randomly generated code to a padlock needed for further progression through the game. 

The reason why TAB and ENTER they work is that the client calls win32's `GetAsyncKeyState` immediately rather than letting the engine handle it. For every other key, the viewport key input dispatcher refers to the input handler which is a one-liner: 

```
return binding && !strcmp( binding, "toggleconsole" );
```

This is only ever true for the key that's bound to the console, which is why opening the console works while the computer interface is open. In fact, running `bind x toggleconsole` and then hitting "x" does open the console AND input the letter x in the input field for the computer. Funny enough, the key input handler routes the engine's Key_Event to the "handled in client.dll" case, while STILL expecting the engine to handle it, as it does nothing otherwise. 

This can be resolved by calling `VGui_KeyEvent( key, down );` regardless in Key_Event's "handled in client.dll" segment. It does reproduce the GoldSrc behaviour for the computer puzzle in CoF. It *could* produce unwanted behaviour for newer mods built using fwgs that rely on suppressing the engine's input, although this is a special/rare case as the mods will need to be inside a VGUI focus state AND suppress the engine's input for this to take effect.

