### PR TITLE
engine: client: input: fix +speed movement scaling for analog input

### DIFF
--- a/engine/client/input.h
+++ b/engine/client/input.h
@@ -49,6 +49,9 @@ uint IN_CollectInputDevices( void );
 void IN_LockInputDevices( qboolean lock );
 void IN_EngineAppendMove( float frametime, usercmd_t *cmd, qboolean active );
 
+qboolean Key_IsCommandDown( const char *cmd );
+qboolean Touch_IsCommandDown( const char *cmd );
+
 void IN_SetRelativeMouseMode( qboolean set );
 void IN_SetMouseGrab( qboolean set );
 

--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -286,6 +286,31 @@ const char *Key_GetBinding( int keynum )
 
 /*
 ===================
+Key_IsCommandDown
+===================
+*/
+qboolean Key_IsCommandDown( const char *cmd )
+{
+    if( !cmd )
+        return false;
+
+    for( int i = 0; i < ARRAYSIZE( keys ); i++ )
+    {
+        if( !keys[i].down )
+            continue;
+
+        if( !keys[i].binding )
+            continue;
+
+        if( !Q_stricmp( keys[i].binding, cmd ))
+            return true;
+    }
+
+    return false;
+}
+
+/*
+===================
 Key_GetKey
 ===================
 */

--- a/engine/client/input/in_touch.c
+++ b/engine/client/input/in_touch.c
@@ -2159,6 +2159,28 @@ void Touch_GetMove( float *forward, float *side, float *pitch, float *yaw )
 	touch.yaw = touch.pitch = 0;
 }
 
+qboolean Touch_IsCommandDown( const char *cmd )
+{
+	touch_button_t *button;
+
+	if( !touch_enable.value )
+		return false;
+
+	if( !cmd )
+		return false;
+
+	for( button = touch.list_user.first; button; button = button->next )
+	{
+		if( button->finger < 0 )
+			continue;
+
+		if( !Q_stricmp( button->command, cmd ))
+			return true;
+	}
+
+	return false;
+}
+
 void Touch_KeyEvent( int key, int down )
 {
 	static float lx, ly;

--- a/engine/client/input/input.c
+++ b/engine/client/input/input.c
@@ -474,12 +474,25 @@ Common function for engine joystick movement
 #define R (1U << 3)	// Right
 #define T (1U << 4)	// Forward stop
 #define S (1U << 5)	// Side stop
+
+static qboolean IN_IsSpeedKeyDown( void )
+{
+    return Key_IsCommandDown( "+speed" ) || Touch_IsCommandDown( "+speed" );
+}
+
 static void IN_JoyAppendMove( usercmd_t *cmd, float forwardmove, float sidemove )
 {
 	static uint moveflags = T | S;
+	float movespeedscale = 1.0f;
 
-	if( forwardmove ) cmd->forwardmove  = forwardmove * cl_forwardspeed.value;
-	if( sidemove ) cmd->sidemove  = sidemove * cl_sidespeed.value;
+	if( IN_IsSpeedKeyDown() )
+	{
+		convar_t *cl_movespeedkey = Cvar_FindVar( "cl_movespeedkey" );
+		movespeedscale = cl_movespeedkey ? cl_movespeedkey->value : 0.3f;
+	}
+
+	if( forwardmove ) cmd->forwardmove  = forwardmove * cl_forwardspeed.value * movespeedscale;
+	if( sidemove ) cmd->sidemove  = sidemove * cl_sidespeed.value * movespeedscale;
 
 	if( forwardmove )
 	{
@@ -619,8 +632,18 @@ static void IN_Commands( void )
 	if( clgame.dllFuncs.pfnLookEvent )
 	{
 		float forward = 0, side = 0, pitch = 0, yaw = 0;
+		float movespeedscale = 1.0f;
 
 		IN_CollectInput( &forward, &side, &pitch, &yaw, in_mouseinitialized && !m_ignore.value );
+
+		if( IN_IsSpeedKeyDown() )
+		{
+			convar_t *cl_movespeedkey = Cvar_FindVar( "cl_movespeedkey" );
+			movespeedscale = cl_movespeedkey ? cl_movespeedkey->value : 0.3f;
+		}
+
+		forward *= movespeedscale;
+		side 	*= movespeedscale;
 
 		if( cls.key_dest == key_game )
 		{


### PR DESCRIPTION
Fixes: https://github.com/FWGS/xash3d-fwgs/issues/1709, https://github.com/Velaron/cs16-client/issues/109

Tested in Half-Life with the original Steam libraries and in CS16Client using keyboard, touch, and gamepad stick controls for movement with `+speed`.