### PR TITLE
engine: don't exempt the listenserver's local client from the send rate limiter in multiplayer

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -921,7 +921,11 @@ static void CL_WritePacket( void )
 	// can send this command?
 	pcmd = &cl.commands[cls.netchan.outgoing_sequence & CL_UPDATE_MASK];
 
-	if( cl.maxclients == 1 || ( NET_IsLocalAddress( cls.netchan.remote_address ) && !host_limitlocal.value ) || ( host.realtime >= cls.nextcmdtime && Netchan_CanPacket( &cls.netchan, true )))
+	// the loopback connection used to be exempted from cl_cmdrate to keep singleplayer
+	// as responsive as possible, but the cl.maxclients == 1 term below already covers
+	// that. on a listenserver the exemption also applied to the host, sending the game
+	// library several times the command packets it expects
+	if( cl.maxclients == 1 || ( host.realtime >= cls.nextcmdtime && Netchan_CanPacket( &cls.netchan, true )))
 		pcmd->heldback = false;
 	else pcmd->heldback = true;
 

--- a/engine/server/sv_frame.c
+++ b/engine/server/sv_frame.c
@@ -832,7 +832,12 @@ void SV_SendClientMessages( void )
 			continue;
 		}
 
-		if( !host_limitlocal.value && NET_IsLocalAddress( cl->netchan.remote_address ))
+		// the loopback client is exempted from the rate limiter to keep singleplayer
+		// as smooth as possible. on a listenserver that also hands the game library
+		// its per-snapshot entry points at frame rate, and mods that keep state in
+		// UpdateClientData/GetWeaponData drift because of it, so keep the exemption
+		// for singleplayer only
+		if( !host_limitlocal.value && svs.maxclients == 1 && NET_IsLocalAddress( cl->netchan.remote_address ))
 			SetBits( cl->flags, FCL_SEND_NET_MESSAGE );
 
 		if( cl->state == cs_spawned )


### PR DESCRIPTION
Fixes #2721.

The loopback client of a listenserver is exempted from the send rate limiter in two
separate places, one per direction. Neither is restricted to singleplayer, so the **host
of a multiplayer listenserver** gets both, and the game library is handed its entry points
at the host's frame rate instead of at `cl_updaterate` / `cl_cmdrate`.

* `cl_main.c` — the loopback term made the host send one command packet per frame. The
  `cl.maxclients == 1` term next to it already covers singleplayer, so the term is simply
  dropped.
* `sv_frame.c` — the same exemption for outgoing snapshots, now gated on
  `svs.maxclients == 1`. `sv_main.c` already gates the same cvar that way in both places
  it uses it.

Mods whose work in `pfnUpdateClientData` / `pfnGetWeaponData` is not idempotent drift
because of it. In Firearms the machine gun bipod does not tighten the spread cone for the
host, while it does on GoldSrc and for everyone else on the same server.

### Testing

Firearms 3.0, listenserver with `maxplayers 16`, Windows 11, `win32-i386`. Bipod behaviour
judged against a Steam GoldSrc server running the same mod files (identical by md5).

| build | bipod tightens the cone |
|---|---|
| stock | no |
| stock + `host_limitlocal 1` | yes |
| `sv_frame.c` hunk only | **no** |
| both hunks | yes |

The third row is why the client-side hunk is here: fixing the snapshot rate on its own was
not enough. I did **not** test the client hunk in isolation, so I cannot claim the server
one is strictly required — I am sending what I actually verified. Happy to drop the
`sv_frame.c` commit if you would rather keep the exemption there.

The cost of both is that the listenserver host loses some smoothness and immediacy, which
is what anyone connected to a real server already lives with.
