### PR TITLE
engine: pm: make the frac clamps in PM_RecursiveHullCheck NaN-proof

### DIFF
--- a/engine/common/pm_trace.c
+++ b/engine/common/pm_trace.c
@@ -260,7 +260,10 @@ loc0:
 	if( side ) frac = ( t1 + DIST_EPSILON ) / ( t1 - t2 );
 	else frac = ( t1 - DIST_EPSILON ) / ( t1 - t2 );
 
-	if( frac < 0.0f ) frac = 0.0f;
+	// inverted comparison also catches NaN (e.g. from a non-finite trace passed
+	// in by the game dll), which otherwise slips through both clamps and turns
+	// the backing-up loop below into an infinite loop, hanging the host
+	if( !( frac >= 0.0f )) frac = 0.0f;
 	if( frac > 1.0f ) frac = 1.0f;
 
 	midf = p1f + ( p2f - p1f ) * frac;
@@ -298,7 +301,8 @@ loc0:
 		// shouldn't really happen, but does occasionally
 		frac -= 0.1f;
 
-		if( frac < 0.0f )
+		// inverted comparison also catches NaN, see above
+		if( !( frac >= 0.0f ))
 		{
 			trace->fraction = midf;
 			VectorCopy( mid, trace->endpos );


### PR DESCRIPTION
A game dll can freeze the whole host by asking for a trace with non-finite coordinates.

In `PM_RecursiveHullCheck`, NaN endpoints make every plane-side comparison fail, `frac` becomes NaN, and both clamps let it through — any comparison against NaN is false. The "backing up" loop at the end then never terminates: `frac -= 0.1f` stays NaN and `frac < 0.0f` is never true. The main thread spins there forever; the game hangs with nothing in the log.

Caught in the wild with gdb attached to a hung listenserver (Natural Selection + EvoBot, which occasionally calls `pfnTraceLine` with NaN endpoints — reported the bot-side bug at RGreenlees/evobot_mm#24, where the same freeze is described against GoldSrc HLDS, sharing this Quake-derived code):

```
#0  PM_HullPointContents (...) at pm_trace.c:129
#1  PM_RecursiveHullCheck (num=8476, p1f=-nan, p2f=-nan, ...) at pm_trace.c:296
#2..#15  PM_RecursiveHullCheck (p1f=0, p2f=-nan, ...)
#16 SV_ClipMoveToEntity  #17 SV_Move  #18 pfnTraceLine  #19 evobot_mm.dll
```

Fix: write the two `frac` clamps with inverted comparisons (`!( frac >= 0.0f )`), which additionally catch NaN. Zero behavior change for finite values; the NaN case exits through the existing "trace backed up past 0.0" warning instead of hanging. Verified: the reproducible ~10-15 min freeze with bots is gone, the warning fires instead.
