### PR TITLE
engine: common: dont bound host_framerate

### DIFF
--- a/engine/common/host.c
+++ b/engine/common/host.c
@@ -639,7 +639,8 @@ static qboolean Host_FilterTime( double time )
 
 	// NOTE: allow only in singleplayer while demos are not active
 	if( host_framerate.value > 0.0f && Host_IsSinglePlayerGame() && !CL_IsPlaybackDemo() && !CL_IsRecordDemo( ))
-		host.frametime = bound( MIN_FRAMETIME, host_framerate.value * scale, MAX_FRAMETIME );
+		// dont bound host framerate here, as it makes sped-up time progression significantly slower than Goldsrc. This is used in some mods like CoF to skip cinematics faster (for more context, see https://github.com/FWGS/xash3d-fwgs/issues/2706)
+		host.frametime = host_framerate.value * scale;
 	else
 		host.frametime = bound( MIN_FRAMETIME, host.frametime, MAX_FRAMETIME );
 


### PR DESCRIPTION
Fixes https://github.com/FWGS/xash3d-fwgs/issues/2718

The issue was that `host_framerate` was both lower and upper bounded, causing CoF's `host_framerate 2` to fall back to `0,25` which made the cinematic skip ~8x slower than goldsrc. It also gives the same behaviour observed via `net_graph` where frames drop from 60 to exactly .5.

With the clamp removed, intro story -> `c_nightmare` cinematic sped-up time was cut down from ~19,6s to ~3,3s which closely matches goldsrc 4554.

This is OK as any changes made to `host_framerate` by the user/client are intentional,  and it doesnt touch anything to do with non `host_framerate > 0` cases.