### PR TITLE
ref: gl: draw normal-rendermode sprites according to their texture format

### DIFF
--- a/ref/gl/gl_sprite.c
+++ b/ref/gl/gl_sprite.c
@@ -421,7 +421,23 @@ void R_DrawSpriteModel( cl_entity_t *e )
 		break;
 	case kRenderNormal:
 	default:
-		pglDisable( GL_BLEND );
+		// GoldSrc parity: in the normal render mode sprites draw according to
+		// their own texture format (Quake heritage) — additive sprites blend
+		// additively and indexalpha sprites alpha-blend
+		switch( psprite->texFormat )
+		{
+		case SPR_ADDITIVE:
+			pglEnable( GL_BLEND );
+			pglBlendFunc( GL_SRC_ALPHA, GL_ONE );
+			break;
+		case SPR_INDEXALPHA:
+			pglEnable( GL_BLEND );
+			pglBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
+			break;
+		default:
+			pglDisable( GL_BLEND );
+			break;
+		}
 		break;
 	}
 


### PR DESCRIPTION
GoldSrc (inheriting from Quake) draws sprites in `kRenderNormal` according to the sprite's own `texFormat`: additive sprites blend additively, indexalpha sprites alpha-blend. Xash disables blending entirely, so they render opaque.

Visible in Natural Selection: the lerk's spore projectile is a client-side temp entity that never sets a rendermode — its indexalpha sprite renders as an opaque green blob instead of a translucent cloud (correct on GoldSrc). Verified fixed in-game.

Minimal repro with any indexalpha sprite, no mod needed:

```
ent_create env_sprite model sprites/spore2.spr spawnflags 1
```

Explicit rendermodes are unaffected — the change only touches the `kRenderNormal`/default path.
