### PR TITLE
engine: server: clip SOLID_CUSTOM entities as their bbox when the game has no physics interface

### DIFF
--- a/engine/server/sv_world.c
+++ b/engine/server/sv_world.c
@@ -1075,8 +1075,9 @@ void SV_CustomClipMoveToEntity( edict_t *ent, const vec3_t start, vec3_t mins, v
 	}
 	else
 	{
-		// function is missed, so we didn't hit anything
-		trace->allsolid = false;
+		// no callbacks are provided, so the game doesn't know about SOLID_CUSTOM:
+		// clip against the entity bbox, like GoldSrc does for out-of-range solid values
+		SV_ClipMoveToEntity( ent, start, mins, maxs, end, trace );
 	}
 }
 


### PR DESCRIPTION
In GoldSrc `solid == 5` carries no special meaning: `SV_HullForEntity` falls through to a bbox hull for any non-BSP solid value, so a game dll that sets `pev->solid` to 5 still gets a tangible bounding box. In Xash 5 is `SOLID_CUSTOM`, whose collision is delegated to the game's physics interface (`ClipMoveToEntity`). When the game doesn't install that interface, `SV_CustomClipMoveToEntity` treated the entity as *not hit*, so it became a ghost to server traces.

This falls back to a bbox clip (matching GoldSrc) when the interface is absent. Mods that genuinely use `SOLID_CUSTOM` install the interface and are unaffected.

Found via Natural Selection: its weldable hatches are marked `pev->solid = 5`, so the marine welder's trace passed straight through them (no interaction, sound or progress) on Xash while working on GoldSrc.

Rebased on current master and reduced to the server-side hunk per review; the player-move changes were dropped. Built with MinGW/i386.
