### PR TITLE
Fix ESCAPE menu issues

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -3609,7 +3609,7 @@ CL_Escape_f
 Escape to menu from game
 =================
 */
-static void CL_Escape_f( void )
+void CL_Escape_f( void )
 {
 	if( cls.key_dest == key_menu )
 		return;

--- a/engine/client/client.h
+++ b/engine/client/client.h
@@ -795,6 +795,7 @@ void CL_SetCheatState( qboolean multiplayer, qboolean allow_cheats );
 void CL_SendGoldSrcConnectPacket( netadr_t adr, int challenge, const void *ticket, size_t ticketlen );
 void CL_NotifyServerListResponse( void );
 qboolean CL_NetRequestSend( net_request_t *nr );
+void CL_Escape_f( void );
 
 //
 // cl_demo.c

--- a/engine/client/input.h
+++ b/engine/client/input.h
@@ -33,6 +33,7 @@ void IN_Init( void );
 void Host_InputFrame( void );
 void IN_Shutdown( void );
 void IN_MouseEvent( int key, int down );
+IN_ClearMouseState( void );
 void IN_MWheelEvent( int direction );
 void IN_ActivateMouse( void );
 void IN_DeactivateMouse( void );

--- a/engine/client/input.h
+++ b/engine/client/input.h
@@ -33,7 +33,7 @@ void IN_Init( void );
 void Host_InputFrame( void );
 void IN_Shutdown( void );
 void IN_MouseEvent( int key, int down );
-IN_ClearMouseState( void );
+void IN_ClearMouseState( void );
 void IN_MWheelEvent( int direction );
 void IN_ActivateMouse( void );
 void IN_DeactivateMouse( void );

--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -776,11 +776,8 @@ void GAME_EXPORT Key_Event( int key, int down )
 				Cvar_DirectSet( &r_showtextures, "0" );
 				return;
 			}
-			else if( host.mouse_visible && cls.state != ca_cinematic )
-			{
-				clgame.dllFuncs.pfnKey_Event( down, key, keys[key].binding );
-				return; // handled in client.dll
-			}
+			// Note: we don't offer the client key handling here since reaching this line proves the client already declined handling it.
+			// this prevents accidentally declining a key the client asked the engine to handle. For more context, see https://github.com/FWGS/xash3d-fwgs/issues/1943
 			break;
 		default:
 			break;

--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -902,15 +902,16 @@ void GAME_EXPORT Key_ClearStates( void )
 
 	for( int i = 0; i < ARRAYSIZE( keys ); i++ )
 	{
-		if( i >= K_MOUSE1 && i <= K_MOUSE5 )
-			IN_MouseEvent( i - K_MOUSE1, false );
-		else
-			Key_Event( i, false );
+		if( i < K_MOUSE1 || i > K_MOUSE5 )
+			Key_Event( i, false ); // checks internally whether a key has been pressed or not
 
 		keys[i].down = 0;
 		keys[i].repeats = 0;
 		keys[i].gamedown = 0;
 	}
+
+	// ensure that only actual mouse buttons are released
+	IN_ClearMouseState();
 
 	if( clgame.hInstance )
 		clgame.dllFuncs.IN_ClearStates();

--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -778,7 +778,10 @@ void GAME_EXPORT Key_Event( int key, int down )
 			}
 			// Note: we don't offer the client key handling here since reaching this line proves the client already declined handling it.
 			// this prevents accidentally declining a key the client asked the engine to handle. For more context, see https://github.com/FWGS/xash3d-fwgs/issues/1943
-			break;
+			
+			// call escape within the engine, since the client may not handle it (Natural Selection doesn't. See https://github.com/FWGS/xash3d-fwgs/issues/528)
+			Cbuf_AddText( "escape\n" );
+			return;
 		default:
 			break;
 		}

--- a/engine/client/input/in_keys.c
+++ b/engine/client/input/in_keys.c
@@ -779,8 +779,8 @@ void GAME_EXPORT Key_Event( int key, int down )
 			// Note: we don't offer the client key handling here since reaching this line proves the client already declined handling it.
 			// this prevents accidentally declining a key the client asked the engine to handle. For more context, see https://github.com/FWGS/xash3d-fwgs/issues/1943
 			
-			// call escape within the engine, since the client may not handle it (Natural Selection doesn't. See https://github.com/FWGS/xash3d-fwgs/issues/528)
-			Cbuf_AddText( "escape\n" );
+			// call escape immediately within the engine, since the client may not handle it (Natural Selection doesn't. See https://github.com/FWGS/xash3d-fwgs/issues/528)
+			CL_Escape_f();
 			return;
 		default:
 			break;

--- a/engine/client/input/input.c
+++ b/engine/client/input/input.c
@@ -395,6 +395,24 @@ void IN_MouseEvent( int key, int down )
 }
 
 /*
+===========
+IN_ClearMouseState
+
+mouse button releases are handled here to ensure that only actual mouse button clicks are released
+===========
+*/
+void IN_ClearMouseState( void )
+{
+	int i;
+
+	for( i = 0; i <= K_MOUSE5 - K_MOUSE1; i++ )
+	{
+		if( FBitSet( in_mstate, BIT( i ))) // is this an actual mouse button click?
+			IN_MouseEvent( i, false );
+	}
+}
+
+/*
 ==============
 IN_MWheelEvent
 

--- a/engine/client/input/input.c
+++ b/engine/client/input/input.c
@@ -403,9 +403,7 @@ mouse button releases are handled here to ensure that only actual mouse button c
 */
 void IN_ClearMouseState( void )
 {
-	int i;
-
-	for( i = 0; i <= K_MOUSE5 - K_MOUSE1; i++ )
+	for( int i = 0; i <= K_MOUSE5 - K_MOUSE1; i++ )
 	{
 		if( FBitSet( in_mstate, BIT( i ))) // is this an actual mouse button click?
 			IN_MouseEvent( i, false );


### PR DESCRIPTION
This PR proposes a fix to two issues with Key_Event's escape button branch. Specifically [issue #1943 (CoF)](https://github.com/FWGS/xash3d-fwgs/issues/1943) and [issue #528 (NS)](https://github.com/FWGS/xash3d-fwgs/issues/528). It also fixes a issue that arised while fixing issue 1943. 

The explanations are scattered across the issue pages and commit descriptions but I'll write a summary here:

## Issue 1943 (CoF)
While in main menu, pressing ESC does not open options menu. This bug is happening inside the [Key_Event](https://github.com/FWGS/xash3d-fwgs/blob/master/engine/client/input/in_keys.c#L688) function where the engine asks the client if it wants to handle the ESC key twice:
First it asks in [line 713](https://github.com/FWGS/xash3d-fwgs/blob/master/engine/client/input/in_keys.c#L713) which the client declines (i confirmed this by adding an if statement right under which would have never have ran had the client handled the ESC key). But ESC is handled exceptionally a [bit downward in the function](https://github.com/FWGS/xash3d-fwgs/blob/master/engine/client/input/in_keys.c#L768-L788). In the case of CoF in the start menu the else-if statement `host.mouse_visible && cls.state != ca_cinematic` runs (start menu asks for a visible cursor and its not a cinematic). This is where it gets interesting: the engine asks the client if it wants to handle the key and returns immediately, assuming that the key is handled by the client. But the client returned 1 to the engine earlier when asked in [line 713](https://github.com/FWGS/xash3d-fwgs/blob/master/engine/client/input/in_keys.c#L713). The engine is essentially asking the same question twice and ignoring the first response. Removing the [else-if](https://github.com/FWGS/xash3d-fwgs/blob/master/engine/client/input/in_keys.c#L779-L783) statement "fixes" this issue. Hitting ESC in the main menu triggers `togglemenu`. The reason why this affects the main menu only is because its the only place where the client asks for a cursor and lets the engine handle the key (for other interfaces such as the inventory / computer interface / animal puzzle etc the client handles the key itself). 

However, the else-if removal triggered another issue downstream: hovering over a vgui button and pressing ESC now opens that vgui button. Basically, a keyboard button press triggered a nonexistent mouse click. This is happening because `Key_ClearStates` calls `IN_MouseEvent` (which doesn't check if an event is an actual mouse click that has been released), unlike `Key_Event` which checks if a button has been pressed. This *could* be solved by adding a condition within `Key_ClearStates` before calling `IN_MouseEvent` but I thought it was appropriate here to refactor it into its own `IN_ClearMouseState` function. Thats a taste thing and a decision to be made by the maintainers, but the fix either way needs to be shipped with the else-if removal. 

How does this change the behaviour of other mods? This only affects mods that return 1 and shows a vgui cursor (CoF's case). Instead of ESC doing nothing now it opens menu. I can't think of a case where the client returns 1, shows a vgui cursor yet intentionally doesn't want ESC to open menu. 

## Issue 528 (NS)
This issue is included here because i at first thought it was related to 1943, turns out its different but operates on the same branch. As Vladislav4KZ described it: "`cancelselect` doesn't open menu but `escape` / `main_menu` does". This is because NS relies on the engine to call `escape` internally, which FWGS doesn't. Compare NS's [CHudAmmo UserCmd_Close](https://github.com/unknownworlds/NS/blob/master/main/source/cl_dll/ammo.cpp#L960-L970) to HL SDK's  [CHudAmmo UserCmd_Close](https://github.com/FWGS/hlsdk-portable/blob/master/cl_dll/ammo.cpp#L753-L763): NS removed the "vanilla" `escape` branch. FWGS currently relies on MODS to internally call `escape`, while GoldSrc doesn't.  I added an escape call after the r_showtextures case

How does this affect other mods? Well, it affects all mods. Instead of going through `ESC -> cancelselect -> escape -> menu` the engine skips cancelselect: `ESC -> escape -> menu` (cancelselect stil works, its just not the route taken). So any mod that intentionally doesn't want ESC to open menu now opens menu. Very few (if any) mods would want that kind of behaviour anyway. Users [can't unbind ESC](https://github.com/FWGS/xash3d-fwgs/blob/ed2239e6138501c03a80bae95f4988c717cb2a64/engine/client/input/in_keys.c#L352-L356) so no one would complain. If anything, the NS commit ensures that the engine's desired behaviour actually runs (it enforces it). 