### PR TITLE
fix cross-compile for win64 from Linux via mingw64; preserve double slash in COM_FixSlashes

### DIFF
--- a/common/xash3d_types.h
+++ b/common/xash3d_types.h
@@ -115,7 +115,11 @@ typedef int qboolean;
 	#endif
 	#define NORETURN           __attribute__(( noreturn ))
 	#define NONNULL            __attribute__(( nonnull ))
-	#define FORMAT_CHECK( x )  __attribute__(( format( printf, x, x + 1 )))
+	#if defined( __MINGW32__ )
+		#define FORMAT_CHECK( x )  __attribute__(( format( gnu_printf, x, x + 1 )))
+	#else
+		#define FORMAT_CHECK( x )  __attribute__(( format( printf, x, x + 1 )))
+	#endif
 	#define ALLOC_CHECK( x )   __attribute__(( alloc_size( x )))
 	#define WARN_UNUSED_RESULT __attribute__(( warn_unused_result ))
 	#define MAYBE_UNUSED       __attribute__(( unused ))

--- a/engine/client/input/input.c
+++ b/engine/client/input/input.c
@@ -144,6 +144,7 @@ void IN_MouseSavePos( void )
 		return;
 
 	Platform_GetMousePos( &in_lastvalidpos.x, &in_lastvalidpos.y );
+
 	in_mouse_savedpos = true;
 }
 

--- a/engine/platform/win32/crash_win.c
+++ b/engine/platform/win32/crash_win.c
@@ -182,7 +182,7 @@ static void Sys_StackTrace( PEXCEPTION_POINTERS pInfo )
 		symbol->SizeOfStruct = sizeof( SYMBOL_INFO );
 		symbol->MaxNameLen = MAX_SYM_NAME;
 
-		len += Q_snprintf( message + len, sizeof( message ) - len, "%2d: %p",
+		len += Q_snprintf( message + len, sizeof( message ) - len, "%2zu: %p",
 			i, (void*)stackframe.AddrPC.Offset );
 		if( SymFromAddr( process, stackframe.AddrPC.Offset, &displacement, symbol ))
 		{

--- a/engine/platform/win32/lib_win.c
+++ b/engine/platform/win32/lib_win.c
@@ -570,7 +570,7 @@ const char *COM_NameForFunction( void *hInstance, void *function )
 	}
 
 	// couldn't find the function address to return name
-	Con_Printf( "Can't find address: %08lx\n", function );
+	Con_Printf( "Can't find address: %p\n", function );
 
 	return NULL;
 }

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -3274,11 +3274,11 @@ void SV_PrintStr64Stats_f( void )
 	Con_Printf( "====================\n" );
 	Con_Printf( "64 bit string pool statistics\n" );
 	Con_Printf( "====================\n" );
-	Con_Printf( "string array size: %lu\n", str64.maxstringarray );
-	Con_Printf( "total alloc %lu\n", str64.totalalloc );
-	Con_Printf( "maximum array usage: %lu\n", str64.maxalloc );
-	Con_Printf( "overflow counter: %lu\n", str64.numoverflows );
-	Con_Printf( "dup string counter: %lu\n", str64.numdups );
+	Con_Printf( "string array size: %zu\n", str64.maxstringarray );
+	Con_Printf( "total alloc %zu\n", str64.totalalloc );
+	Con_Printf( "maximum array usage: %zu\n", str64.maxalloc );
+	Con_Printf( "overflow counter: %zu\n", str64.numoverflows );
+	Con_Printf( "dup string counter: %zu\n", str64.numdups );
 #else // !XASH_64BIT
 	Con_Printf( "Not implemented\n" );
 #endif // !XASH_64BIT

--- a/public/crtlib.h
+++ b/public/crtlib.h
@@ -380,7 +380,10 @@ static inline void COM_FixSlashes( char *pname )
 	while(( s = Q_strchr( s, '\\' )))
 		*s = '/';
 
-	for( i = 0, j = 0; pname[i]; i++ )
+	// a leading '//' is an UNC path prefix and must be preserved
+	i = j = ( pname[0] == '/' && pname[1] == '/' ) ? 2 : 0;
+
+	for( ; pname[i]; i++ )
 	{
 		if( pname[i] == '/' && pname[i+1] == '/' )
 			continue;

--- a/public/tests/test_strings.c
+++ b/public/tests/test_strings.c
@@ -51,6 +51,8 @@ static int Test_FixSlashes( void )
 	string s = "path\\with\\back\\slashes";
 	string s2 = "path/with/fwd/slashes";
 	string s3 = "path\\with/mixed\\slashes";
+	string s4 = "path//with///duplicate\\\\slashes";
+	string s5 = "\\\\server\\share\\path";
 
 	COM_FixSlashes( s );
 
@@ -66,6 +68,16 @@ static int Test_FixSlashes( void )
 
 	if( Q_strcmp( s3, "path/with/mixed/slashes" ))
 		return 3;
+
+	COM_FixSlashes( s4 );
+
+	if( Q_strcmp( s4, "path/with/duplicate/slashes" ))
+		return 4;
+
+	COM_FixSlashes( s5 );
+
+	if( Q_strcmp( s5, "//server/share/path" ))
+		return 5;
 
 	return 0;
 }

--- a/public/wscript
+++ b/public/wscript
@@ -105,7 +105,9 @@ def configure(conf):
 	# save some time on Windows, msvc is too slow
 	# these calls must be available with both msvc and mingw
 	if conf.env.DEST_OS == 'win32':
-		conf.export_define('HAVE_TGMATH_H', conf.simple_check(TGMATH_H_TEST, 'tgmath.h', use='M werror export'))
+		# on MinGW tgmath.h macros expand over the function declarations in intrin.h, which SDL_cpuinfo.h includes
+		if conf.env.COMPILER_CC == 'msvc':
+			conf.export_define('HAVE_TGMATH_H', conf.simple_check(TGMATH_H_TEST, 'tgmath.h', use='M werror export'))
 		conf.export_define('HAVE_STRNICMP')
 		conf.export_define('HAVE_STRICMP')
 	else:

--- a/wscript
+++ b/wscript
@@ -492,6 +492,12 @@ def configure(conf):
 			conf.check_cc(lib='m')
 		# otherwise LIB_M is defined by xcompile (as it might be libm_hard, depending on NDK configuration)
 	elif conf.env.DEST_OS == 'win32':
+		# MinGW defaults to msvcrt stdio, which lacks C99 conversions like %zu
+		# this also switches GCC format checking from ms_printf to gnu_printf
+		if conf.env.COMPILER_CC != 'msvc':
+			conf.env.append_unique('CFLAGS', '-D__USE_MINGW_ANSI_STDIO=1')
+			conf.env.append_unique('CXXFLAGS', '-D__USE_MINGW_ANSI_STDIO=1')
+
 		# Common Win32 libraries
 		# Don't check them more than once, to save time
 		# Usually, they are always available


### PR DESCRIPTION
adding a mingw compilation and linking fix since I wanted to compile for win64 from within Linux. compiled and tested on my system. there was also another issue, which I only noticed upon pulling (I initially cloned months ago), which was that COM_FixSlashes was collapsing double slashes (UNC), so fixed that as well