### PR TITLE
engine: client: don't read stale pe->solid when deciding where a physent's model goes

### DIFF
--- a/engine/client/dll_int/cl_pmove.c
+++ b/engine/client/dll_int/cl_pmove.c
@@ -333,12 +333,12 @@ static void CL_CopyEntityToPhysEnt( physent_t *pe, entity_state_t *state, qboole
 
 	if( state->solid == SOLID_BBOX )
 	{
-		if( FBitSet( mod->flags, STUDIO_TRACE_HITBOX ))
+		if( mod != NULL && FBitSet( mod->flags, STUDIO_TRACE_HITBOX ))
 			pe->studiomodel = mod;
 	}
 	else
 	{
-		if( pe->solid != SOLID_BSP && ( mod != NULL ) && ( mod->type == mod_studio ))
+		if( state->solid != SOLID_BSP && ( mod != NULL ) && ( mod->type == mod_studio ))
 			pe->studiomodel = mod;
 		else pe->model = mod;
 	}


### PR DESCRIPTION
`CL_CopyEntityToPhysEnt` decides whether an entity's model goes into `pe->studiomodel` or `pe->model` by testing `pe->solid` — but `pe->solid` is only assigned ~15 lines later in the same function. The test therefore reads whatever value was left in that physent slot by a previous frame: `CL_SetSolidEntities` only memsets element 0 (the world), so slots 1+ keep stale contents across frames.

When a slot that previously held a `SOLID_BSP` entity (a door, for example) is reused for a player, the stale test routes the player's studio model into `pe->model`, where game code expects a brush model with valid hulls.

Mods whose movement/collision code walks `pe->model->hulls` directly then read garbage. Natural Selection (which is on the supported mod list) crashes with `c0000005` at a fixed offset inside its statically linked collision code, reliably within minutes whenever another player is in view. The crash comes and goes with physent list churn — more entities entering/leaving the PVS means faster slot reuse — which is why it looked random and movement-dependent. Diagnosed by disassembling the faulting code in NS's `client.dll` down to the exact structures it walks (`pmove->physents[i].model->hulls[0]`), then auditing what fills them.

Fix: test `state->solid`, matching what `SV_CopyEdictToPhysEnt` already does on the server side. Also guard the `STUDIO_TRACE_HITBOX` branch against `mod` being NULL (the `CL_SetSolidPlayers` path does not validate `CL_ModelHandle`), again matching the server side.

Verified in NS 3.2: before the fix, a listenserver with any second player (human or bot) in view crashes within minutes; with the fix, full matches run without issue. No behavior change for any other slot/entity combination — the stale value only alters the outcome in exactly the buggy case.
